### PR TITLE
Change `random_range` to check that `min <= max`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Change `random_range` to check that `min` is smaller than `max`, swapping the
+  two if not. This avoids some common `panic!`s.
 - Add custom `Vector` types - replaces the use of `cgmath::{VectorN, PointN}`
   types.
 - Update `rand` to version `0.5`.

--- a/examples/nature_of_code/chp_02_forces/2_10_exercise_attract_repel.rs
+++ b/examples/nature_of_code/chp_02_forces/2_10_exercise_attract_repel.rs
@@ -20,12 +20,12 @@ struct Mover {
 
 // A type for a draggable attractive body in our world
 struct Attractor {
-    mass: f32,             // Mass, tied to size
-    radius: f32,           // Radius of the attractor
-    position: Point2,      // position
-    dragging: bool,        // Is the object being dragged?
-    roll_over: bool,       // Is the mouse over the ellipse?
-    drag: Vector2,         // holds the offset for when the object is clicked on
+    mass: f32,        // Mass, tied to size
+    radius: f32,      // Radius of the attractor
+    position: Point2, // position
+    dragging: bool,   // Is the object being dragged?
+    roll_over: bool,  // Is the mouse over the ellipse?
+    drag: Vector2,    // holds the offset for when the object is clicked on
 }
 
 impl Attractor {

--- a/examples/nature_of_code/chp_02_forces/2_6_attraction.rs
+++ b/examples/nature_of_code/chp_02_forces/2_6_attraction.rs
@@ -25,11 +25,11 @@ struct Mover {
 
 // A type for a draggable attractive body in our world
 struct Attractor {
-    mass: f32,                 // Maxx, tied to size
-    position: Point2,          // position
-    dragging: bool,            // Is the object being dragged?
-    roll_over: bool,           // Is the mouse over the ellipse?
-    drag_offset: Vector2,      // holds the offset for when the object is clicked on
+    mass: f32,            // Maxx, tied to size
+    position: Point2,     // position
+    dragging: bool,       // Is the object being dragged?
+    roll_over: bool,      // Is the mouse over the ellipse?
+    drag_offset: Vector2, // holds the offset for when the object is clicked on
 }
 
 impl Attractor {

--- a/examples/nature_of_code/chp_02_forces/2_7_attraction_many.rs
+++ b/examples/nature_of_code/chp_02_forces/2_7_attraction_many.rs
@@ -25,11 +25,11 @@ struct Mover {
 
 // A type for a draggable attractive body in our world
 struct Attractor {
-    mass: f32,                 // Maxx, tied to size
-    position: Point2,          // position
-    dragging: bool,            // Is the object being dragged?
-    roll_over: bool,           // Is the mouse over the ellipse?
-    drag_offset: Vector2,      // holds the offset for when the object is clicked on
+    mass: f32,            // Maxx, tied to size
+    position: Point2,     // position
+    dragging: bool,       // Is the object being dragged?
+    roll_over: bool,      // Is the mouse over the ellipse?
+    drag_offset: Vector2, // holds the offset for when the object is clicked on
 }
 
 impl Attractor {

--- a/examples/nature_of_code/chp_03_oscillation/3_02_forces_angular_motion.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_02_forces_angular_motion.rs
@@ -13,9 +13,9 @@ fn main() {
 
 // A type for a draggable attractive body in our world
 struct Attractor {
-    mass: f32,             // Mass, tied to size
-    location: Point2,      // Location
-    g: f32,                // Gravity
+    mass: f32,        // Mass, tied to size
+    location: Point2, // Location
+    g: f32,           // Gravity
 }
 
 impl Attractor {

--- a/examples/nature_of_code/chp_03_oscillation/3_10_exercise_oop_wave.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_10_exercise_oop_wave.rs
@@ -17,12 +17,12 @@ struct Model {
 }
 
 struct Wave {
-    x_spacing: f32,       // How far apart should each horizontal position be spaced
-    _w: f32,              // Width of entire wave
-    origin: Point2,       // Where does the wave's first point start
-    theta: f32,           // Start angle at 0
-    amplitude: f32,       // Height of the wave
-    _period: f32,         // How many pixels before the wave repeats
+    x_spacing: f32,     // How far apart should each horizontal position be spaced
+    _w: f32,            // Width of entire wave
+    origin: Point2,     // Where does the wave's first point start
+    theta: f32,         // Start angle at 0
+    amplitude: f32,     // Height of the wave
+    _period: f32,       // How many pixels before the wave repeats
     dx: f32, // Value for incementing X, to be calculated as a function of period and x_spacing
     y_values: Vec<f32>, // Using a vector to store the height values for the wave (not entirely necessary)
 }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -25,11 +25,15 @@ pub fn random_f64() -> f64 {
 /// The generated value may be within the range [min, max). That is, the result is inclusive of
 /// `min`, but will never be `max`.
 ///
+/// If the given `min` is greater than the given `max`, they will be swapped before calling
+/// `gen_range` internally to avoid triggering a `panic!`.
+///
 /// This calls `rand::thread_rng().gen_range(min, max)` internally, in turn using the thread-local
 /// default random number generator.
 pub fn random_range<T>(min: T, max: T) -> T
 where
     T: PartialOrd + distributions::range::SampleRange,
 {
+    let (min, max) = if min <= max { (min, max) } else { (max, min) };
     rand::thread_rng().gen_range(min, max)
 }


### PR DESCRIPTION
This avoids a common `panic!` that would occur when the `min` value is
greater than the `max` value. Rather than `panic!`ing, we simply swap
the min and max values instead.