### PR TITLE
Add `draw.mesh()` API. Add `simple_mesh.rs` example. Add `IntoVertex` trait.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add many items to prelude (audio, io, math, osc, ui, window).
 - Change event positioning types to use DefaultScalar.
 - Implement `draw.polygon()`
+- Implement `draw.mesh()`
 - Update internal `IntoDrawn` API to support a dynamic number of arbitrary
   vertices.
 - Update `Drawing` API to allow builders to produce new `Drawing` types.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ path = "examples/simple_audio.rs"
 name = "simple_draw" 
 path = "examples/simple_draw.rs"
 [[example]] 
+name = "simple_mesh" 
+path = "examples/simple_mesh.rs"
+[[example]] 
 name = "simple_polygon" 
 path = "examples/simple_polygon.rs"
 [[example]] 

--- a/examples/simple_mesh.rs
+++ b/examples/simple_mesh.rs
@@ -1,0 +1,58 @@
+extern crate nannou;
+
+use nannou::prelude::*;
+
+fn main() {
+    nannou::view(view);
+}
+
+fn view(app: &App, frame: Frame) -> Frame {
+    // Begin drawing 
+    let win = app.window_rect();
+    let t = app.time;
+    let draw = app.draw();
+
+    // Clear the background to blue.
+    draw.background().color(BLACK);
+
+    // Use the mouse position to affect the frequency and amplitude.
+    let hz = map_range(app.mouse.x, win.left(), win.right(), 0.0, 100.0);
+    let amp = app.mouse.y;
+
+    // Create an iterator yielding triangles for drawing a sine wave.
+    let tris = (1..win.w() as usize)
+        .flat_map(|i| {
+            let l_fract = (i - 1) as f32 / win.w();
+            let r_fract = i as f32 / win.w();
+
+            // Map the vertices to the window.
+            let l_x = map_range(l_fract, 0.0, 1.0, win.left(), win.right());
+            let r_x = map_range(r_fract, 0.0, 1.0, win.left(), win.right());
+            let l_y = (t * hz + l_fract * hz * TAU).sin() * amp;
+            let r_y = (t * hz + r_fract * hz * TAU).sin() * amp;
+
+            // Produce this slice of the triangle as a quad.
+            let a = pt2(l_x, l_y);
+            let b = pt2(r_x, r_y);
+            let c = pt2(r_x, 0.0);
+            let d = pt2(l_x, 0.0);
+            geom::Quad([a, b, c, d]).triangles_iter()
+        })
+        .map(|tri| {
+            // Color the vertices based on their amplitude.
+            tri.map_vertices(|v| {
+                let y_fract = map_range(v.y.abs(), 0.0, win.top(), 0.0, 1.0);
+                let color = Rgba::new(y_fract, 1.0 - y_fract, 1.0 - y_fract, 1.0);
+                geom::vertex::Rgba(v, color)
+            })
+        });
+
+    // Draw the mesh!
+    draw.mesh().tris(tris);
+
+    // Write the result of our drawing to the window's OpenGL frame.
+    draw.to_frame(app, &frame).unwrap();
+
+    // Return the drawn frame.
+    frame
+}

--- a/src/draw/backend/glium.rs
+++ b/src/draw/backend/glium.rs
@@ -300,7 +300,7 @@ impl Renderer {
         let (w, h) = facade.get_context().get_framebuffer_dimensions();
         let map_vertex = |v| Vertex::from_mesh_vertex(v, w as _, h as _, dpi_factor);
         self.vertices.extend(draw.raw_vertices().map(map_vertex));
-        self.indices.extend(draw.mesh().indices().iter().map(|&u| u as u32));
+        self.indices.extend(draw.inner_mesh().indices().iter().map(|&u| u as u32));
         let index_prim = glium::index::PrimitiveType::TrianglesList;
         let vertex_buffer = glium::VertexBuffer::new(facade, &self.vertices[..])?;
         let index_buffer = glium::IndexBuffer::new(facade, index_prim, &self.indices[..])?;

--- a/src/draw/drawing.rs
+++ b/src/draw/drawing.rs
@@ -120,14 +120,14 @@ where
     // vertices.
     fn map_primitive_with_vertices<F, T2>(mut self, map: F) -> Drawing<'a, T2, S>
     where
-        F: FnOnce(draw::properties::Primitive<S>, &mut draw::GeomVertexData<S>) -> draw::properties::Primitive<S>,
+        F: FnOnce(draw::properties::Primitive<S>, &mut draw::IntermediaryMesh<S>) -> draw::properties::Primitive<S>,
         T2: IntoDrawn<S> + Into<Primitive<S>>,
     {
         if let Ok(mut state) = self.draw.state.try_borrow_mut() {
             if let Some(mut primitive) = state.drawing.remove(&self.index) {
                 {
-                    let mut geom_vertex_data = state.geom_vertex_data.borrow_mut();
-                    primitive = map(primitive, &mut *geom_vertex_data);
+                    let mut intermediary_mesh = state.intermediary_mesh.borrow_mut();
+                    primitive = map(primitive, &mut *intermediary_mesh);
                 }
                 state.drawing.insert(self.index, primitive);
             }
@@ -163,7 +163,7 @@ where
     /// **Panics** if the primitive does not contain type **T**.
     pub(crate) fn map_ty_with_vertices<F, T2>(self, map: F) -> Drawing<'a, T2, S>
     where
-        F: FnOnce(T, &mut draw::GeomVertexData<S>) -> T2,
+        F: FnOnce(T, &mut draw::IntermediaryMesh<S>) -> T2,
         T2: IntoDrawn<S> + Into<Primitive<S>>,
         Primitive<S>: Into<Option<T>>,
     {

--- a/src/draw/mesh/vertex.rs
+++ b/src/draw/mesh/vertex.rs
@@ -130,6 +130,18 @@ where
     }
 }
 
+impl<S, V> IntoVertex<S> for geom::vertex::Rgba<V>
+where
+    S: BaseFloat,
+    V: geom::Vertex<Scalar = S>,
+    (V, Color): IntoVertex<S>,
+{
+    fn into_vertex(self) -> Vertex<S> {
+        let geom::vertex::Rgba(v, color) = self;
+        (v, color).into_vertex()
+    }
+}
+
 // IntoPoint Implementations.
 
 impl<S> IntoPoint<S> for Point<S> {

--- a/src/draw/properties/mod.rs
+++ b/src/draw/properties/mod.rs
@@ -119,14 +119,14 @@ where
     }
 }
 
-/// Similar to the `Iterator` trait, but provides access to the **GeomVertexData** on each call to
+/// Similar to the `Iterator` trait, but provides access to the **IntermediaryMesh** on each call to
 /// the **next** method.
 pub trait Vertices<S>: Sized {
     /// Return the next **Vertex** within the sequence.
-    fn next(&mut self, data: &mut draw::GeomVertexData<S>) -> Option<draw::mesh::Vertex<S>>;
+    fn next(&mut self, data: &mut draw::IntermediaryMesh<S>) -> Option<draw::mesh::Vertex<S>>;
 
     /// Converts `self` and the given `data` into an iterator yielding vertices.
-    fn into_iter(self, data: &mut draw::GeomVertexData<S>) -> IterVertices<Self, S> {
+    fn into_iter(self, data: &mut draw::IntermediaryMesh<S>) -> IterVertices<Self, S> {
         IterVertices {
             vertices: self,
             data,
@@ -151,10 +151,10 @@ where
 }
 
 /// An iterator adaptor around a type implementing the **Vertices** trait and the
-/// **GeomVertexData** necessary for producing vertices.
+/// **IntermediaryMesh** necessary for producing vertices.
 pub struct IterVertices<'a, V, S: 'a> {
     vertices: V,
-    data: &'a mut draw::GeomVertexData<S>,
+    data: &'a mut draw::IntermediaryMesh<S>,
 }
 
 // Implement a method to simplify retrieving the dimensions of a type from `dimension::Properties`.
@@ -183,7 +183,7 @@ impl<S, I> Vertices<S> for I
 where
     I: Iterator<Item = draw::mesh::Vertex<S>>,
 {
-    fn next(&mut self, _data: &mut draw::GeomVertexData<S>) -> Option<draw::mesh::Vertex<S>> {
+    fn next(&mut self, _data: &mut draw::IntermediaryMesh<S>) -> Option<draw::mesh::Vertex<S>> {
         self.next()
     }
 }

--- a/src/draw/properties/mod.rs
+++ b/src/draw/properties/mod.rs
@@ -11,6 +11,7 @@ use geom;
 use geom::graph::node;
 use math::BaseFloat;
 use std::cell::RefCell;
+use std::ops;
 
 pub mod color;
 pub mod primitive;
@@ -44,6 +45,19 @@ where
     S: 'a + BaseFloat,
 {
     state: RefCell<&'a mut draw::State<S>>,
+}
+
+/// Uses a set of ranges to index into the intermediary mesh and produce vertices.
+#[derive(Debug)]
+pub struct VerticesFromRanges {
+    pub ranges: draw::IntermediaryVertexDataRanges,
+    pub fill_color: Option<draw::mesh::vertex::Color>,
+}
+
+/// Uses a range to index into the intermediary mesh indices.
+#[derive(Debug)]
+pub struct IndicesFromRange {
+    pub range: ops::Range<usize>,
 }
 
 impl<'a, S> Draw<'a, S>
@@ -119,17 +133,30 @@ where
     }
 }
 
-/// Similar to the `Iterator` trait, but provides access to the **IntermediaryMesh** on each call to
-/// the **next** method.
+/// Similar to the `Iterator` trait, but provides access to the **IntermediaryMesh** on each call
+/// to the **next** method.
 pub trait Vertices<S>: Sized {
     /// Return the next **Vertex** within the sequence.
-    fn next(&mut self, data: &mut draw::IntermediaryMesh<S>) -> Option<draw::mesh::Vertex<S>>;
-
+    fn next(&mut self, data: &draw::IntermediaryMesh<S>) -> Option<draw::mesh::Vertex<S>>;
     /// Converts `self` and the given `data` into an iterator yielding vertices.
-    fn into_iter(self, data: &mut draw::IntermediaryMesh<S>) -> IterVertices<Self, S> {
+    fn into_iter(self, data: &draw::IntermediaryMesh<S>) -> IterVertices<Self, S> {
         IterVertices {
             vertices: self,
             data,
+        }
+    }
+}
+
+/// Similar to the `Iterator` trait, but provides access to the **IntermediaryMesh** on each call
+/// to the **next** method.
+pub trait Indices: Sized {
+    /// Return the next index within the sequence.
+    fn next(&mut self, intermediary_indices: &[usize]) -> Option<usize>;
+    /// Converts `self` and the given `intermediary_indices` into an iterator yielding indices.
+    fn into_iter(self, intermediary_indices: &[usize]) -> IterIndices<Self> {
+        IterIndices {
+            indices: self,
+            intermediary_indices,
         }
     }
 }
@@ -145,7 +172,7 @@ where
     /// scaling and rotation transformations will be performed via the geometry graph.
     type Vertices: Vertices<S>;
     /// The iterator type yielding all vertex indices, describing edges of the drawing.
-    type Indices: IntoIterator<Item = usize>;
+    type Indices: Indices;
     /// Consume `self` and return its **Drawn** form.
     fn into_drawn(self, Draw<S>) -> Drawn<S, Self::Vertices, Self::Indices>;
 }
@@ -154,7 +181,14 @@ where
 /// **IntermediaryMesh** necessary for producing vertices.
 pub struct IterVertices<'a, V, S: 'a> {
     vertices: V,
-    data: &'a mut draw::IntermediaryMesh<S>,
+    data: &'a draw::IntermediaryMesh<S>,
+}
+
+/// An iterator adaptor around a type implementing the **Vertices** trait and the
+/// **IntermediaryMesh** necessary for producing vertices.
+pub struct IterIndices<'a, I> {
+    indices: I,
+    intermediary_indices: &'a [usize],
 }
 
 // Implement a method to simplify retrieving the dimensions of a type from `dimension::Properties`.
@@ -183,7 +217,16 @@ impl<S, I> Vertices<S> for I
 where
     I: Iterator<Item = draw::mesh::Vertex<S>>,
 {
-    fn next(&mut self, _data: &mut draw::IntermediaryMesh<S>) -> Option<draw::mesh::Vertex<S>> {
+    fn next(&mut self, _data: &draw::IntermediaryMesh<S>) -> Option<draw::mesh::Vertex<S>> {
+        self.next()
+    }
+}
+
+impl<I> Indices for I
+where
+    I: Iterator<Item = usize>,
+{
+    fn next(&mut self, _intermediary_indices: &[usize]) -> Option<usize> {
         self.next()
     }
 }
@@ -196,8 +239,80 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         let IterVertices {
             ref mut vertices,
-            ref mut data,
+            data,
         } = *self;
-        Vertices::next(vertices, *data)
+        Vertices::next(vertices, data)
+    }
+}
+
+impl<'a, I> Iterator for IterIndices<'a, I>
+where
+    I: Indices,
+{
+    type Item = usize;
+    fn next(&mut self) -> Option<Self::Item> {
+        let IterIndices {
+            ref mut indices,
+            intermediary_indices,
+        } = *self;
+        Indices::next(indices, intermediary_indices)
+    }
+}
+
+impl<S> Vertices<S> for VerticesFromRanges
+where
+    S: BaseFloat,
+{
+    fn next(&mut self, mesh: &draw::IntermediaryMesh<S>) -> Option<draw::mesh::Vertex<S>> {
+        let VerticesFromRanges {
+            ref mut ranges,
+            fill_color,
+        } = *self;
+
+        let point = Iterator::next(&mut ranges.points);
+        let color = Iterator::next(&mut ranges.colors);
+        let tex_coords = Iterator::next(&mut ranges.tex_coords);
+
+        let point = match point {
+            None => return None,
+            Some(point_ix) => {
+                *mesh.vertex_data
+                    .points
+                    .get(point_ix)
+                    .expect("no point for point index in IntermediaryMesh")
+            },
+        };
+
+        let color = color
+            .map(|color_ix| {
+                *mesh.vertex_data
+                    .colors
+                    .get(color_ix)
+                    .expect("no color for color index in IntermediaryMesh")
+            })
+            .or(fill_color)
+            .expect("no color for vertex");
+
+        let tex_coords = tex_coords
+            .map(|tex_coords_ix| {
+                *mesh.vertex_data
+                    .tex_coords
+                    .get(tex_coords_ix)
+                    .expect("no tex_coords for tex_coords index in IntermediaryMesh")
+            })
+            .unwrap_or_else(draw::mesh::vertex::default_tex_coords);
+
+        Some(draw::mesh::vertex::new(point, color, tex_coords))
+    }
+}
+
+impl Indices for IndicesFromRange {
+    fn next(&mut self, intermediary_indices: &[usize]) -> Option<usize> {
+        Iterator::next(&mut self.range)
+            .map(|ix| {
+                *intermediary_indices
+                    .get(ix)
+                    .expect("index into `intermediary_indices` is out of range")
+            })
     }
 }

--- a/src/draw/properties/primitive/mesh.rs
+++ b/src/draw/properties/primitive/mesh.rs
@@ -1,9 +1,11 @@
-use draw::{self, mesh, Drawing};
-use draw::properties::{ColorScalar, Draw, Drawn, IntoDrawn, Primitive, Rgba, SetColor, SetOrientation, SetPosition};
+use draw::{self, Drawing};
+use draw::mesh::vertex::IntoVertex;
+use draw::properties::{Draw, Drawn, IntoDrawn, Primitive, SetOrientation, SetPosition};
 use draw::properties::spatial::{self, orientation, position};
 use geom;
 use math::BaseFloat;
-use std::iter;
+use mesh::vertex::{WithColor, WithTexCoords};
+use std::{iter, ops};
 
 /// The mesh type prior to being initialised with vertices or indices.
 #[derive(Clone, Debug, Default)]
@@ -14,8 +16,15 @@ pub struct Vertexless;
 pub struct Mesh<S = geom::DefaultScalar> {
     position: position::Properties<S>,
     orientation: orientation::Properties<S>,
-    vertex_data_ranges: draw::GeomVertexDataRanges,
-    index_ranges: ops::Range<usize>,
+    vertex_data_ranges: draw::IntermediaryVertexDataRanges,
+    index_range: ops::Range<usize>,
+}
+
+// A simple iterator for flattening a fixed-size array of indices.
+struct FlattenIndices<I> {
+    iter: I,
+    index: usize,
+    current: [usize; 3],
 }
 
 impl Vertexless {
@@ -23,11 +32,237 @@ impl Vertexless {
     ///
     /// Each triangle may be composed of any vertex type that may be converted directly into the
     /// `draw;;mesh::vertex` type.
+    pub fn tris<S, I, V>(
+        self,
+        mesh: &mut draw::IntermediaryMesh<S>,
+        tris: I,
+    ) -> Mesh<S>
+    where
+        S: BaseFloat,
+        I: IntoIterator<Item = geom::Tri<V>>,
+        V: geom::Vertex + IntoVertex<S>,
+    {
+        let mut vertex_data_ranges = draw::IntermediaryVertexDataRanges::default();
+        let mut index_range = 0..0;
+        vertex_data_ranges.points.start = mesh.vertex_data.points.len();
+        vertex_data_ranges.colors.start = mesh.vertex_data.colors.len();
+        vertex_data_ranges.tex_coords.start = mesh.vertex_data.tex_coords.len();
+        index_range.start = mesh.indices.len();
+
+        let vertices = tris.into_iter()
+            .flat_map(geom::Tri::vertices)
+            .map(IntoVertex::into_vertex);
+        for (i, vertex) in vertices.enumerate() {
+            let WithTexCoords {
+                tex_coords,
+                vertex: WithColor {
+                    color,
+                    vertex: point,
+                },
+            } = vertex;
+            mesh.vertex_data.points.push(point);
+            mesh.vertex_data.colors.push(color);
+            mesh.vertex_data.tex_coords.push(tex_coords);
+            mesh.indices.push(i);
+        }
+        vertex_data_ranges.points.end = mesh.vertex_data.points.len();
+        vertex_data_ranges.colors.end = mesh.vertex_data.colors.len();
+        vertex_data_ranges.tex_coords.end = mesh.vertex_data.tex_coords.len();
+        index_range.end = mesh.indices.len();
+        Mesh::new(vertex_data_ranges, index_range)
+    }
+
+    /// Describe the mesh with the given indexed vertices.
+    ///
+    /// Each trio of `indices` describes a single triangle of `vertices`.
+    ///
+    /// Each vertex may be any type that may be converted directly into the `draw;;mesh::vertex`
+    /// type.
+    pub fn indexed<S, V, I>(
+        self,
+        mesh: &mut draw::IntermediaryMesh<S>,
+        vertices: V,
+        indices: I,
+    ) -> Mesh<S>
+    where
+        S: BaseFloat,
+        V: IntoIterator,
+        V::Item: IntoVertex<S>,
+        I: IntoIterator<Item = [usize; 3]>,
+    {
+        let mut vertex_data_ranges = draw::IntermediaryVertexDataRanges::default();
+        vertex_data_ranges.points.start = mesh.vertex_data.points.len();
+        vertex_data_ranges.colors.start = mesh.vertex_data.colors.len();
+        vertex_data_ranges.tex_coords.start = mesh.vertex_data.tex_coords.len();
+        for vertex in vertices {
+            let WithTexCoords {
+                tex_coords,
+                vertex: WithColor {
+                    color,
+                    vertex: point,
+                },
+            } = vertex.into_vertex();
+            mesh.vertex_data.points.push(point);
+            mesh.vertex_data.colors.push(color);
+            mesh.vertex_data.tex_coords.push(tex_coords);
+        }
+        vertex_data_ranges.points.end = mesh.vertex_data.points.len();
+        vertex_data_ranges.colors.end = mesh.vertex_data.colors.len();
+        vertex_data_ranges.tex_coords.end = mesh.vertex_data.tex_coords.len();
+        let mut index_range = mesh.indices.len()..mesh.indices.len();
+        let iter = FlattenIndices { iter: indices.into_iter(), current: [0; 3], index: 3 };
+        mesh.indices.extend(iter);
+        index_range.end = mesh.indices.len();
+        Mesh::new(vertex_data_ranges, index_range)
+    }
 }
 
-// draw.mesh().tris(tris)
-// draw.mesh().indexed(vertices, indices)
+impl<S> Mesh<S>
+where
+    S: BaseFloat,
+{
+    // Initialise a new `Mesh` with its ranges into the intermediary mesh, ready for drawing.
+    fn new(
+        vertex_data_ranges: draw::IntermediaryVertexDataRanges,
+        index_range: ops::Range<usize>,
+    ) -> Self {
+        let orientation = Default::default();
+        let position = Default::default();
+        Mesh {
+            orientation,
+            position,
+            vertex_data_ranges,
+            index_range,
+        }
+    }
+}
 
-// draw.mesh().textured_tris(tris) // calls `tris` under the hood.
-// draw.mesh().colored_tris(tris) // calls `tris` under the hood.
-// draw.mesh().colored_textured_tris(tris)
+impl<'a, S> Drawing<'a, Vertexless, S>
+where
+    S: BaseFloat,
+{
+    /// Describe the mesh with the given sequence of triangles.
+    pub fn tris<I, V>(self, tris: I) -> Drawing<'a, Mesh<S>, S>
+    where
+        S: BaseFloat,
+        I: IntoIterator<Item = geom::Tri<V>>,
+        V: geom::Vertex + IntoVertex<S>,
+    {
+        self.map_ty_with_vertices(|ty, mesh| ty.tris(mesh, tris))
+    }
+
+    /// Describe the mesh with the given sequence of indexed vertices.
+    pub fn indexed<V, I>(self, vertices: V, indices: I) -> Drawing<'a, Mesh<S>, S>
+    where
+        S: BaseFloat,
+        V: IntoIterator,
+        V::Item: IntoVertex<S>,
+        I: IntoIterator<Item = [usize; 3]>,
+    {
+        self.map_ty_with_vertices(|ty, mesh| ty.indexed(mesh, vertices, indices))
+    }
+}
+
+impl<S> IntoDrawn<S> for Vertexless
+where
+    S: BaseFloat,
+{
+    type Vertices = iter::Empty<draw::mesh::Vertex<S>>;
+    type Indices = iter::Empty<usize>;
+    fn into_drawn(self, _draw: Draw<S>) -> Drawn<S, Self::Vertices, Self::Indices> {
+        let properties = Default::default();
+        let vertices = iter::empty();
+        let indices = iter::empty();
+        (properties, vertices, indices)
+    }
+}
+
+impl<S> IntoDrawn<S> for Mesh<S>
+where
+    S: BaseFloat,
+{
+    type Vertices = draw::properties::VerticesFromRanges;
+    type Indices = draw::properties::IndicesFromRange;
+    fn into_drawn(self, _draw: Draw<S>) -> Drawn<S, Self::Vertices, Self::Indices> {
+        let Mesh {
+            orientation,
+            position,
+            vertex_data_ranges,
+            index_range,
+        } = self;
+
+        let dimensions = spatial::dimension::Properties::default();
+        let spatial = spatial::Properties { dimensions, orientation, position };
+        let vertices = draw::properties::VerticesFromRanges {
+            ranges: vertex_data_ranges,
+            fill_color: None,
+        };
+        let indices = draw::properties::IndicesFromRange { range: index_range };
+        (spatial, vertices, indices)
+    }
+}
+
+impl<I> Iterator for FlattenIndices<I>
+where
+    I: Iterator<Item = [usize; 3]>,
+{
+    type Item = usize;
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.index < self.current.len() {
+                let ix = self.current[self.index];
+                self.index += 1;
+                return Some(ix);
+            }
+            match self.iter.next() {
+                None => return None,
+                Some(trio) => {
+                    self.current = trio;
+                    self.index = 0;
+                },
+            }
+        }
+    }
+}
+
+impl<S> SetOrientation<S> for Mesh<S> {
+    fn properties(&mut self) -> &mut orientation::Properties<S> {
+        SetOrientation::properties(&mut self.orientation)
+    }
+}
+
+impl<S> SetPosition<S> for Mesh<S> {
+    fn properties(&mut self) -> &mut position::Properties<S> {
+        SetPosition::properties(&mut self.position)
+    }
+}
+
+impl<S> From<Vertexless> for Primitive<S> {
+    fn from(prim: Vertexless) -> Self {
+        Primitive::MeshVertexless(prim)
+    }
+}
+
+impl<S> From<Mesh<S>> for Primitive<S> {
+    fn from(prim: Mesh<S>) -> Self {
+        Primitive::Mesh(prim)
+    }
+}
+
+impl<S> Into<Option<Vertexless>> for Primitive<S> {
+    fn into(self) -> Option<Vertexless> {
+        match self {
+            Primitive::MeshVertexless(prim) => Some(prim),
+            _ => None,
+        }
+    }
+}
+
+impl<S> Into<Option<Mesh<S>>> for Primitive<S> {
+    fn into(self) -> Option<Mesh<S>> {
+        match self {
+            Primitive::Mesh(prim) => Some(prim),
+            _ => None,
+        }
+    }
+}

--- a/src/draw/properties/primitive/mesh.rs
+++ b/src/draw/properties/primitive/mesh.rs
@@ -1,0 +1,33 @@
+use draw::{self, mesh, Drawing};
+use draw::properties::{ColorScalar, Draw, Drawn, IntoDrawn, Primitive, Rgba, SetColor, SetOrientation, SetPosition};
+use draw::properties::spatial::{self, orientation, position};
+use geom;
+use math::BaseFloat;
+use std::iter;
+
+/// The mesh type prior to being initialised with vertices or indices.
+#[derive(Clone, Debug, Default)]
+pub struct Vertexless;
+
+/// Properties related to drawing an arbitrary mesh of colours, geometry and texture.
+#[derive(Clone, Debug)]
+pub struct Mesh<S = geom::DefaultScalar> {
+    position: position::Properties<S>,
+    orientation: orientation::Properties<S>,
+    vertex_data_ranges: draw::GeomVertexDataRanges,
+    index_ranges: ops::Range<usize>,
+}
+
+impl Vertexless {
+    /// Describe the mesh with a sequence of triangles.
+    ///
+    /// Each triangle may be composed of any vertex type that may be converted directly into the
+    /// `draw;;mesh::vertex` type.
+}
+
+// draw.mesh().tris(tris)
+// draw.mesh().indexed(vertices, indices)
+
+// draw.mesh().textured_tris(tris) // calls `tris` under the hood.
+// draw.mesh().colored_tris(tris) // calls `tris` under the hood.
+// draw.mesh().colored_textured_tris(tris)

--- a/src/draw/properties/primitive/mod.rs
+++ b/src/draw/properties/primitive/mod.rs
@@ -2,6 +2,7 @@ use geom;
 
 pub mod ellipse;
 pub mod line;
+pub mod mesh;
 pub mod polygon;
 pub mod quad;
 pub mod rect;
@@ -9,6 +10,7 @@ pub mod tri;
 
 pub use self::ellipse::Ellipse;
 pub use self::line::Line;
+pub use self::mesh::Mesh;
 pub use self::polygon::Polygon;
 pub use self::quad::Quad;
 pub use self::rect::Rect;
@@ -23,11 +25,11 @@ pub use self::tri::Tri;
 pub enum Primitive<S = geom::DefaultScalar> {
     Ellipse(Ellipse<S>),
     Line(Line<S>),
-
+    MeshVertexless(mesh::Vertexless),
+    Mesh(Mesh<S>),
     PolygonPointless(polygon::Pointless),
     PolygonFill(Polygon<polygon::Fill, S>),
     PolygonColorPerVertex(Polygon<polygon::PerVertex, S>),
-
     Quad(Quad<S>),
     Rect(Rect<S>),
     Tri(Tri<S>),


### PR DESCRIPTION
Allows for drawing a mesh via a sequence of triangles. The triangles can
be provided either as a sequence of `Tri<V>` or via a sequence of
vertices alongside a sequence of indices into those vertices.

The `IntoDrawn` trait API has been changed to allow for a more flexible
`Indices` type. The `Indices` type now has access to the Draw's
intermediary mesh each time the next index is requested.

The `GeomVertexData` has been changed to `IntermediaryMesh` and a
`indices` buffer has been added in order to support indexed vertices.
This will be useful for the `draw.mesh()` API.

An `IntoVertex` trait has been added which should aid in simplifying the
`draw.mesh()` API.