### PR TITLE
[nannou-new] Create `assets` directory when generating project

### DIFF
--- a/nannou-new/Cargo.toml
+++ b/nannou-new/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou-new"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A tool for easily starting Nannou projects."
 readme = "README.md"

--- a/nannou-new/src/main.rs
+++ b/nannou-new/src/main.rs
@@ -183,6 +183,10 @@ fn main() {
         writeln!(file, "{}", nannou_dependency).expect("failed to append nannou dependency");
     }
 
+    // Create the assets directory.
+    let assets_path = project_path.join("assets");
+    fs::create_dir(assets_path).expect("failed to create assets directory");
+
     // Change the directory to the newly created path.
     println!("Changing the current directory to \"{}\"", project_path.display());
     env::set_current_dir(&project_path).expect("failed to change directories");


### PR DESCRIPTION
Published as 0.1.1.

Closes #211.