### PR TITLE
Publish 0.5.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Start your own project with:
 cargo new my_project
 cd my_project
 ```
-Add `nannou = "0.1"` under the `[dependencies]` line in your Cargo.toml.  This
+Add `nannou = "0.5"` under the `[dependencies]` line in your Cargo.toml.  This
 is everything you need to use the framework in your own project or sketch.
 Rust's package manager *cargo* will automatically download and install
 everything you need!

--- a/nannou-new/src/main.rs
+++ b/nannou-new/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
     // TODO: Ask the user for additional cargo args.
 
     // TODO: Find the current version of nannou.
-    let nannou_version = "0.4";
+    let nannou_version = "0.5";
     let nannou_dependency = format!("nannou = \"{}\"", nannou_version);
 
     // TODO: Load the template example or fallback to compiled template.


### PR DESCRIPTION
Changes include:

- Update to glium 0.21.0, fixing lots of mac bugs.
- Update to conrod 0.59.0.
- Removed `app.window.*` fields in favour of `app.window_rect()`.
- Vsync and multisampling are now enabled by default. These can be
disabled via the associated window builder methods.
- Add support for toggling fullscreen via standard keyboard shortcuts.
- Add `Draw::line` method.
- Fix `draw::Background` color API.
- Fix OSC default binding address.
- Add `Range::lerp` method.
- Add some missing `Rect` constructors.
- Add a bunch of named colours under `nannou::color::named`. These are
imported via the prelude.