### PR TITLE
Fix DPI bug, Ui API tweaks, Add `App::window_id`, Improve default focused window

### DIFF
--- a/examples/osc_receiver.rs
+++ b/examples/osc_receiver.rs
@@ -19,7 +19,7 @@ struct Model {
 const PORT: u16 = 34254;
 
 fn model(app: &App) -> Model {
-    let window = app.new_window()
+    app.new_window()
         .with_title("OSC Receiver")
         .with_dimensions(1400, 480)
         .build()
@@ -32,7 +32,7 @@ fn model(app: &App) -> Model {
     let received_packets = vec![];
 
     // Create a simple UI to display received messages.
-    let mut ui = app.new_ui(window).build().unwrap();
+    let mut ui = app.new_ui().build().unwrap();
     let text = ui.generate_widget_id();
 
     Model { receiver, received_packets, ui, text }

--- a/examples/osc_sender.rs
+++ b/examples/osc_sender.rs
@@ -22,7 +22,7 @@ fn target_address_string() -> String {
 }
 
 fn model(app: &App) -> Model {
-    let window = app.new_window()
+    app.new_window()
         .with_title("OSC Sender")
         .with_dimensions(680, 480)
         .build()
@@ -35,7 +35,7 @@ fn model(app: &App) -> Model {
     let sender = osc::sender().unwrap().connect(target_addr).unwrap();
 
     // Create a simple UI to tell the user what to do.
-    let mut ui = app.new_ui(window).build().unwrap();
+    let mut ui = app.new_ui().build().unwrap();
     let text = ui.generate_widget_id();
 
     Model { sender, ui, text }

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -25,7 +25,7 @@ fn model(app: &App) -> Model {
     app.set_loop_mode(LoopMode::wait(3));
 
     // Create the UI.
-    let mut ui = app.new_ui(app.window.id()).build().unwrap();
+    let mut ui = app.new_ui().build().unwrap();
 
     // Generate some ids for our widgets.
     let ids = Ids {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,21 +126,21 @@ impl<M, E> Builder<M, E>
         let events_loop = glutin::EventsLoop::new();
 
         // Initialise the app.
-        let mut app = App::new(events_loop);
+        let app = App::new(events_loop);
 
         // Create the default window if necessary
         if create_default_window {
             let window_id = app.new_window().build().expect("could not build default app window");
-            app.window.id = Some(window_id);
+            *app.focused_window.borrow_mut() = Some(window_id);
         }
 
         // Call the user's model function.
         let model = model(&app);
 
         // If there is not yet some default window in "focus" check to see if one has been created.
-        if app.window.id.is_none() {
+        if app.focused_window.borrow().is_none() {
             if let Some(id) = app.windows.borrow().keys().next() {
-                app.window.id = Some(id.clone());
+                *app.focused_window.borrow_mut() = Some(id.clone());
             }
         }
 
@@ -179,7 +179,7 @@ where
             })
             .collect();
         // TODO: This currently passes the *focused* window but should pass the *main* one.
-        let undrawn_frame = frame::new(gl_frames, app.window.id);
+        let undrawn_frame = frame::new(gl_frames, *app.focused_window.borrow());
         let frame = match *view {
             View::Full(view_fn) => view_fn(&app, &model, undrawn_frame),
             View::Simple(view_fn) => view_fn(&app, undrawn_frame),
@@ -301,9 +301,9 @@ where
                 let ty = |y: geom::DefaultScalar| -((y / hidpi_factor) - win_h as geom::DefaultScalar / 2.0);
 
                 // If the window ID has changed, ensure the dimensions are up to date.
-                if app.window.id != Some(window_id) {
+                if *app.focused_window.borrow() != Some(window_id) {
                     if app.window(window_id).is_some() {
-                        app.window.id = Some(window_id);
+                        *app.focused_window.borrow_mut() = Some(window_id);
                     }
                 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -69,6 +69,12 @@ impl<'a, 'b> Builder<'a, 'b> {
         let display = glium::Display::new(window, context, &app.events_loop)?;
         let window_id = display.gl_window().id();
         app.windows.borrow_mut().insert(window_id, Window { display });
+
+        // If this is the first window, set it as the app's "focused" window.
+        if app.windows.borrow().len() == 1 {
+            *app.focused_window.borrow_mut() = Some(window_id);
+        }
+
         Ok(window_id)
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -281,7 +281,7 @@ impl Window {
             .get_inner_size()
             .map(|(w_px, h_px)| {
                 let dpi_factor = self.hidpi_factor();
-                (w_px as f32 * dpi_factor, h_px as f32 * dpi_factor)
+                (w_px as f32 / dpi_factor, h_px as f32 / dpi_factor)
             })
             .expect(Self::NO_LONGER_EXISTS)
     }


### PR DESCRIPTION
- Fix bug in DPI usage within Window::inner_size_points method
- **Ui::draw** methods no longer clear the screen to black.
- **App::new_ui** no longer requires specifying a window, instead a
window can be optionally specified via a builder method. The focused
window is used by default.
- **window::Builder::build** now sets the window as the app's
`focused_window` if none is currently set.