### PR TITLE
Add better `panic!` message to `map_range` if cast fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unpublished
 
+- Add better `panic!` message to `map_range` if cast fails
+
+# Version 0.6.0 (2017-06-07)
+
 - Add beginnings of Nature of Code and Generative Gestaltung examples.
 - Add `App::elapsed_frames` method.
 - Remove `app.window.id` field in favour of more reliable `app.window_id`

--- a/src/math.rs
+++ b/src/math.rs
@@ -24,14 +24,20 @@ where
     X: NumCast,
     Y: NumCast,
 {
-    let val_f: f64 = NumCast::from(val).unwrap();
-    let in_min_f: f64 = NumCast::from(in_min).unwrap();
-    let in_max_f: f64 = NumCast::from(in_max).unwrap();
-    let out_min_f: f64 = NumCast::from(out_min).unwrap();
-    let out_max_f: f64 = NumCast::from(out_max).unwrap();
-    NumCast::from(
-        (val_f - in_min_f) / (in_max_f - in_min_f) * (out_max_f - out_min_f) + out_min_f
-    ).unwrap()
+    macro_rules! unwrap_or_panic {
+        ($result:expr, $arg:expr) => {
+            $result.unwrap_or_else(|| panic!("[map_range] failed to cast {} arg to `f64`"))
+        };
+    }
+
+    let val_f: f64 = unwrap_or_panic!(NumCast::from(val), "first");
+    let in_min_f: f64 = unwrap_or_panic!(NumCast::from(in_min), "second");
+    let in_max_f: f64 = unwrap_or_panic!(NumCast::from(in_max), "third");
+    let out_min_f: f64 = unwrap_or_panic!(NumCast::from(out_min), "fourth");
+    let out_max_f: f64 = unwrap_or_panic!(NumCast::from(out_max), "fifth");
+
+    NumCast::from((val_f - in_min_f) / (in_max_f - in_min_f) * (out_max_f - out_min_f) + out_min_f)
+        .unwrap_or_else(|| panic!("[map_range] failed to cast result to target type"))
 }
 
 /// The max between two partially ordered values.


### PR DESCRIPTION
Ran into an issue during the workshop where the mapped result was out of
range of the target type's value range, but because `unwrap` was used it
was difficult to find where unwrap was occuring. This should make any
invalid casts much more obvious.