### PR TITLE
Add simple accessor field for getting the time since app start in secs

### DIFF
--- a/examples/simple_draw.rs
+++ b/examples/simple_draw.rs
@@ -20,7 +20,7 @@ fn view(app: &App, frame: Frame) -> Frame {
         .color(DARK_PURPLE);
 
     // Draw an ellipse to follow the mouse.
-    let t = app.duration.since_start.secs() as f32;
+    let t = app.time;
     draw.ellipse()
         .x_y(app.mouse.x * t.cos(), app.mouse.y)
         .radius(win.w() * 0.125 * t.sin())

--- a/src/app.rs
+++ b/src/app.rs
@@ -56,6 +56,24 @@ pub struct App {
     ///
     /// `duration.since_prev_update` specifies the duration since the previous update event.
     pub duration: state::Time,
+
+    /// The time in seconds since the `App` started running.
+    ///
+    /// Primarily, this field is a convenience that removes the need to call
+    /// `app.duration.since_start.secs()`. Normally we would try to avoid using such an ambiguous
+    /// field name, however due to the sheer amount of use that this value has we feel it is
+    /// beneficial to provide easier access.
+    ///
+    /// This value is of the same type as the scalar value used for describing space in animations.
+    /// This makes it very easy to animate graphics and create changes over time without having to
+    /// cast values or repeatedly calculate it from a `Duration` type. A small example might be
+    /// `app.time.sin()` for simple oscillation behaviour.
+    ///
+    /// **Note:** This is suitable for use in short sketches, however should be avoided in long
+    /// running installations. This is because the "resolution" of `f64` values reduces the higher
+    /// the number becomes. Instead, we recommend using `app.duration.since_start` or
+    /// `app.duration.since_last` to access a more precise form of this time.,
+    pub time: DrawScalar,
 }
 
 /// Miscellaneous app configuration parameters.
@@ -228,6 +246,7 @@ impl App {
         let window = state::Window::new();
         let keys = state::Keys::default();
         let duration = state::Time::default();
+        let time = duration.since_start.secs() as _;
         App {
             events_loop,
             windows,
@@ -239,6 +258,7 @@ impl App {
             window,
             keys,
             duration,
+            time,
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -70,9 +70,9 @@ pub struct App {
     /// `app.time.sin()` for simple oscillation behaviour.
     ///
     /// **Note:** This is suitable for use in short sketches, however should be avoided in long
-    /// running installations. This is because the "resolution" of `f64` values reduces the higher
-    /// the number becomes. Instead, we recommend using `app.duration.since_start` or
-    /// `app.duration.since_last` to access a more precise form of this time.,
+    /// running installations. This is because the "resolution" of floating point values reduces as
+    /// the number becomes higher. Instead, we recommend using `app.duration.since_start` or
+    /// `app.duration.since_prev_update` to access a more precise form of app time.
     pub time: DrawScalar,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,6 +417,7 @@ where
                 let since_start = now.duration_since(loop_start).into();
                 app.duration.since_start = since_start;
                 app.duration.since_prev_update = since_last;
+                app.time = app.duration.since_start.secs() as _;
 
                 // Emit an update event.
                 let event = E::from(update_event(loop_start, &mut last_update));
@@ -471,6 +472,7 @@ where
                 let since_start = now.duration_since(loop_start).into();
                 app.duration.since_start = since_start;
                 app.duration.since_prev_update = since_last;
+                app.time = app.duration.since_start.secs() as _;
 
                 // Emit an update event.
                 let event = E::from(update_event(loop_start, &mut last_update));


### PR DESCRIPTION
From the docs:

> The time in seconds since the `App` started running.
> 
> Primarily, this field is a convenience that removes the need to call
> `app.duration.since_start.secs()`. Normally we would try to avoid using
> such an ambiguous field name, however due to the sheer amount of use
> that this value has we feel it is beneficial to provide easier access.
> 
> This value is of the same type as the scalar value used for describing
> space in animations.  This makes it very easy to animate graphics and
> create changes over time without having to cast values or repeatedly
> calculate it from a `Duration` type. A small example might be
> `app.time.sin()` for simple oscillation behaviour.
> 
> **Note:** This is suitable for use in short sketches, however should be
> avoided in long running installations. This is because the "resolution"
> of float values reduces the higher the number becomes. Instead, we
> recommend using `app.duration.since_start` or `app.duration.since_last`
> to access a more precise form of this time.