### PR TITLE
Improve the efficiency of the App proxy by only calling OS when needed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate toml;
 use event::LoopEvent;
 use glium::glutin;
 use std::cell::RefCell;
+use std::sync::atomic;
 use std::time::Instant;
 
 pub use app::{App, LoopMode};
@@ -451,7 +452,10 @@ where
                 // If there are no events and the `Ui` does not need updating,
                 // wait for the next event.
                 if glutin_events.is_empty() && updates_remaining == 0 {
+                    let events_loop_is_asleep = app.events_loop_is_asleep.clone();
+                    events_loop_is_asleep.store(true, atomic::Ordering::Relaxed);
                     app.events_loop.run_forever(|event| {
+                        events_loop_is_asleep.store(false, atomic::Ordering::Relaxed);
                         glutin_events.push(event);
                         glium::glutin::ControlFlow::Break
                     });

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -377,8 +377,10 @@ impl Ui {
     /// method offers more flexibility.
     ///
     /// This has no effect if the window originally associated with the `Ui` no longer exists.
+    ///
+    /// Returns `true` if the call resulted in re-drawing the `Ui` due to changes.
     pub fn draw_to_frame_if_changed(&self, app: &App, frame: &Frame)
-        -> Result<(), conrod::backend::glium::DrawError>
+        -> Result<bool, conrod::backend::glium::DrawError>
     {
         let Ui { ref ui, ref renderer, ref image_map, window_id, .. } = *self;
         if let Some(window) = app.window(window_id) {
@@ -388,11 +390,12 @@ impl Ui {
                         renderer.fill(&window.display, primitives, &image_map);
                         window_frame.clear_color(0.0, 0.0, 0.0, 1.0);
                         renderer.draw(&window.display, &mut window_frame.frame.frame, image_map)?;
+                        return Ok(true);
                     }
                 }
             }
         }
-        Ok(())
+        Ok(false)
     }
 }
 


### PR DESCRIPTION
The app proxy now checks a flag to determine whether or not to call the
`winit::EventsLoopProxy::wakeup` method and in turn the underlying OS
wakeup function. This flag indicates whether or not the event loop is
currently "asleep" aka waiting for input events. The proxy will now only
wakeup the main event loop if the flag indicates that the event loop is
currently asleep.

This should allow the user to call the `wakeup` method as often as they
want without unnecessarily triggering the underlying OS wakeup function
which on some systems can cause lock contention and significant CPU
increase.