### PR TITLE
Implement `draw.polygon()` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Add better `panic!` message to `map_range` if cast fails.
 - Add many items to prelude (audio, io, math, osc, ui, window).
 - Change event positioning types to use DefaultScalar.
+- Implement `draw.polygon()`
+- Update internal `IntoDrawn` API to support a dynamic number of arbitrary
+  vertices.
+- Update `Drawing` API to allow builders to produce new `Drawing` types.
 
 # Version 0.6.0 (2017-06-07)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ path = "examples/simple_audio.rs"
 name = "simple_draw" 
 path = "examples/simple_draw.rs"
 [[example]] 
+name = "simple_polygon" 
+path = "examples/simple_polygon.rs"
+[[example]] 
 name = "simple_ui" 
 path = "examples/simple_ui.rs"
 [[example]] 

--- a/examples/simple_polygon.rs
+++ b/examples/simple_polygon.rs
@@ -1,0 +1,60 @@
+extern crate nannou;
+
+use nannou::prelude::*;
+
+fn main() {
+    nannou::view(view);
+}
+
+fn view(app: &App, frame: Frame) -> Frame {
+    // Begin drawing 
+    let win = app.window_rect();
+    let t = app.time;
+    let draw = app.draw();
+
+    // Clear the background to blue.
+    draw.background().color(BLACK);
+
+    // Create an `ngon` of points.
+    let n_points = 5;
+    let radius = win.w().min(win.h()) * 0.25;
+    let points = (0..n_points)
+        .map(|i| {
+            let fract = i as f32 / n_points as f32;
+            let phase = fract;
+            let x = radius * (TAU * phase).cos();
+            let y = radius * (TAU * phase).sin();
+            pt3(x, y, 0.0)
+        });
+    draw.polygon()
+        .points(points)
+        .x(-win.w() * 0.25)
+        .color(WHITE)
+        .rotate(-t * 0.1);
+
+    // Do the same, but give each point a unique colour.
+    let n_points = 7;
+    let colored_points = (0..n_points)
+        .map(|i| {
+            let fract = i as f32 / n_points as f32;
+            let phase = fract;
+            let x = radius * (TAU * phase).cos();
+            let y = radius * (TAU * phase).sin();
+            let r = fract;
+            let g = 1.0 - fract;
+            let b = (0.5 + fract) % 1.0;
+            let a = 1.0;
+            let color = Rgba::new(r, g, b, a);
+            (pt3(x, y, 0.0), color)
+        });
+    draw.polygon()
+        .colored_points(colored_points)
+        .x(win.w() * 0.25)
+        .rotate(t * 0.2);
+
+    // Write the result of our drawing to the window's OpenGL frame.
+    draw.to_frame(app, &frame).unwrap();
+
+    // Return the drawn frame.
+    frame
+}

--- a/src/draw/mesh/vertex.rs
+++ b/src/draw/mesh/vertex.rs
@@ -8,6 +8,7 @@ pub type Point<S> = Point3<S>;
 pub type Color = color::Rgba;
 pub type TexCoords<S> = Point2<S>;
 pub type Normal<S> = Vector3<S>;
+pub type ColoredPoint<S> = WithColor<Point<S>, Color>;
 
 /// Types that can be converted into a `draw::mesh::vertex::Point`.
 pub trait IntoPoint<S> {
@@ -166,6 +167,20 @@ pub struct IterFromPoints<I, S = geom::DefaultScalar> {
     _scalar: PhantomData<S>,
 }
 
+/// A type that converts an iterator yielding 2D points to an iterator yielding **Vertex**s.
+///
+/// The `z` position for each vertex will be `0.0`.
+///
+/// The given `default_color` is used to color every vertex.
+///
+/// The default value of `(0.0, 0.0)` is used for tex_coords.
+#[derive(Clone, Debug)]
+pub struct IterFromPoint2s<I, S = geom::DefaultScalar> {
+    points: I,
+    default_color: Color,
+    _scalar: PhantomData<S>,
+}
+
 impl<I, S> IterFromPoints<I, S> {
     /// Produce an iterator that converts an iterator yielding points to an iterator yielding
     /// **Vertex**s.
@@ -188,37 +203,6 @@ impl<I, S> IterFromPoints<I, S> {
     }
 }
 
-impl<I, S> Iterator for IterFromPoints<I, S>
-where
-    I: Iterator<Item = Point<S>>,
-    S: BaseFloat,
-{
-    type Item = Vertex<S>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.points.next().map(|vertex| {
-            let color = self.default_color;
-            let vertex = WithColor { vertex, color };
-            let tex_coords = default_tex_coords();
-            let vertex = WithTexCoords { vertex, tex_coords };
-            vertex
-        })
-    }
-}
-
-/// A type that converts an iterator yielding 2D points to an iterator yielding **Vertex**s.
-///
-/// The `z` position for each vertex will be `0.0`.
-///
-/// The given `default_color` is used to color every vertex.
-///
-/// The default value of `(0.0, 0.0)` is used for tex_coords.
-#[derive(Clone, Debug)]
-pub struct IterFromPoint2s<I, S = geom::DefaultScalar> {
-    points: I,
-    default_color: Color,
-    _scalar: PhantomData<S>,
-}
-
 impl<I, S> IterFromPoint2s<I, S> {
     /// A type that converts an iterator yielding 2D points to an iterator yielding **Vertex**s.
     ///
@@ -239,6 +223,23 @@ impl<I, S> IterFromPoint2s<I, S> {
             default_color,
             _scalar,
         }
+    }
+}
+
+impl<I, S> Iterator for IterFromPoints<I, S>
+where
+    I: Iterator<Item = Point<S>>,
+    S: BaseFloat,
+{
+    type Item = Vertex<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.points.next().map(|vertex| {
+            let color = self.default_color;
+            let vertex = WithColor { vertex, color };
+            let tex_coords = default_tex_coords();
+            let vertex = WithTexCoords { vertex, tex_coords };
+            vertex
+        })
     }
 }
 

--- a/src/draw/properties/mod.rs
+++ b/src/draw/properties/mod.rs
@@ -11,6 +11,7 @@ use geom;
 use geom::graph::node;
 use math::BaseFloat;
 use std::cell::RefCell;
+use std::ops;
 
 pub mod color;
 pub mod primitive;

--- a/src/draw/properties/primitive/mod.rs
+++ b/src/draw/properties/primitive/mod.rs
@@ -23,7 +23,11 @@ pub use self::tri::Tri;
 pub enum Primitive<S = geom::DefaultScalar> {
     Ellipse(Ellipse<S>),
     Line(Line<S>),
-    Polygon(Polygon<S>),
+
+    PolygonPointless(polygon::Pointless),
+    PolygonFill(Polygon<polygon::Fill, S>),
+    PolygonColorPerVertex(Polygon<polygon::PerVertex, S>),
+
     Quad(Quad<S>),
     Rect(Rect<S>),
     Tri(Tri<S>),

--- a/src/draw/properties/primitive/mod.rs
+++ b/src/draw/properties/primitive/mod.rs
@@ -2,12 +2,14 @@ use geom;
 
 pub mod ellipse;
 pub mod line;
+pub mod polygon;
 pub mod quad;
 pub mod rect;
 pub mod tri;
 
 pub use self::ellipse::Ellipse;
 pub use self::line::Line;
+pub use self::polygon::Polygon;
 pub use self::quad::Quad;
 pub use self::rect::Rect;
 pub use self::tri::Tri;
@@ -21,6 +23,7 @@ pub use self::tri::Tri;
 pub enum Primitive<S = geom::DefaultScalar> {
     Ellipse(Ellipse<S>),
     Line(Line<S>),
+    Polygon(Polygon<S>),
     Quad(Quad<S>),
     Rect(Rect<S>),
     Tri(Tri<S>),

--- a/src/draw/properties/primitive/polygon.rs
+++ b/src/draw/properties/primitive/polygon.rs
@@ -1,0 +1,59 @@
+use draw::{self, mesh, Drawing};
+use draw::properties::{spatial, ColorScalar, Draw, Drawn, IntoDrawn, Primitive, Rgba, SetColor, SetDimensions, SetOrientation, SetPosition};
+use draw::properties::spatial::{dimension, orientation, position};
+use geom;
+use math::{BaseFloat, Vector2};
+use std::iter::Empty;
+
+/// Properties related to drawing a **Polygon**.
+#[derive(Clone, Debug)]
+pub struct Polygon<S = geom::DefaultScalar> {
+    spatial: spatial::Properties<S>,
+    color: Option<Rgba>,
+    point_range: ops::Range<usize>,
+    points: Rc<RefCell<Vec<mesh::vertex::Point<S>>>>,
+}
+
+impl<I, S> Polygon<I, S>
+where
+    I: Iterator,
+    S: BaseFloat,
+{
+    /// Create a new `Polygon` whose convex edges are described by the given points.
+    pub fn new<P>(points: P) -> Self
+    where
+        P: IntoIterator<IntoIter = I, Item = I::Item>,
+    {
+        let spatial = Default::default();
+        let color = Default::default();
+        let polygon = geom::Polygon::new(points);
+        Polygon {
+            spatial,
+            color,
+            polygon,
+        }
+    }
+
+    /// Use the given points to describe the outer edge of the polygon.
+    pub fn points(self, points: P) -> Polygon<P::IntoIter, S>
+    where
+        P: IntoIterator<Item = I::Item>,
+    {
+        let Polygon { spatial, color, .. } = self;
+        let polygon = geom::Polygon::new(points);
+        Polygon {
+            spatial,
+            color,
+            polygon,
+        }
+    }
+}
+
+impl<S> Default for Polygon<Empty<mesh::vertex::Point<S>>, S>
+where
+    S: BaseFloat,
+{
+    fn default() -> Self {
+        Polygon::new(Empty::default())
+    }
+}

--- a/src/draw/properties/primitive/polygon.rs
+++ b/src/draw/properties/primitive/polygon.rs
@@ -2,58 +2,202 @@ use draw::{self, mesh, Drawing};
 use draw::properties::{spatial, ColorScalar, Draw, Drawn, IntoDrawn, Primitive, Rgba, SetColor, SetDimensions, SetOrientation, SetPosition};
 use draw::properties::spatial::{dimension, orientation, position};
 use geom;
-use math::{BaseFloat, Vector2};
-use std::iter::Empty;
+use math::{BaseFloat, Vector2, Point3};
+use std::iter;
+
+/// A polygon prior to being initialised.
+#[derive(Clone, Debug, Default)]
+pub struct Pointless;
 
 /// Properties related to drawing a **Polygon**.
 #[derive(Clone, Debug)]
-pub struct Polygon<S = geom::DefaultScalar> {
+pub struct Polygon<C = Fill, S = geom::DefaultScalar> {
     spatial: spatial::Properties<S>,
-    color: Option<Rgba>,
-    point_range: ops::Range<usize>,
-    points: Rc<RefCell<Vec<mesh::vertex::Point<S>>>>,
+    color: C,
+    ranges: draw::GeomVertexDataRanges,
 }
 
-impl<I, S> Polygon<I, S>
+/// Color all vertices of the polygon with a single color.
+#[derive(Clone, Debug)]
+pub struct Fill(Option<mesh::vertex::Color>);
+
+/// Color each vertex individually.
+#[derive(Clone, Debug)]
+pub struct PerVertex;
+
+impl Pointless {
+    /// Draw a filled, convex polygon whose edges are defined by the given list of vertices.
+    pub(crate) fn points<P, S>(
+        self,
+        vertex_data: &mut draw::GeomVertexData<S>,
+        points: P,
+    ) -> Polygon<Fill, S>
+    where
+        P: IntoIterator,
+        P::Item: Into<mesh::vertex::Point<S>>,
+        S: BaseFloat,
+    {
+        let mut ranges = draw::GeomVertexDataRanges::default();
+        ranges.points.start = vertex_data.points.len();
+        vertex_data.points.extend(points.into_iter().map(Into::into));
+        ranges.points.end = vertex_data.points.len();
+        let color = Fill(None);
+        Polygon::new(color, ranges)
+    }
+
+    /// Draw a convex polygon whose edges and vertex colours are described by the given sequence of
+    /// vertices.
+    pub(crate) fn colored_points<P, S>(
+        self,
+        vertex_data: &mut draw::GeomVertexData<S>,
+        points: P,
+    ) -> Polygon<PerVertex, S>
+    where
+        P: IntoIterator,
+        P::Item: Into<::mesh::vertex::WithColor<mesh::vertex::Point<S>, mesh::vertex::Color>>,
+        S: BaseFloat,
+    {
+        let mut ranges = draw::GeomVertexDataRanges::default();
+        ranges.points.start = vertex_data.points.len();
+        ranges.colors.start = vertex_data.colors.len();
+        for v in points.into_iter().map(Into::into) {
+            vertex_data.points.push(v.vertex);
+            vertex_data.colors.push(v.color);
+        }
+        ranges.points.end = vertex_data.points.len();
+        ranges.colors.end = vertex_data.colors.len();
+        let color = PerVertex;
+        Polygon::new(color, ranges)
+    }
+}
+
+impl<C, S> Polygon<C, S>
 where
-    I: Iterator,
     S: BaseFloat,
 {
-    /// Create a new `Polygon` whose convex edges are described by the given points.
-    pub fn new<P>(points: P) -> Self
-    where
-        P: IntoIterator<IntoIter = I, Item = I::Item>,
-    {
+    // Initialise a new `Polygon` with no points, ready for drawing.
+    //
+    // The given `GeomVertexData` is use used to fill points.
+    fn new(color: C, ranges: draw::GeomVertexDataRanges) -> Self {
         let spatial = Default::default();
-        let color = Default::default();
-        let polygon = geom::Polygon::new(points);
         Polygon {
             spatial,
             color,
-            polygon,
-        }
-    }
-
-    /// Use the given points to describe the outer edge of the polygon.
-    pub fn points(self, points: P) -> Polygon<P::IntoIter, S>
-    where
-        P: IntoIterator<Item = I::Item>,
-    {
-        let Polygon { spatial, color, .. } = self;
-        let polygon = geom::Polygon::new(points);
-        Polygon {
-            spatial,
-            color,
-            polygon,
+            ranges,
         }
     }
 }
 
-impl<S> Default for Polygon<Empty<mesh::vertex::Point<S>>, S>
+impl<S> IntoDrawn<S> for Pointless
 where
     S: BaseFloat,
 {
-    fn default() -> Self {
-        Polygon::new(Empty::default())
+    type Vertices = iter::Empty<draw::mesh::Vertex<S>>;
+    type Indices = iter::Empty<usize>;
+    fn into_drawn(self, draw: Draw<S>) -> Drawn<S, Self::Vertices, Self::Indices> {
+        let properties = Default::default();
+        let vertices = iter::empty();
+        let indices = iter::empty();
+        (properties, vertices, indices)
     }
 }
+
+// impl<S> IntoDrawn<S> for Polygon<Fill, S>
+// where
+//     S: BaseFloat,
+// {
+//     type Vertices = (draw::GeomVertexDataRanges, Color);
+//     type Indices = ops::Range<usize>;
+//     fn into_drawn(self, draw: Draw<S>) -> Drawn<S, Self::Vertices, Self::Indices> {
+//         let Polygon {
+//             spatial,
+//             color: Fill(color),
+//             ranges,
+//         } = self;
+//         unimplemented!();
+//     }
+// }
+
+impl<C, S> SetOrientation<S> for Polygon<C, S> {
+    fn properties(&mut self) -> &mut orientation::Properties<S> {
+        SetOrientation::properties(&mut self.spatial)
+    }
+}
+
+impl<C, S> SetPosition<S> for Polygon<C, S> {
+    fn properties(&mut self) -> &mut position::Properties<S> {
+        SetPosition::properties(&mut self.spatial)
+    }
+}
+
+// impl<C, S> SetDimensions<S> for Polygon<C, S> {
+//     fn properties(&mut self) -> &mut dimension::Properties<S> {
+//         SetDimensions::properties(&mut self.spatial)
+//     }
+// }
+
+impl<S> SetColor<ColorScalar> for Polygon<Fill, S> {
+    fn rgba_mut(&mut self) -> &mut Option<Rgba> {
+        SetColor::rgba_mut(&mut self.color.0)
+    }
+}
+
+impl<S> From<Pointless> for Primitive<S> {
+    fn from(prim: Pointless) -> Self {
+        Primitive::PolygonPointless(prim)
+    }
+}
+
+impl<S> From<Polygon<Fill, S>> for Primitive<S> {
+    fn from(prim: Polygon<Fill, S>) -> Self {
+        Primitive::PolygonFill(prim)
+    }
+}
+
+impl<S> From<Polygon<PerVertex, S>> for Primitive<S> {
+    fn from(prim: Polygon<PerVertex, S>) -> Self {
+        Primitive::PolygonColorPerVertex(prim)
+    }
+}
+
+impl<S> Into<Option<Pointless>> for Primitive<S> {
+    fn into(self) -> Option<Pointless> {
+        match self {
+            Primitive::PolygonPointless(prim) => Some(prim),
+            _ => None,
+        }
+    }
+}
+
+impl<S> Into<Option<Polygon<Fill, S>>> for Primitive<S> {
+    fn into(self) -> Option<Polygon<Fill, S>> {
+        match self {
+            Primitive::PolygonFill(prim) => Some(prim),
+            _ => None,
+        }
+    }
+}
+
+impl<S> Into<Option<Polygon<PerVertex, S>>> for Primitive<S> {
+    fn into(self) -> Option<Polygon<PerVertex, S>> {
+        match self {
+            Primitive::PolygonColorPerVertex(prim) => Some(prim),
+            _ => None,
+        }
+    }
+}
+
+// impl<'a, S> Drawing<'a, Pointless, S>
+// where
+//     S: BaseFloat,
+// {
+//     /// Describe the polygon's edges with the given list of consecutive vertices that join them.
+//     pub fn points<P>(self, points: P) -> Drawing<'a, Polygon<Fill, S>, S>
+//     where
+//         P: IntoIterator,
+//         P::Item: Into<mesh::vertex::Point<S>>,
+//         S: BaseFloat,
+//     {
+//         self.map_ty_with_vertices(|ty, data| ty.points(data, points))
+//     }
+// }

--- a/src/mesh/vertex.rs
+++ b/src/mesh/vertex.rs
@@ -192,3 +192,42 @@ where
         self.vertex.point3()
     }
 }
+
+// For converting from a tuples to vertices.
+
+impl<A, V, C> From<(A, C)> for WithColor<V, C>
+where
+    A: Into<V>,
+{
+    fn from((vertex, color): (A, C)) -> Self {
+        let vertex = vertex.into();
+        WithColor { vertex, color }
+    }
+}
+
+impl<A, V, T> From<(A, T)> for WithTexCoords<V, T>
+where
+    A: Into<V>,
+{
+    fn from((vertex, tex_coords): (A, T)) -> Self {
+        let vertex = vertex.into();
+        WithTexCoords { vertex, tex_coords }
+    }
+}
+
+impl<A, V, N> From<(A, N)> for WithNormal<V, N>
+where
+    A: Into<V>,
+{
+    fn from((vertex, normal): (A, N)) -> Self {
+        let vertex = vertex.into();
+        WithNormal { vertex, normal }
+    }
+}
+
+#[test]
+fn test_tuple_conv() {
+    use color::named::GREEN;
+    let _: Point2<_> = [0.0, 0.0].into();
+    let _: WithColor<Point2<_>, _> = ([0.0, 0.0], GREEN).into();
+}


### PR DESCRIPTION
This involved a large update to the inner **IntoDrawn** API used for mapping `Drawing`s of geometric primitives to their "meshed" representation. The overhaul now allows for a dynamic number of arbitrary vertices per drawn primitive without requiring the need to reallocate buffers on each draw call.

The `Drawing` API has also been updated to allow for builders to produce new `Drawing` types. This allows for typed ordering of builder methods. E.g. `draw.polygon().points(points)` produces a `Drawing<Polygon<Fill>>` which implements `SetColor`, while `draw.polygon().colored_points(points)` produces a `Drawing<Polygon<PerVertex>>` which does not (as the color is specified via the vertices).

`draw.polygon()` supports both "filled" coloring and per-vertex coloring. A `simple_polygon.rs` example has been added demonstrating the new feature.

See the commit messages below for more details.