### PR TITLE
Add window-specific view and event user function support. Add app update user function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - The `view` function is now called separately for each frame for each window,
   rather than a single frame for all windows at once. The window a frame is
   associated with can be determined via `Frame::window_id`.
+- A suite of new event handling functions have been added as an alternative to
+  matching on the raw `Event` type. This has simplified a lot of the examples.
+  See the `app::Builder` and `window::Builder` docs for the newly available
+  methods and more documentation.
 
 # Version 0.8.0 (2018-07-19)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ winit = "0.18"
 
 # --------------- Nannou Examples
 [[example]]
+name = "all_functions"
+path = "examples/all_functions.rs"
+[[example]]
 name = "loop_mode"
 path = "examples/loop_mode.rs"
 [[example]]

--- a/examples/all_functions.rs
+++ b/examples/all_functions.rs
@@ -1,0 +1,139 @@
+extern crate nannou;
+
+use nannou::prelude::*;
+
+fn main() {
+    nannou::app(model)
+        .event(event)
+        .update(update)
+        .view(view)
+        .run();
+}
+
+struct Model {}
+
+fn model(app: &App) -> Model {
+    app.new_window()
+        .with_dimensions(720, 720)
+        .event(window_event)
+        .raw_event(raw_window_event)
+        .key_pressed(key_pressed)
+        .key_released(key_released)
+        .mouse_moved(mouse_moved)
+        .mouse_pressed(mouse_pressed)
+        .mouse_released(mouse_released)
+        .mouse_wheel(mouse_wheel)
+        .mouse_entered(mouse_entered)
+        .mouse_exited(mouse_exited)
+        .touch(touch)
+        .touchpad_pressure(touchpad_pressure)
+        .moved(window_moved)
+        .resized(window_resized)
+        .hovered_file(hovered_file)
+        .hovered_file_cancelled(hovered_file_cancelled)
+        .dropped_file(dropped_file)
+        .focused(window_focused)
+        .unfocused(window_unfocused)
+        .closed(window_closed)
+        .build()
+        .unwrap();
+    Model {}
+}
+
+fn event(_app: &App, _model: &mut Model, event: Event) {
+    match event {
+        Event::WindowEvent { id: _, raw: _, simple: _  } => {}
+        Event::DeviceEvent(_device_id, _event) => {}
+        Event::Update(_dt) => {}
+        Event::Awakened => {}
+        Event::Suspended(_b) => {}
+    }
+}
+
+fn update(_app: &App, _model: &mut Model, _update: Update) {
+}
+
+fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+    frame.clear(DARK_BLUE);
+    frame
+}
+
+fn window_event(_app: &App, _model: &mut Model, event: WindowEvent) {
+    match event {
+        KeyPressed(_key) => {}
+        KeyReleased(_key) => {}
+        MouseMoved(_pos) => {}
+        MousePressed(_button) => {}
+        MouseReleased(_button) => {}
+        MouseEntered => {}
+        MouseExited => {}
+        MouseWheel(_amount, _phase) => {}
+        Moved(_pos) => {}
+        Resized(_size) => {}
+        Touch(_touch) => {}
+        TouchPressure(_pressure) => {}
+        HoveredFile(_path) => {}
+        DroppedFile(_path) => {}
+        HoveredFileCancelled => {}
+        Focused => {}
+        Unfocused => {}
+        Closed => {}
+    }
+}
+
+fn raw_window_event(_app: &App, _model: &mut Model, _event: nannou::winit::WindowEvent) {
+}
+
+fn key_pressed(_app: &App, _model: &mut Model, _key: Key) {
+}
+
+fn key_released(_app: &App, _model: &mut Model, _key: Key) {
+}
+
+fn mouse_moved(_app: &App, _model: &mut Model, _pos: Point2) {
+}
+
+fn mouse_pressed(_app: &App, _model: &mut Model, _button: MouseButton) {
+}
+
+fn mouse_released(_app: &App, _model: &mut Model, _button: MouseButton) {
+}
+
+fn mouse_wheel(_app: &App, _model: &mut Model, _dt: MouseScrollDelta, _phase: TouchPhase) {
+}
+
+fn mouse_entered(_app: &App, _model: &mut Model) {
+}
+
+fn mouse_exited(_app: &App, _model: &mut Model) {
+}
+
+fn touch(_app: &App, _model: &mut Model, _touch: TouchEvent) {
+}
+
+fn touchpad_pressure(_app: &App, _model: &mut Model, _pressure: TouchpadPressure) {
+}
+
+fn window_moved(_app: &App, _model: &mut Model, _pos: Point2) {
+}
+
+fn window_resized(_app: &App, _model: &mut Model, _dim: Vector2) {
+}
+
+fn window_focused(_app: &App, _model: &mut Model) {
+}
+
+fn window_unfocused(_app: &App, _model: &mut Model) {
+}
+
+fn window_closed(_app: &App, _model: &mut Model) {
+}
+
+fn hovered_file(_app: &App, _model: &mut Model, _path: std::path::PathBuf) {
+}
+
+fn hovered_file_cancelled(_app: &App, _model: &mut Model) {
+}
+
+fn dropped_file(_app: &App, _model: &mut Model, _path: std::path::PathBuf) {
+}

--- a/examples/basics/1_nannou_events.rs
+++ b/examples/basics/1_nannou_events.rs
@@ -2,65 +2,61 @@ extern crate nannou;
 
 use nannou::prelude::*;
 
-// every rust program has to have a main function which gets
-// called when the program is run.
+// Every rust program has to have a main function which gets called when the program is run.
+// In the main function, we build the nannou app and run it.
 fn main() {
-    nannou::app(model).event(event).simple_window(view).run();
+    nannou::app(model).update(update).run();
 }
 
-// model represents the state of our app
+// Model represents the state of our application. We don't have any state in this demonstration, so
+// for now it is just an empty struct.
 struct Model;
 
-// put your setup code here, to run once before the application loop:
-fn model(_app: &App) -> Model {
+// This function is where we setup the application and create the `Model` for the first time.
+fn model(app: &App) -> Model {
+    // Create a window that can receive user input like mouse and keyboard events.
+    app.new_window().event(event).view(view).build().unwrap();
     Model
 }
 
-// put your update code here, to set variables and handle
-// keyboard and mouse events before drawing each frame:
-fn event(_app: &App, model: Model, event: Event) -> Model {
+// Update the state of your application here. By default, this gets called right before `view`.
+fn update(_app: &App, _model: &mut Model, _update: Update) {
+}
+
+// We can also update the application based on events received by the window like key presses and
+// mouse movement here.
+fn event(_app: &App, _model: &mut Model, event: WindowEvent) {
+    // Print events as they occur to the console
+    println!("{:?}", event);
+
+    // We can `match` on the event to do something different depending on the kind of event.
     match event {
-        Event::WindowEvent {
-            simple: Some(event),
-            ..
-        } => {
-            // Print events as they occur to the console
-            println!("{:#?}", event);
+        // Keyboard events
+        KeyPressed(_key) => {}
+        KeyReleased(_key) => {}
 
-            match event {
-                // KEY EVENTS
-                KeyPressed(_key) => {}
+        // Mouse events
+        MouseMoved(_pos) => {}
+        MousePressed(_button) => {}
+        MouseReleased(_button) => {}
+        MouseWheel(_amount, _phase) => {}
+        MouseEntered => {}
+        MouseExited => {}
 
-                KeyReleased(_key) => {}
+        // Touch events
+        Touch(_touch) => {}
+        TouchPressure(_pressure) => {}
 
-                // MOUSE EVENTS
-                MouseMoved(_pos) => {}
-
-                MouseDragged(_pos, _button) => {}
-
-                MousePressed(_button) => {}
-
-                MouseReleased(_button) => {}
-
-                MouseEntered => {}
-
-                MouseExited => {}
-
-                // WINDOW EVENTS
-                Resized(_size) => {}
-
-                Moved(_pos) => {}
-
-                _other => (),
-            }
-        }
-
-        // update gets called just before view every frame
-        Event::Update(_dt) => {}
-
-        _ => (),
+        // Window events
+        Moved(_pos) => {}
+        Resized(_size) => {}
+        HoveredFile(_path) => {}
+        DroppedFile(_path) => {}
+        HoveredFileCancelled => {}
+        Focused => {}
+        Unfocused => {}
+        Closed => {}
     }
-    model
 }
 
 // put your main code here, to run repeatedly:

--- a/examples/basics/2_variables_window_console.rs
+++ b/examples/basics/2_variables_window_console.rs
@@ -3,24 +3,18 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).view(view).run();
 }
 
-struct Model {
-    window: WindowId,
-}
+struct Model;
 
 fn model(app: &App) -> Model {
-    // Construct and define the size of our window using .with_dimensions(.,.)
-    // Argument 1 = width of window; Argument 2 = height of window
-    let window = app.new_window().with_dimensions(640, 480).build().unwrap();
-
-    // Below are the different variable types available in Rust
-    let i = 50; // Ints store whole numbers
-    let f = 36.6; // Floats are used to store numbers with decimals or fractions of numbers
-    let b = true; // Boolean values can be either 'true' or 'false'
-    let c = '!'; // Char can only hold a single character
-    let message = "hello world"; // Strings hold a collection of characters
+    // Below are some of the different primitive types available in Rust.
+    let i = 50; // Integers store whole numbers.
+    let f = 36.6; // Floats are used to store numbers with decimals or fractions.
+    let b = true; // Boolean values can be either 'true' or 'false'.
+    let c = '!'; // Characters represent a single UTF8 character.
+    let message = "hello world"; // Strings are a sequence of characters.
 
     // Print the values stored in our varibales to the console
     println!("i = {}", i);
@@ -29,11 +23,10 @@ fn model(app: &App) -> Model {
     println!("c = {}", c);
     println!("message = {}", message);
 
-    Model { window }
-}
+    // Construct and define the size of our window using `.with_dimensions(width, height)`.
+    app.new_window().with_dimensions(640, 480).build().unwrap();
 
-fn event(_app: &App, model: Model, _event: Event) -> Model {
-    model
+    Model
 }
 
 fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {

--- a/examples/basics/3_variable_scope.rs
+++ b/examples/basics/3_variable_scope.rs
@@ -2,11 +2,12 @@ extern crate nannou;
 
 use nannou::prelude::*;
 
-// This is how you make a global constant value. Accessible anywhere in your app
+// This is how you make a global constant value.
+// Constant values are accessible anywhere in your app but cannot be changed.
 const GLOBAL: i32 = 10;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).run();
 }
 
 struct Model {
@@ -14,48 +15,31 @@ struct Model {
     bar: f64,
 }
 
-fn model(_app: &App) -> Model {
-    // Initialise our models variables
+fn model(app: &App) -> Model {
+    // Make a window.
+    app.new_window().event(event).view(view).build().unwrap();
+    // Initialise our model's fields.
     let foo = 80;
     let bar = 3.14;
-
-    // Construct and return the model with our initialised values
+    // Construct and return the model with our initialised values.
     Model { foo, bar }
 }
 
-fn event(_app: &App, model: Model, event: Event) -> Model {
+fn event(_app: &App, model: &mut Model, event: WindowEvent) {
     match event {
-        Event::WindowEvent {
-            simple: Some(event),
-            ..
-        } => {
-            match event {
-                // KEY EVENTS
-                KeyPressed(_key) => {
-                    println!("foo = {}", model.foo);
-                    println!("bar = {}", model.bar);
-                }
-
-                KeyReleased(_key) => {
-                    let local_var = 94;
-                    println!("local_variable to KeyReleased = {}", local_var);
-                }
-
-                // MOUSE EVENTS
-                MousePressed(_button) => {
-                    println!("global scope: GLOBAL = {}", GLOBAL);
-                }
-
-                _other => (),
-            }
+        KeyPressed(_key) => {
+            println!("foo = {}", model.foo);
+            println!("bar = {}", model.bar);
         }
-
-        // update gets called just before view every frame
-        Event::Update(_dt) => {}
-
-        _ => (),
+        KeyReleased(_key) => {
+            let local_var = 94;
+            println!("local_variable to KeyReleased = {}", local_var);
+        }
+        MousePressed(_button) => {
+            println!("global scope: GLOBAL = {}", GLOBAL);
+        }
+        _other => (),
     }
-    model
 }
 
 fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {

--- a/examples/basics/4_conditionals.rs
+++ b/examples/basics/4_conditionals.rs
@@ -31,7 +31,7 @@ fn view(app: &App, frame: Frame) -> Frame {
         draw.ellipse().color(DARK_GREEN);
     }
 
-    // Write to the window frame.
+    // Draw to the window frame.
     draw.to_frame(app, &frame).unwrap();
 
     // Return the drawn frame.

--- a/examples/basics/5_loops.rs
+++ b/examples/basics/5_loops.rs
@@ -3,37 +3,40 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).simple_window(view).run();
 }
 
 struct Model;
 
 fn model(_app: &App) -> Model {
-    // For loops in Rust is an iterator which gives back a series of elemaents
-    // one at a time. The current value of the iterator is assigned in this case to 'i'
+    // For loops let us loop over many items, one at a time.
+    // The part between `for` and `in` is the name that we give the item we are currently handling.
+    // The part between `in` and `{` is the sequence we will loop over, known as an `Iterator`.
+    // The part between `{` and `}` is where we put everything we want to happen for every `i`.
+    println!("`for` loop:");
     for i in 0..10 {
-        println!("for iterator = {}", i);
+        println!("{}", i);
     }
 
-    // While loops continue until a certain condition is met. Note that we need
-    // to make x 'mutable' so we can change its value inside of the loop.
+    // While loops continue until a certain condition is met.
+    // Note that we need to make x 'mutable' so we can change its value inside of the loop.
+    println!("`while` loop:");
     let mut x = 0;
     while x < 10 {
-        println!("while = {}", x);
+        println!("{}", x);
         x += 1;
     }
 
-    // If you want to loop forever, Rust provides a dedicated keyword to handle this
-    // Note your code will be stuck in this loop until you decide to break.
-    // In this case we loop while y is less than 30 and then we use the 'break'
-    // keyword to exit the loop.
+    // If you want to loop forever, Rust provides a dedicated keyword called `loop`.
+    // Note your code will be stuck in this loop until you decide to `break` from the loop.
+    // In this case we loop while y is less than 30 and then we use 'break' to exit.
+    println!("`loop`:");
     let mut y = 0;
     loop {
+        println!("{}", y);
         y += 1;
-        println!("loooooping");
-
         if y > 30 {
-            println!("breaking out of loop");
+            println!("`break`");
             break;
         }
     }
@@ -41,13 +44,7 @@ fn model(_app: &App) -> Model {
     Model
 }
 
-fn event(_app: &App, model: Model, _event: Event) -> Model {
-    model
-}
-
 fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
-    // Color the window dark charcoal.
     frame.clear(DARK_CHARCOAL);
-    // Return the drawn frame.
     frame
 }

--- a/examples/basics/6_functions.rs
+++ b/examples/basics/6_functions.rs
@@ -3,12 +3,13 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).simple_window(view).run();
+    nannou::app(model).run();
 }
 
 struct Model;
 
-fn model(_app: &App) -> Model {
+fn model(app: &App) -> Model {
+    app.new_window().event(event).view(view).build().unwrap();
     Model
 }
 
@@ -37,37 +38,23 @@ fn random() -> f32 {
     nannou::rand::random()
 }
 
-fn event(_app: &App, model: Model, event: Event) -> Model {
+fn event(_app: &App, _model: &mut Model, event: WindowEvent) {
     match event {
-        Event::WindowEvent {
-            simple: Some(event),
-            ..
-        } => match event {
-            KeyPressed(_key) => {
-                println!("add 10 + 2 = {}", add(10, 2));
-                println!("subtract 100 - 30 = {}", subtract(100, 30));
-                println!("multiply 3.5 * 10.2 = {}", multiply(3.5, 10.2));
-                println!("random = {}", random());
-                println!("remaped value = {}", random_range(0.0f32, 100.0));
-            }
-
-            MousePressed(_button) => {
-                do_something();
-            }
-
-            _other => (),
-        },
-
-        Event::Update(_dt) => {}
-
-        _ => (),
+        KeyPressed(_key) => {
+            println!("add 10 + 2 = {}", add(10, 2));
+            println!("subtract 100 - 30 = {}", subtract(100, 30));
+            println!("multiply 3.5 * 10.2 = {}", multiply(3.5, 10.2));
+            println!("random = {}", random());
+            println!("remaped value = {}", random_range(0.0f32, 100.0));
+        }
+        MousePressed(_button) => {
+            do_something();
+        }
+        _other => {}
     }
-    model
 }
 
 fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
-    // Clear the window with dark charcoal.
     frame.clear(DARK_CHARCOAL);
-    // Return the drawn frame.
     frame
 }

--- a/examples/basics/7_modules/7_modules.rs
+++ b/examples/basics/7_modules/7_modules.rs
@@ -6,7 +6,7 @@ mod ball;
 use ball::Ball;
 
 fn main() {
-    nannou::app(model).event(event).simple_window(view).run();
+    nannou::app(model).update(update).simple_window(view).run();
 }
 
 struct Model {
@@ -15,28 +15,24 @@ struct Model {
 
 fn model(_app: &App) -> Model {
     // Create a new ball with a color
-    let ball = Ball::new(Rgba::new(0.0, 1.0, 0.5, 1.0));
-
+    let ball = Ball::new(GREEN);
     // Construct and return the model with our initialised ball
     Model { ball }
 }
 
-fn event(app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        model.ball.position = pt2(app.mouse.x, app.mouse.y);
-    }
-    model
+// By default, `update` is called right before `view` is called each frame.
+fn update(app: &App, model: &mut Model, _update: Update) {
+    model.ball.position = pt2(app.mouse.x, app.mouse.y);
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
-    // Begin drawing
+    // Begin drawing.
     let draw = app.draw();
     // Draw dark gray for the background
-    draw.background().rgb(0.02, 0.02, 0.02);
+    draw.background().color(DARK_CHARCOAL);
     // Draw our ball
     model.ball.display(&draw);
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
     // Return the drawn frame.
     frame

--- a/examples/generative_design/color/p_1_0_01.rs
+++ b/examples/generative_design/color/p_1_0_01.rs
@@ -46,7 +46,7 @@ fn view(app: &App, frame: Frame) -> Frame {
     draw.background().hsl(norm_mouse_y, 1.0, 0.5);
 
     draw.rect()
-        .w_h(app.mouse.x, app.mouse.x)
+        .w_h(app.mouse.x * 2.0, app.mouse.x * 2.0)
         .hsv(1.0 - (norm_mouse_y), 1.0, 0.5);
 
     // Write to the window frame.

--- a/examples/generative_design/color/p_1_1_01.rs
+++ b/examples/generative_design/color/p_1_1_01.rs
@@ -15,8 +15,8 @@ fn view(app: &App, frame: Frame) -> Frame {
     draw.background().color(BLACK);
     let win_rect = app.window_rect();
 
-    let step_x = (app.mouse.x - win_rect.left()).max(1.0);
-    let step_y = (win_rect.top() - app.mouse.y).max(1.0);
+    let step_x = (app.mouse.x - win_rect.left()).max(5.0);
+    let step_y = (win_rect.top() - app.mouse.y).max(5.0);
 
     let size = vec2(step_x, step_y);
     let r = nannou::geom::Rect::from_wh(size)
@@ -35,7 +35,7 @@ fn view(app: &App, frame: Frame) -> Frame {
         grid_y += step_y;
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
 
     // Return the drawn frame.

--- a/examples/generative_design/color/p_1_2_3_01.rs
+++ b/examples/generative_design/color/p_1_2_3_01.rs
@@ -10,15 +10,16 @@
 * c                   : save color palette
 */
 extern crate nannou;
+
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).run();
 }
 
 struct Model {
-    tile_count_x: i32,
-    tile_count_y: i32,
+    tile_count_x: usize,
+    tile_count_y: usize,
     hue_values: Vec<f32>,
     saturation_values: Vec<f32>,
     brightness_values: Vec<f32>,
@@ -28,17 +29,17 @@ fn model(app: &App) -> Model {
     let tile_count_x = 50;
     let tile_count_y = 10;
 
-    let mut hue_values: Vec<f32> = Vec::new();
-    let mut saturation_values: Vec<f32> = Vec::new();
-    let mut brightness_values: Vec<f32> = Vec::new();
+    let hue_values = (0..tile_count_x).map(|_| random()).collect();
+    let saturation_values = (0..tile_count_x).map(|_| random()).collect();
+    let brightness_values = (0..tile_count_x).map(|_| random()).collect();
 
-    for _i in 0..tile_count_x as i32 {
-        hue_values.push(random());
-        saturation_values.push(random());
-        brightness_values.push(random());
-    }
+    app.new_window()
+        .with_dimensions(720, 720)
+        .key_pressed(key_pressed)
+        .view(view)
+        .build()
+        .unwrap();
 
-    let _window = app.new_window().with_dimensions(720, 720).build().unwrap();
     Model {
         tile_count_x,
         tile_count_y,
@@ -48,105 +49,92 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    match event {
-        Event::WindowEvent {
-            simple: Some(event),
-            ..
-        } => {
-            match event {
-                // KEY EVENTS
-                KeyPressed(key) => match key {
-                    Key::Key1 => {
-                        for i in 0..model.tile_count_x as i32 {
-                            model.hue_values[i as usize] = random();
-                            model.saturation_values[i as usize] = random();
-                            model.brightness_values[i as usize] = random();
-                        }
-                    }
-                    Key::Key2 => {
-                        for i in 0..model.tile_count_x as i32 {
-                            model.hue_values[i as usize] = random();
-                            model.saturation_values[i as usize] = random();
-                            model.brightness_values[i as usize] = 1.0;
-                        }
-                    }
-                    Key::Key3 => {
-                        for i in 0..model.tile_count_x as i32 {
-                            model.hue_values[i as usize] = random();
-                            model.saturation_values[i as usize] = 1.0;
-                            model.brightness_values[i as usize] = random();
-                        }
-                    }
-                    Key::Key4 => {
-                        for i in 0..model.tile_count_x as i32 {
-                            model.hue_values[i as usize] = 0.0;
-                            model.saturation_values[i as usize] = 0.0;
-                            model.brightness_values[i as usize] = random();
-                        }
-                    }
-                    Key::Key5 => {
-                        for i in 0..model.tile_count_x as i32 {
-                            model.hue_values[i as usize] = 0.54;
-                            model.saturation_values[i as usize] = 1.0;
-                            model.brightness_values[i as usize] = random();
-                        }
-                    }
-                    Key::Key6 => {
-                        for i in 0..model.tile_count_x as i32 {
-                            model.hue_values[i as usize] = 0.54;
-                            model.saturation_values[i as usize] = random();
-                            model.brightness_values[i as usize] = 1.0;
-                        }
-                    }
-                    Key::Key7 => {
-                        for i in 0..model.tile_count_x as i32 {
-                            model.hue_values[i as usize] = random_f32() * 0.5;
-                            model.saturation_values[i as usize] = random_f32() * 0.2 + 0.8;
-                            model.brightness_values[i as usize] = random_f32() * 0.4 + 0.5;
-                        }
-                    }
-                    Key::Key8 => {
-                        for i in 0..model.tile_count_x as i32 {
-                            model.hue_values[i as usize] = random_f32() * 0.5 + 0.5;
-                            model.saturation_values[i as usize] = random_f32() * 0.2 + 0.8;
-                            model.brightness_values[i as usize] = random_f32() * 0.4 + 0.5;
-                        }
-                    }
-                    Key::Key9 => {
-                        for i in 0..model.tile_count_x as i32 {
-                            if i % 2 == 0 {
-                                model.hue_values[i as usize] = random();
-                                model.saturation_values[i as usize] = 1.0;
-                                model.brightness_values[i as usize] = random();
-                            } else {
-                                model.hue_values[i as usize] = 0.54;
-                                model.saturation_values[i as usize] = random();
-                                model.brightness_values[i as usize] = 1.0;
-                            }
-                        }
-                    }
-                    Key::Key0 => {
-                        for i in 0..model.tile_count_x as i32 {
-                            if i % 2 == 0 {
-                                model.hue_values[i as usize] = 0.38;
-                                model.saturation_values[i as usize] = random_f32() * 0.7 + 0.3;
-                                model.brightness_values[i as usize] = random_f32() * 0.6 + 0.4;
-                            } else {
-                                model.hue_values[i as usize] = 0.58;
-                                model.saturation_values[i as usize] = random_f32() * 0.6 + 0.4;
-                                model.brightness_values[i as usize] = random_f32() * 0.5 + 0.5;
-                            }
-                        }
-                    }
-                    _ => (),
-                },
-                _other => (),
+fn key_pressed(_app: &App, model: &mut Model, key: Key) {
+    match key {
+        Key::Key1 => {
+            for i in 0..model.tile_count_x {
+                model.hue_values[i] = random();
+                model.saturation_values[i] = random();
+                model.brightness_values[i] = random();
             }
         }
-        _ => (),
+        Key::Key2 => {
+            for i in 0..model.tile_count_x {
+                model.hue_values[i] = random();
+                model.saturation_values[i] = random();
+                model.brightness_values[i] = 1.0;
+            }
+        }
+        Key::Key3 => {
+            for i in 0..model.tile_count_x {
+                model.hue_values[i] = random();
+                model.saturation_values[i] = 1.0;
+                model.brightness_values[i] = random();
+            }
+        }
+        Key::Key4 => {
+            for i in 0..model.tile_count_x {
+                model.hue_values[i] = 0.0;
+                model.saturation_values[i] = 0.0;
+                model.brightness_values[i] = random();
+            }
+        }
+        Key::Key5 => {
+            for i in 0..model.tile_count_x {
+                model.hue_values[i] = 0.54;
+                model.saturation_values[i] = 1.0;
+                model.brightness_values[i] = random();
+            }
+        }
+        Key::Key6 => {
+            for i in 0..model.tile_count_x {
+                model.hue_values[i] = 0.54;
+                model.saturation_values[i] = random();
+                model.brightness_values[i] = 1.0;
+            }
+        }
+        Key::Key7 => {
+            for i in 0..model.tile_count_x {
+                model.hue_values[i] = random_f32() * 0.5;
+                model.saturation_values[i] = random_f32() * 0.2 + 0.8;
+                model.brightness_values[i] = random_f32() * 0.4 + 0.5;
+            }
+        }
+        Key::Key8 => {
+            for i in 0..model.tile_count_x {
+                model.hue_values[i] = random_f32() * 0.5 + 0.5;
+                model.saturation_values[i] = random_f32() * 0.2 + 0.8;
+                model.brightness_values[i] = random_f32() * 0.4 + 0.5;
+            }
+        }
+        Key::Key9 => {
+            for i in 0..model.tile_count_x {
+                if i % 2 == 0 {
+                    model.hue_values[i] = random();
+                    model.saturation_values[i] = 1.0;
+                    model.brightness_values[i] = random();
+                } else {
+                    model.hue_values[i] = 0.54;
+                    model.saturation_values[i] = random();
+                    model.brightness_values[i] = 1.0;
+                }
+            }
+        }
+        Key::Key0 => {
+            for i in 0..model.tile_count_x {
+                if i % 2 == 0 {
+                    model.hue_values[i] = 0.38;
+                    model.saturation_values[i] = random_f32() * 0.7 + 0.3;
+                    model.brightness_values[i] = random_f32() * 0.6 + 0.4;
+                } else {
+                    model.hue_values[i] = 0.58;
+                    model.saturation_values[i] = random_f32() * 0.6 + 0.4;
+                    model.brightness_values[i] = random_f32() * 0.5 + 0.5;
+                }
+            }
+        }
+        _other_key => {}
     }
-    model
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
@@ -181,8 +169,8 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         let mut grid_x = 0;
         while grid_x < model.tile_count_x {
             let r = r
-                .shift_x((tile_width * grid_x) as f32)
-                .shift_y(-(tile_height * grid_y) as f32);
+                .shift_x((tile_width * grid_x as i32) as f32)
+                .shift_y(-(tile_height * grid_y as i32) as f32);
             let index = counter % current_tile_count_x as usize;
             draw.rect().xy(r.xy()).wh(r.wh()).hsv(
                 model.hue_values[index],
@@ -195,7 +183,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         grid_y += 1;
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
 
     // Return the drawn frame.

--- a/examples/generative_design/color/p_1_2_3_02.rs
+++ b/examples/generative_design/color/p_1_2_3_02.rs
@@ -12,54 +12,45 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).simple_window(view).run();
 }
 
 struct Model {
-    color_count: i32,
-    _act_random_seed: i32,
+    color_count: usize,
     hue_values: Vec<f32>,
     saturation_values: Vec<f32>,
     brightness_values: Vec<f32>,
 }
 
-fn model(app: &App) -> Model {
+fn model(_app: &App) -> Model {
     let color_count = 20;
-    let _act_random_seed = 0;
 
     // Note you can decalre and pack a vector with random values like this in rust
-    let hue_values = (0..color_count).map(|_| 0.0).collect();
-    let saturation_values = (0..color_count).map(|_| 0.0).collect();
-    let brightness_values = (0..color_count).map(|_| 0.0).collect();
+    let hue_values = vec![0.0; color_count];
+    let saturation_values = vec![0.0; color_count];
+    let brightness_values = vec![0.0; color_count];
 
-    let _window = app.new_window().with_dimensions(720, 720).build().unwrap();
     Model {
         color_count,
-        _act_random_seed,
         hue_values,
         saturation_values,
         brightness_values,
     }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        // ------ colors ------
-        // create palette
-        for i in 0..model.color_count {
-            if i % 2 == 0 {
-                model.hue_values[i as usize] = random_f32(); // * 0.36 + 0.61;
-                model.saturation_values[i as usize] = 1.0;
-                model.brightness_values[i as usize] = random_f32() * 0.85 + 0.15;
-            } else {
-                model.hue_values[i as usize] = 0.54;
-                model.saturation_values[i as usize] = random_f32() * 0.8 + 0.2;
-                model.brightness_values[i as usize] = 1.0;
-            }
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    // Create palette
+    for i in 0..model.color_count {
+        if i % 2 == 0 {
+            model.hue_values[i] = random_f32(); // * 0.36 + 0.61;
+            model.saturation_values[i] = 1.0;
+            model.brightness_values[i] = random_f32() * 0.85 + 0.15;
+        } else {
+            model.hue_values[i] = 0.54;
+            model.saturation_values[i] = random_f32() * 0.8 + 0.2;
+            model.brightness_values[i] = 1.0;
         }
     }
-    model
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
@@ -134,7 +125,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         }
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
 
     // Return the drawn frame.

--- a/examples/loop_mode.rs
+++ b/examples/loop_mode.rs
@@ -12,7 +12,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).simple_window(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model;
@@ -20,39 +20,31 @@ struct Model;
 fn model(app: &App) -> Model {
     // Start in `Wait` mode. In other words, don't keep looping, just wait for events.
     app.set_loop_mode(LoopMode::wait(3));
-    // Set a window title.
-    let title = format!("`LoopMode` Demonstration - `{:?}`", app.loop_mode());
-    app.main_window().set_title(&title);
+    let _window = app.new_window()
+        .with_title(format!("`LoopMode` Demonstration - `{:?}`", app.loop_mode()))
+        .key_pressed(key_pressed)
+        .view(view)
+        .build()
+        .unwrap();
     Model
 }
 
-fn event(app: &App, model: Model, event: Event) -> Model {
-    match event {
-        Event::WindowEvent {
-            simple: Some(event),
-            ..
-        } => match event {
-            KeyPressed(_) => {
-                match app.loop_mode() {
-                    LoopMode::Wait { .. } => app.set_loop_mode(LoopMode::refresh_sync()),
-                    LoopMode::RefreshSync { .. } => app.set_loop_mode(LoopMode::rate_fps(60.0)),
-                    LoopMode::Rate { .. } => app.set_loop_mode(LoopMode::wait(3)),
-                }
-                println!("Loop mode switched to: {:?}", app.loop_mode());
-                let title = format!("`LoopMode` Demonstration - `{:?}`", app.loop_mode());
-                app.main_window().set_title(&title);
-            }
-            _ => (),
-        },
-        Event::Update(update) => {
-            println!("{:?}", update);
-        }
-        _ => (),
-    }
-    model
+fn update(_app: &App, _model: &mut Model, update: Update) {
+    println!("{:?}", update);
 }
 
-// Draw the state of your `Model` into the given `Frame` here.
+fn key_pressed(app: &App, _model: &mut Model, _key: Key) {
+    // Switch to the next loop mode on key pressed.
+    match app.loop_mode() {
+        LoopMode::Wait { .. } => app.set_loop_mode(LoopMode::refresh_sync()),
+        LoopMode::RefreshSync { .. } => app.set_loop_mode(LoopMode::rate_fps(60.0)),
+        LoopMode::Rate { .. } => app.set_loop_mode(LoopMode::wait(3)),
+    }
+    println!("Loop mode switched to: {:?}", app.loop_mode());
+    let title = format!("`LoopMode` Demonstration - `{:?}`", app.loop_mode());
+    app.main_window().set_title(&title);
+}
+
 fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
     frame.clear(DARK_CHARCOAL);
     frame

--- a/examples/multi_window.rs
+++ b/examples/multi_window.rs
@@ -3,7 +3,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).view(view).run();
 }
 
 struct Model {
@@ -13,32 +13,28 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
-    let a = app.new_window().with_title("window a").build().unwrap();
-    let b = app.new_window().with_title("window b").build().unwrap();
-    let c = app.new_window().with_title("window c").build().unwrap();
+    let a = app.new_window().with_title("window a").event(event_a).build().unwrap();
+    let b = app.new_window().with_title("window b").event(event_b).build().unwrap();
+    let c = app.new_window().with_title("window c").event(event_c).build().unwrap();
     Model { a, b, c }
 }
 
-fn event(_app: &App, model: Model, event: Event) -> Model {
-    match event {
-        // Handle window events like mouse, keyboard, resize, etc here.
-        Event::WindowEvent {
-            id,
-            simple: Some(event),
-            ..
-        } => {
-            println!("Window {:?}: {:?}", id, event);
-        }
-        // `Update` the model here.
-        Event::Update(_update) => {}
-        _ => (),
-    }
-    model
+fn update(_app: &App, _model: &mut Model, _update: Update) {
 }
 
-// Draw the state of your `Model` into the given `Frame` here.
+fn event_a(_app: &App, _model: &mut Model, event: WindowEvent) {
+    println!("window a: {:?}", event);
+}
+
+fn event_b(_app: &App, _model: &mut Model, event: WindowEvent) {
+    println!("window b: {:?}", event);
+}
+
+fn event_c(_app: &App, _model: &mut Model, event: WindowEvent) {
+    println!("window c: {:?}", event);
+}
+
 fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
-    // Clear each window with a different colour.
     match frame.window_id() {
         id if id == model.a => frame.clear(RED),
         id if id == model.b => frame.clear(GREEN),

--- a/examples/nature_of_code/chp_01_vectors/1_10_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_10_motion101_acceleration.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -59,17 +59,14 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    let _window = app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     let mover = Mover::new(app.window_rect());
     Model { mover }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
+fn update(app: &App, m: &mut Model, _update: Update) {
     // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        m.mover.update(pt2(app.mouse.x, app.mouse.y));
-    }
-    m
+    m.mover.update(pt2(app.mouse.x, app.mouse.y));
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_01_vectors/1_11_motion101_acceleration_array.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_11_motion101_acceleration_array.rs
@@ -13,7 +13,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -67,9 +67,9 @@ impl Mover {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -77,14 +77,11 @@ fn model(app: &App) -> Model {
     Model { movers }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        for mover in &mut m.movers {
-            mover.update(pt2(app.mouse.x, app.mouse.y));
-        }
+// update gets called just before view every frame
+fn update(app: &App, m: &mut Model, _update: Update) {
+    for mover in &mut m.movers {
+        mover.update(pt2(app.mouse.x, app.mouse.y));
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_01_vectors/1_1_bouncingball_novectors.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_1_bouncingball_novectors.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -24,7 +24,7 @@ fn model(app: &App) -> Model {
     let x_speed = 2.5;
     let y_speed = 2.0;
 
-    let _window = app.new_window().with_dimensions(800, 200).build().unwrap();
+    let _window = app.new_window().with_dimensions(800, 200).view(view).build().unwrap();
     Model {
         x,
         y,
@@ -33,23 +33,19 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn event(app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        // Add the current speed to the position
-        model.x = model.x + model.x_speed;
-        model.y = model.y + model.y_speed;
+fn update(app: &App, model: &mut Model, _update: Update) {
+    // Add the current speed to the position
+    model.x = model.x + model.x_speed;
+    model.y = model.y + model.y_speed;
 
-        let win_rect = app.window_rect();
+    let win_rect = app.window_rect();
 
-        if (model.x > win_rect.right()) || (model.x < win_rect.left()) {
-            model.x_speed = model.x_speed * -1.0;
-        }
-        if (model.y > win_rect.top()) || (model.y < win_rect.bottom()) {
-            model.y_speed = model.y_speed * -1.0;
-        }
+    if (model.x > win_rect.right()) || (model.x < win_rect.left()) {
+        model.x_speed = model.x_speed * -1.0;
     }
-    model
+    if (model.y > win_rect.top()) || (model.y < win_rect.bottom()) {
+        model.y_speed = model.y_speed * -1.0;
+    }
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -20,25 +20,21 @@ fn model(app: &App) -> Model {
     let position = pt2(100.0, 100.0);
     let velocity = vec2(2.5, 5.0);
 
-    let _window = app.new_window().with_dimensions(200, 200).build().unwrap();
+    let _window = app.new_window().with_dimensions(200, 200).view(view).build().unwrap();
     Model { position, velocity }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        // Add the current speed to the position.
-        m.position += m.velocity;
+fn update(app: &App, m: &mut Model, _update: Update) {
+    // Add the current speed to the position.
+    m.position += m.velocity;
 
-        let rect = app.window_rect();
-        if (m.position.x > rect.right()) || (m.position.x < rect.left()) {
-            m.velocity.x = m.velocity.x * -1.0;
-        }
-        if (m.position.y > rect.top()) || (m.position.y < rect.bottom()) {
-            m.velocity.y = m.velocity.y * -1.0;
-        }
+    let rect = app.window_rect();
+    if (m.position.x > rect.right()) || (m.position.x < rect.left()) {
+        m.velocity.x = m.velocity.x * -1.0;
     }
-    m
+    if (m.position.y > rect.top()) || (m.position.y < rect.bottom()) {
+        m.velocity.y = m.velocity.y * -1.0;
+    }
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
@@ -54,7 +50,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .x_y(model.position.x, model.position.y)
         .w_h(16.0, 16.0)
         .rgb(0.5, 0.5, 0.5);
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
 
     // Return the drawn frame.

--- a/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors_object.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors_object.rs
@@ -9,7 +9,7 @@ use nannou::prelude::*;
 
 fn main() {
     nannou::app(model)
-        .event(event)
+        .update(update)
         .simple_window(view)
         .run();
 }
@@ -52,17 +52,13 @@ impl Ball {
 }
 
 fn model(app: &App) -> Model {
-    app.main_window().set_inner_size_points(200.0, 200.0);
+    app.main_window().set_inner_size_points(300.0, 300.0);
     let ball = Ball::new();
     Model { ball }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        m.ball.update(app.window_rect());
-    }
-    m
+fn update(app: &App, m: &mut Model, _update: Update) {
+    m.ball.update(app.window_rect());
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_01_vectors/1_7_motion101.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_7_motion101.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -58,18 +58,14 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     let mover = Mover::new(app.window_rect());
     Model { mover }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        m.mover.update();
-        m.mover.check_edges(app.window_rect());
-    }
-    m
+fn update(app: &App, m: &mut Model, _update: Update) {
+    m.mover.update();
+    m.mover.check_edges(app.window_rect());
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_01_vectors/1_8_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_8_motion101_acceleration.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -68,18 +68,14 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     let mover = Mover::new(app.window_rect());
     Model { mover }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        m.mover.update();
-        m.mover.check_edges(app.window_rect());
-    }
-    m
+fn update(app: &App, m: &mut Model, _update: Update) {
+    m.mover.update();
+    m.mover.check_edges(app.window_rect());
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_01_vectors/1_9_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_9_motion101_acceleration.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -70,17 +70,13 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     let mover = Mover::new(app.window_rect());
     Model { mover }
 }
 
-fn event(_app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        m.mover.update();
-    }
-    m
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    m.mover.update();
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_02_forces/2_10_exercise_attract_repel.rs
+++ b/examples/nature_of_code/chp_02_forces/2_10_exercise_attract_repel.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Mover {
@@ -169,9 +169,10 @@ struct Model {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .event(event)
+        .view(view)
         .build()
         .unwrap();
 
@@ -190,47 +191,36 @@ fn model(app: &App) -> Model {
     Model { movers, attractor }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
+fn event(app: &App, m: &mut Model, event: WindowEvent) {
     match event {
-        Event::WindowEvent {
-            simple: Some(event),
-            ..
-        } => {
-            match event {
-                // MOUSE EVENTS
-                MousePressed(_button) => {
-                    m.attractor.clicked(app.mouse.x, app.mouse.y);
-                }
-                MouseReleased(_buttom) => {
-                    m.attractor.stop_dragging();
-                }
-                _other => (),
-            }
+        MousePressed(_button) => {
+            m.attractor.clicked(app.mouse.x, app.mouse.y);
         }
-        // update gets called just before view every frame
-        Event::Update(_dt) => {
-            m.attractor.drag(app.mouse.x, app.mouse.y);
-            m.attractor.rollover(app.mouse.x, app.mouse.y);
-
-            for i in 0..m.movers.len() {
-                for j in 0..m.movers.len() {
-                    if i != j {
-                        let force = m.movers[j].repel(&m.movers[i]);
-                        m.movers[i].apply_force(force);
-                    }
-                }
-                let force = m.attractor.attract(&m.movers[i]);
-                m.movers[i].apply_force(force);
-                m.movers[i].update();
-            }
+        MouseReleased(_buttom) => {
+            m.attractor.stop_dragging();
         }
-        _ => (),
+        _other => (),
     }
-    m
+}
+
+fn update(app: &App, m: &mut Model, _update: Update) {
+    m.attractor.drag(app.mouse.x, app.mouse.y);
+    m.attractor.rollover(app.mouse.x, app.mouse.y);
+
+    for i in 0..m.movers.len() {
+        for j in 0..m.movers.len() {
+            if i != j {
+                let force = m.movers[j].repel(&m.movers[i]);
+                m.movers[i].apply_force(force);
+            }
+        }
+        let force = m.attractor.attract(&m.movers[i]);
+        m.movers[i].apply_force(force);
+        m.movers[i].update();
+    }
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {
-    // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
 

--- a/examples/nature_of_code/chp_02_forces/2_1_forces.rs
+++ b/examples/nature_of_code/chp_02_forces/2_1_forces.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -72,26 +72,22 @@ impl Mover {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
     let mover = Mover::new(rect);
     Model { mover }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        let wind = vec2(0.01, 0.0);
-        let gravity = vec2(0.0, -0.1);
-        m.mover.apply_force(wind);
-        m.mover.apply_force(gravity);
-        m.mover.update();
-        m.mover.check_edges(app.window_rect());
-    }
-    m
+fn update(app: &App, m: &mut Model, _update: Update) {
+    let wind = vec2(0.01, 0.0);
+    let gravity = vec2(0.0, -0.1);
+    m.mover.apply_force(wind);
+    m.mover.apply_force(gravity);
+    m.mover.update();
+    m.mover.check_edges(app.window_rect());
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_02_forces/2_2_forces_many.rs
+++ b/examples/nature_of_code/chp_02_forces/2_2_forces_many.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -72,9 +72,9 @@ impl Mover {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -84,19 +84,15 @@ fn model(app: &App) -> Model {
     Model { movers }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        for i in 0..m.movers.len() {
-            let wind = vec2(0.01, 0.0);
-            let gravity = vec2(0.0, -0.1);
-            m.movers[i].apply_force(wind);
-            m.movers[i].apply_force(gravity);
-            m.movers[i].update();
-            m.movers[i].check_edges(app.window_rect());
-        }
+fn update(app: &App, m: &mut Model, _update: Update) {
+    for i in 0..m.movers.len() {
+        let wind = vec2(0.01, 0.0);
+        let gravity = vec2(0.0, -0.1);
+        m.movers[i].apply_force(wind);
+        m.movers[i].apply_force(gravity);
+        m.movers[i].update();
+        m.movers[i].check_edges(app.window_rect());
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_02_forces/2_3_forces_many_real_gravity.rs
+++ b/examples/nature_of_code/chp_02_forces/2_3_forces_many_real_gravity.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -72,9 +72,9 @@ impl Mover {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -84,19 +84,15 @@ fn model(app: &App) -> Model {
     Model { movers }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        for i in 0..m.movers.len() {
-            let wind = vec2(0.01, 0.0);
-            let gravity = vec2(0.0, -0.1 * m.movers[i].mass);
-            m.movers[i].apply_force(wind);
-            m.movers[i].apply_force(gravity);
-            m.movers[i].update();
-            m.movers[i].check_edges(app.window_rect());
-        }
+fn update(app: &App, m: &mut Model, _update: Update) {
+    for i in 0..m.movers.len() {
+        let wind = vec2(0.01, 0.0);
+        let gravity = vec2(0.0, -0.1 * m.movers[i].mass);
+        m.movers[i].apply_force(wind);
+        m.movers[i].apply_force(gravity);
+        m.movers[i].update();
+        m.movers[i].check_edges(app.window_rect());
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_02_forces/2_4_forces_friction.rs
+++ b/examples/nature_of_code/chp_02_forces/2_4_forces_friction.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -72,9 +72,9 @@ impl Mover {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(383.0, 200.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -90,30 +90,25 @@ fn model(app: &App) -> Model {
     Model { movers }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        for i in 0..m.movers.len() {
-            let wind = vec2(0.01, 0.0);
-            let gravity = vec2(0.0, -0.1 * m.movers[i].mass);
+fn update(app: &App, m: &mut Model, _update: Update) {
+    for mover in &mut m.movers {
+        let wind = vec2(0.01, 0.0);
+        let gravity = vec2(0.0, -0.1 * mover.mass);
 
-            let c = 0.05;
-            let mut friction = m.movers[i].velocity;
-            if friction.magnitude() > 0.0 {
-                friction *= -1.0;
-                friction = friction.normalize();
-                friction *= c;
-                m.movers[i].apply_force(friction);
-            }
-
-            m.movers[i].apply_force(wind);
-            m.movers[i].apply_force(gravity);
-
-            m.movers[i].update();
-            m.movers[i].check_edges(app.window_rect());
+        let c = 0.05;
+        let mut friction = mover.velocity;
+        if friction.magnitude() > 0.0 {
+            friction *= -1.0;
+            friction = friction.normalize();
+            friction *= c;
+            mover.apply_force(friction);
         }
+
+        mover.apply_force(wind);
+        mover.apply_force(gravity);
+        mover.update();
+        mover.check_edges(app.window_rect());
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_02_forces/2_4_forces_no_friction.rs
+++ b/examples/nature_of_code/chp_02_forces/2_4_forces_no_friction.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -72,9 +72,9 @@ impl Mover {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(383.0, 200.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -90,30 +90,16 @@ fn model(app: &App) -> Model {
     Model { movers }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        for i in 0..m.movers.len() {
-            let wind = vec2(0.01, 0.0);
-            let gravity = vec2(0.0, -0.1 * m.movers[i].mass);
+fn update(app: &App, m: &mut Model, _update: Update) {
+    for mover in &mut m.movers {
+        let wind = vec2(0.01, 0.0);
+        let gravity = vec2(0.0, -0.1 * mover.mass);
 
-            let c = 0.05;
-            let mut friction = m.movers[i].velocity;
-            if friction.magnitude() > 0.0 {
-                friction *= -1.0;
-                friction = friction.normalize();
-                friction *= c;
-                //m.movers[i].apply_force(friction);
-            }
-
-            m.movers[i].apply_force(wind);
-            m.movers[i].apply_force(gravity);
-
-            m.movers[i].update();
-            m.movers[i].check_edges(app.window_rect());
-        }
+        mover.apply_force(wind);
+        mover.apply_force(gravity);
+        mover.update();
+        mover.check_edges(app.window_rect());
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_02_forces/2_5_fluid_resistance.rs
+++ b/examples/nature_of_code/chp_02_forces/2_5_fluid_resistance.rs
@@ -12,7 +12,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -131,9 +131,10 @@ impl Mover {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .mouse_pressed(mouse_pressed)
+        .view(view)
         .build()
         .unwrap();
 
@@ -155,39 +156,30 @@ fn model(app: &App) -> Model {
     Model { movers, liquid }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    match event {
-        Event::WindowEvent {
-            simple: Some(MousePressed(_button)),
-            ..
-        } => {
-            // Restart all the Mover objects randomly
-            for mover in &mut m.movers {
-                *mover = Mover::new_random(&app.window_rect());
-            }
-        }
-        // update gets called just before view every frame
-        Event::Update(_update) => {
-            for i in 0..m.movers.len() {
-                // Is the Mover in the liquid?
-                if m.liquid.contains(&m.movers[i]) {
-                    let drag_force = m.liquid.drag(&m.movers[i]);
-                    // Apply drag force to Mover
-                    m.movers[i].apply_force(drag_force);
-                }
-
-                // Gravity is scaled by mass here!
-                let gravity = vec2(0.0, -0.1 * m.movers[i].mass);
-
-                // Apply gravity
-                m.movers[i].apply_force(gravity);
-                m.movers[i].update();
-                m.movers[i].check_edges(app.window_rect());
-            }
-        }
-        _ => (),
+fn mouse_pressed(app: &App, m: &mut Model, _button: MouseButton) {
+    // Restart all the Mover objects randomly
+    for mover in &mut m.movers {
+        *mover = Mover::new_random(&app.window_rect());
     }
-    m
+}
+
+fn update(app: &App, m: &mut Model, _update: Update) {
+    for i in 0..m.movers.len() {
+        // Is the Mover in the liquid?
+        if m.liquid.contains(&m.movers[i]) {
+            let drag_force = m.liquid.drag(&m.movers[i]);
+            // Apply drag force to Mover
+            m.movers[i].apply_force(drag_force);
+        }
+    
+        // Gravity is scaled by mass here!
+        let gravity = vec2(0.0, -0.1 * m.movers[i].mass);
+    
+        // Apply gravity
+        m.movers[i].apply_force(gravity);
+        m.movers[i].update();
+        m.movers[i].check_edges(app.window_rect());
+    }
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_02_forces/2_6_attraction.rs
+++ b/examples/nature_of_code/chp_02_forces/2_6_attraction.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -151,9 +151,10 @@ impl Mover {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .event(event)
+        .view(view)
         .build()
         .unwrap();
 
@@ -163,35 +164,24 @@ fn model(app: &App) -> Model {
     Model { mover, attractor }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
+fn event(app: &App, m: &mut Model, event: WindowEvent) {
     match event {
-        Event::WindowEvent {
-            simple: Some(event),
-            ..
-        } => {
-            match event {
-                // MOUSE EVENTS
-                MousePressed(_button) => {
-                    m.attractor.clicked(app.mouse.x, app.mouse.y);
-                }
-
-                MouseReleased(_buttom) => {
-                    m.attractor.stop_dragging();
-                }
-                _other => (),
-            }
+        MousePressed(_button) => {
+            m.attractor.clicked(app.mouse.x, app.mouse.y);
         }
-        // update gets called just before view every frame
-        Event::Update(_dt) => {
-            let force = m.attractor.attract(&m.mover);
-            m.mover.apply_force(force);
-            m.mover.update();
-            m.attractor.drag(app.mouse.x, app.mouse.y);
-            m.attractor.hover(app.mouse.x, app.mouse.y);
+        MouseReleased(_buttom) => {
+            m.attractor.stop_dragging();
         }
-        _ => (),
+        _other => (),
     }
-    m
+}
+
+fn update(app: &App, m: &mut Model, _update: Update) {
+    let force = m.attractor.attract(&m.mover);
+    m.mover.apply_force(force);
+    m.mover.update();
+    m.attractor.drag(app.mouse.x, app.mouse.y);
+    m.attractor.hover(app.mouse.x, app.mouse.y);
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_02_forces/2_7_attraction_many.rs
+++ b/examples/nature_of_code/chp_02_forces/2_7_attraction_many.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -142,6 +142,8 @@ fn model(app: &App) -> Model {
     let _window = app
         .new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .event(event)
+        .view(view)
         .build()
         .unwrap();
 
@@ -160,37 +162,26 @@ fn model(app: &App) -> Model {
     Model { movers, attractor }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
+fn event(app: &App, m: &mut Model, event: WindowEvent) {
     match event {
-        Event::WindowEvent {
-            simple: Some(event),
-            ..
-        } => {
-            match event {
-                // MOUSE EVENTS
-                MousePressed(_button) => {
-                    m.attractor.clicked(app.mouse.x, app.mouse.y);
-                }
-                MouseReleased(_buttom) => {
-                    m.attractor.stop_dragging();
-                }
-                _other => (),
-            }
+        MousePressed(_button) => {
+            m.attractor.clicked(app.mouse.x, app.mouse.y);
         }
-        // update gets called just before view every frame
-        Event::Update(_dt) => {
-            m.attractor.drag(app.mouse.x, app.mouse.y);
-            m.attractor.hover(app.mouse.x, app.mouse.y);
-
-            for i in 0..m.movers.len() {
-                let force = m.attractor.attract(&m.movers[i]);
-                m.movers[i].apply_force(force);
-                m.movers[i].update();
-            }
+        MouseReleased(_buttom) => {
+            m.attractor.stop_dragging();
         }
-        _ => (),
+        _other => (),
     }
-    m
+}
+
+fn update(app: &App, m: &mut Model, _update: Update) {
+    m.attractor.drag(app.mouse.x, app.mouse.y);
+    m.attractor.hover(app.mouse.x, app.mouse.y);
+    for i in 0..m.movers.len() {
+        let force = m.attractor.attract(&m.movers[i]);
+        m.movers[i].apply_force(force);
+        m.movers[i].update();
+    }
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_02_forces/2_8_mutual_attraction.rs
+++ b/examples/nature_of_code/chp_02_forces/2_8_mutual_attraction.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -67,9 +67,9 @@ impl Mover {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -86,20 +86,16 @@ fn model(app: &App) -> Model {
     Model { movers }
 }
 
-fn event(_app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        for i in 0..m.movers.len() {
-            for j in 0..m.movers.len() {
-                if i != j {
-                    let force = m.movers[j].attract(&m.movers[i]);
-                    m.movers[i].apply_force(force);
-                }
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    for i in 0..m.movers.len() {
+        for j in 0..m.movers.len() {
+            if i != j {
+                let force = m.movers[j].attract(&m.movers[i]);
+                m.movers[i].apply_force(force);
             }
-            m.movers[i].update();
         }
+        m.movers[i].update();
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_02_forces/2_forces_many_mutual_boundaries.rs
+++ b/examples/nature_of_code/chp_02_forces/2_forces_many_mutual_boundaries.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Mover {
@@ -88,9 +88,9 @@ struct Model {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -107,21 +107,17 @@ fn model(app: &App) -> Model {
     Model { movers }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        for i in 0..m.movers.len() {
-            for j in 0..m.movers.len() {
-                if i != j {
-                    let force = m.movers[j].attract(&m.movers[i]);
-                    m.movers[i].apply_force(force);
-                }
+fn update(app: &App, m: &mut Model, _update: Update) {
+    for i in 0..m.movers.len() {
+        for j in 0..m.movers.len() {
+            if i != j {
+                let force = m.movers[j].attract(&m.movers[i]);
+                m.movers[i].apply_force(force);
             }
-            m.movers[i].boundaries(app.window_rect());
-            m.movers[i].update();
         }
+        m.movers[i].boundaries(app.window_rect());
+        m.movers[i].update();
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_01_angular_motion.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_01_angular_motion.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -21,8 +21,7 @@ fn model(app: &App) -> Model {
     let angle = 0.0;
     let a_velocity = 0.0;
     let a_acceleration = 0.0001;
-
-    let _window = app.new_window().with_dimensions(800, 200).build().unwrap();
+    app.new_window().with_dimensions(800, 200).view(view).build().unwrap();
     Model {
         angle,
         a_velocity,
@@ -30,13 +29,9 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        model.angle += model.a_velocity;
-        model.a_velocity += model.a_acceleration;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    model.angle += model.a_velocity;
+    model.a_velocity += model.a_acceleration;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_02_forces_angular_motion.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_02_forces_angular_motion.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 // A type for a draggable attractive body in our world
@@ -107,9 +107,9 @@ struct Model {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(800.0, 200.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -128,16 +128,12 @@ fn model(app: &App) -> Model {
     Model { movers, attractor }
 }
 
-fn event(_app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        for i in 0..m.movers.len() {
-            let force = m.attractor.attract(&m.movers[i]);
-            m.movers[i].apply_force(force);
-            m.movers[i].update();
-        }
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    for i in 0..m.movers.len() {
+        let force = m.attractor.attract(&m.movers[i]);
+        m.movers[i].apply_force(force);
+        m.movers[i].update();
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_04_exercise_spiral.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_04_exercise_spiral.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -20,19 +20,15 @@ fn model(app: &App) -> Model {
     let r = 0.0;
     let theta = 0.0;
 
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     Model { r, theta }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        // Increment the angle
-        model.theta += 0.01;
-        // Increment the radius
-        model.r += 0.05;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    // Increment the angle
+    model.theta += 0.01;
+    // Increment the radius
+    model.r += 0.05;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -18,9 +18,9 @@ struct Model {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -30,13 +30,9 @@ fn model(app: &App) -> Model {
     Model { r, theta }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        // Increase the angle over time
-        model.theta += 0.02;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    // Increase the angle over time
+    model.theta += 0.02;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian_trail.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian_trail.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -18,9 +18,9 @@ struct Model {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(800.0, 200.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -30,13 +30,9 @@ fn model(app: &App) -> Model {
     Model { r, theta }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        // Increase the angle over time
-        model.theta += 0.02;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    // Increase the angle over time
+    model.theta += 0.02;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_06_simple_harmonic_motion.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_06_simple_harmonic_motion.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -20,16 +20,12 @@ fn model(app: &App) -> Model {
     let angle = 0.0;
     let a_velocity = 0.03;
 
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     Model { angle, a_velocity }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        model.angle += model.a_velocity;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    model.angle += model.a_velocity;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_07_oscillating_objects.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_07_oscillating_objects.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -51,9 +51,9 @@ impl Oscillator {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 360.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
     //let oscillators = vec![Oscillator::new(app.window_rect()); 10];
@@ -61,14 +61,10 @@ fn model(app: &App) -> Model {
     Model { oscillators }
 }
 
-fn event(_app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        for osc in &mut m.oscillators {
-            osc.oscillate();
-        }
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    for osc in &mut m.oscillators {
+        osc.oscillate();
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_09_wave.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_09_wave.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -17,7 +17,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     let start_angle = 0.0;
     let angle_vel = 0.23;
     Model {
@@ -26,12 +26,8 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        model.start_angle += 0.015;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    model.start_angle += 0.015;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_09_wave_a.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_09_wave_a.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -17,7 +17,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(200, 200).build().unwrap();
+    app.new_window().with_dimensions(200, 200).view(view).build().unwrap();
     let start_angle = 0.0;
     let angle_vel = 0.05;
     Model {
@@ -26,12 +26,8 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        model.start_angle += 0.015;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    model.start_angle += 0.015;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_09_wave_b.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_09_wave_b.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -17,7 +17,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(250, 200).build().unwrap();
+    app.new_window().with_dimensions(250, 200).view(view).build().unwrap();
     let start_angle = 0.0;
     let angle_vel = 0.2;
     Model {
@@ -26,12 +26,8 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        model.start_angle += 0.015;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    model.start_angle += 0.015;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_09_wave_c.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_09_wave_c.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -17,7 +17,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(200, 200).build().unwrap();
+    app.new_window().with_dimensions(200, 200).view(view).build().unwrap();
     let start_angle = 0.0;
     let angle_vel = 0.4;
     Model {
@@ -26,12 +26,8 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        model.start_angle += 0.015;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    model.start_angle += 0.015;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_10_exercise_oop_wave.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_10_exercise_oop_wave.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -76,20 +76,16 @@ impl Wave {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(750, 200).build().unwrap();
+    app.new_window().with_dimensions(750, 200).view(view).build().unwrap();
     let wave0 = Wave::new(pt2(-325.0, 25.0), 100.0, 20.0, 500.0);
     let wave1 = Wave::new(pt2(-75.0, 0.0), 300.0, 40.0, 220.0);
     Model { wave0, wave1 }
 }
 
-fn event(_app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        // Update waves
-        m.wave0.calculate();
-        m.wave1.calculate();
-    }
-    m
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    // Update waves
+    m.wave0.calculate();
+    m.wave1.calculate();
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_extra_oscillating_up_and_down.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_extra_oscillating_up_and_down.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -16,17 +16,13 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(400, 400).build().unwrap();
+    app.new_window().with_dimensions(400, 400).view(view).build().unwrap();
     let angle = 0.0;
     Model { angle }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        model.angle += 0.02;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    model.angle += 0.02;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_multiple_oscillations.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_multiple_oscillations.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -29,7 +29,7 @@ fn model(app: &App) -> Model {
     let a_velocity2 = 0.3;
     let amplitude2 = 10.0;
 
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     Model {
         angle1,
         a_velocity1,
@@ -40,13 +40,9 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        model.angle1 += model.a_velocity1;
-        model.angle2 += model.a_velocity2;
-    }
-    model
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    model.angle1 += model.a_velocity1;
+    model.angle2 += model.a_velocity2;
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_03_oscillation/3_oop_wave_particles.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_oop_wave_particles.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -97,20 +97,16 @@ impl Wave {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(750, 200).build().unwrap();
+    app.new_window().with_dimensions(750, 200).view(view).build().unwrap();
     let wave0 = Wave::new(pt2(-325.0, 25.0), 100.0, 20.0, 500.0);
     let wave1 = Wave::new(pt2(-75.0, 0.0), 300.0, 40.0, 220.0);
     Model { wave0, wave1 }
 }
 
-fn event(_app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        // Update waves
-        m.wave0.calculate();
-        m.wave1.calculate();
-    }
-    m
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    // Update waves
+    m.wave0.calculate();
+    m.wave1.calculate();
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_04_systems/4_01_single_particle.rs
+++ b/examples/nature_of_code/chp_04_systems/4_01_single_particle.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -65,20 +65,16 @@ impl Particle {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     let p = Particle::new(pt2(0.0, app.window_rect().top() - 20.0));
     Model { p }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        m.p.update();
-        if m.p.is_dead() {
-            m.p = Particle::new(pt2(0.0, app.window_rect().top() - 20.0));
-        }
+fn update(app: &App, m: &mut Model, _update: Update) {
+    m.p.update();
+    if m.p.is_dead() {
+        m.p = Particle::new(pt2(0.0, app.window_rect().top() - 20.0));
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_04_systems/4_02_vector_particle.rs
+++ b/examples/nature_of_code/chp_04_systems/4_02_vector_particle.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -66,24 +66,20 @@ impl Particle {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     let particles = Vec::new();
     Model { particles }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        m.particles
-            .push(Particle::new(pt2(0.0, app.window_rect().top() - 50.0)));
-        for i in (0..m.particles.len()).rev() {
-            m.particles[i].update();
-            if m.particles[i].is_dead() {
-                m.particles.remove(i);
-            }
+fn update(app: &App, m: &mut Model, _update: Update) {
+    m.particles
+        .push(Particle::new(pt2(0.0, app.window_rect().top() - 50.0)));
+    for i in (0..m.particles.len()).rev() {
+        m.particles[i].update();
+        if m.particles[i].is_dead() {
+            m.particles.remove(i);
         }
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_04_systems/4_03_particle_system_type.rs
+++ b/examples/nature_of_code/chp_04_systems/4_03_particle_system_type.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -98,19 +98,15 @@ impl ParticleSystem {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     let (_w, h) = app.window_rect().w_h();
     let ps = ParticleSystem::new(pt2(0.0, (h as f32 / 2.0) - 50.0));
     Model { ps }
 }
 
-fn event(_app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        m.ps.add_particle();
-        m.ps.update();
-    }
-    m
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    m.ps.add_particle();
+    m.ps.update();
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_04_systems/4_04_system_of_systems.rs
+++ b/examples/nature_of_code/chp_04_systems/4_04_system_of_systems.rs
@@ -8,7 +8,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -110,30 +110,25 @@ impl ParticleSystem {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window()
+        .with_dimensions(640, 360)
+        .mouse_pressed(mouse_pressed)
+        .view(view)
+        .build()
+        .unwrap();
     let systems = Vec::new();
     Model { systems }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    match event {
-        Event::WindowEvent {
-            simple: Some(MousePressed(_button)),
-            ..
-        } => {
-            m.systems
-                .push(ParticleSystem::new(1, pt2(app.mouse.x, app.mouse.y)));
-        }
-        // update gets called just before view every frame
-        Event::Update(_dt) => {
-            for ps in m.systems.iter_mut() {
-                ps.add_particle();
-                ps.update();
-            }
-        }
-        _ => (),
+fn mouse_pressed(app: &App, m: &mut Model, _button: MouseButton) {
+    m.systems.push(ParticleSystem::new(1, pt2(app.mouse.x, app.mouse.y)));
+}
+
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    for ps in m.systems.iter_mut() {
+        ps.add_particle();
+        ps.update();
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_06_agents/6_01_seek.rs
+++ b/examples/nature_of_code/chp_06_agents/6_01_seek.rs
@@ -13,7 +13,7 @@ use nannou::prelude::*;
 use nannou::Draw;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -68,25 +68,15 @@ impl Vehicle {
 }
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(640, 360).build().unwrap();
+    app.new_window().with_dimensions(640, 360).view(view).build().unwrap();
     let middle = app.window_rect().xy();
     let vehicle = Vehicle::new(middle.x, middle.y);
     Model { vehicle }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    {
-        let Model {
-            ref mut vehicle, ..
-        } = m;
-        let mouse = vec2(app.mouse.x, app.mouse.y);
-        // update gets called just before view every frame
-        if let Event::Update(_update) = event {
-            seek(vehicle, mouse);
-            vehicle.update();
-        }
-    }
-    m
+fn update(app: &App, m: &mut Model, _update: Update) {
+    seek(&mut m.vehicle, app.mouse.position());
+    m.vehicle.update();
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {
@@ -112,7 +102,7 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
 
 // A method that calculates a steering force towards a target
 // STEER = DESIRED MINUS VELOCITY
-fn seek(vehicle: &mut Vehicle, target: Vector2) {
+fn seek(vehicle: &mut Vehicle, target: Point2) {
     let steer = {
         let Vehicle {
             ref position,

--- a/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_figures.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_figures.rs
@@ -12,7 +12,7 @@ use nannou::prelude::*;
 use std::ops::Range;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 // A Type to manage the CA
@@ -146,9 +146,9 @@ struct Model {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(1800.0, 600.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -157,17 +157,13 @@ fn model(app: &App) -> Model {
     Model { ca }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        if m.ca.finished(&app.window_rect()) == false {
-            m.ca.generate();
-        } else {
-            m.ca.randomize();
-            m.ca.restart();
-        }
+fn update(app: &App, m: &mut Model, _update: Update) {
+    if m.ca.finished(&app.window_rect()) == false {
+        m.ca.generate();
+    } else {
+        m.ca.randomize();
+        m.ca.restart();
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_simple.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_simple.rs
@@ -12,7 +12,7 @@ use nannou::prelude::*;
 use std::ops::Range;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 // A Type to manage the CA
@@ -117,6 +117,7 @@ fn model(app: &App) -> Model {
     let _window = app
         .new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -124,14 +125,10 @@ fn model(app: &App) -> Model {
     Model { ca }
 }
 
-fn event(app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        if m.ca.generation < app.window_rect().h() as i32 / m.ca.w {
-            m.ca.generate();
-        }
+fn update(app: &App, m: &mut Model, _update: Update) {
+    if m.ca.generation < app.window_rect().h() as i32 / m.ca.w {
+        m.ca.generate();
     }
-    m
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_07_cellular_automata/7_02_game_of_life_simple.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_02_game_of_life_simple.rs
@@ -16,7 +16,7 @@ use nannou::prelude::*;
 use std::ops::Range;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Gol {
@@ -131,9 +131,10 @@ struct Model {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0 * 2.0, 360.0 * 2.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .mouse_pressed(mouse_pressed)
+        .view(view)
         .build()
         .unwrap();
 
@@ -141,23 +142,13 @@ fn model(app: &App) -> Model {
     Model { gol }
 }
 
-fn event(_app: &App, mut m: Model, event: Event) -> Model {
-    match event {
-        Event::WindowEvent {
-            simple: Some(MousePressed(_button)),
-            ..
-        } => {
-            // Reset board when mouse is pressed
-            m.gol.init();
-        }
+fn mouse_pressed(_app: &App, m: &mut Model, _button: MouseButton) {
+    // Reset board when mouse is pressed
+    m.gol.init();
+}
 
-        // update gets called just before view every frame
-        Event::Update(_dt) => {
-            m.gol.generate();
-        }
-        _ => (),
-    }
-    m
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    m.gol.generate();
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_07_cellular_automata/7_03_game_of_life_oop.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_03_game_of_life_oop.rs
@@ -13,7 +13,7 @@ use nannou::prelude::*;
 use std::ops::Range;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 #[derive(Clone)]
@@ -154,9 +154,10 @@ struct Model {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0 * 2.0, 360.0 * 2.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .mouse_pressed(mouse_pressed)
+        .view(view)
         .build()
         .unwrap();
 
@@ -164,23 +165,13 @@ fn model(app: &App) -> Model {
     Model { gol }
 }
 
-fn event(_app: &App, mut m: Model, event: Event) -> Model {
-    match event {
-        Event::WindowEvent {
-            simple: Some(MousePressed(_button)),
-            ..
-        } => {
-            // Reset board when mouse is pressed
-            m.gol.init();
-        }
+fn mouse_pressed(_app: &App, m: &mut Model, _button: MouseButton) {
+    // Reset board when mouse is pressed
+    m.gol.init();
+}
 
-        // update gets called just before view every frame
-        Event::Update(_dt) => {
-            m.gol.generate();
-        }
-        _ => (),
-    }
-    m
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    m.gol.generate();
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/nature_of_code/chp_07_cellular_automata/7_04_exercise_wolfram_ca_scrolling.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_04_exercise_wolfram_ca_scrolling.rs
@@ -16,7 +16,7 @@ use std::ops::Range;
 const RULE: i32 = 2;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 // A Type to manage the CA
@@ -157,9 +157,9 @@ struct Model {
 
 fn model(app: &App) -> Model {
     let rect = Rect::from_w_h(640.0, 800.0);
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(rect.w() as u32, rect.h() as u32)
+        .view(view)
         .build()
         .unwrap();
 
@@ -176,12 +176,8 @@ fn model(app: &App) -> Model {
     Model { ca }
 }
 
-fn event(_app: &App, mut m: Model, event: Event) -> Model {
-    // update gets called just before view every frame
-    if let Event::Update(_update) = event {
-        m.ca.generate();
-    }
-    m
+fn update(_app: &App, m: &mut Model, _update: Update) {
+    m.ca.generate();
 }
 
 fn view(app: &App, m: &Model, frame: Frame) -> Frame {

--- a/examples/osc_receiver.rs
+++ b/examples/osc_receiver.rs
@@ -5,7 +5,7 @@ use nannou::prelude::*;
 use nannou::ui::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -22,6 +22,7 @@ fn model(app: &App) -> Model {
     app.new_window()
         .with_title("OSC Receiver")
         .with_dimensions(1400, 480)
+        .view(view)
         .build()
         .unwrap();
 
@@ -43,38 +44,32 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    match event {
-        Event::Update(_update) => {
-            // Receive any pending osc packets.
-            for (packet, addr) in model.receiver.try_iter() {
-                model.received_packets.push((addr, packet));
-            }
-
-            // We'll display 10 packets at a time, so remove any excess.
-            let max_packets = 10;
-            while model.received_packets.len() > max_packets {
-                model.received_packets.remove(0);
-            }
-
-            // Create a string showing all the packets.
-            let mut packets_text = format!("Listening on port {}\nReceived packets:\n", PORT);
-            for &(addr, ref packet) in model.received_packets.iter().rev() {
-                packets_text.push_str(&format!("{}: {:?}\n", addr, packet));
-            }
-
-            // Use the UI to display the packet string.
-            model.ui.clear_with(color::DARK_BLUE);
-            let mut ui = model.ui.set_widgets();
-            widget::Text::new(&packets_text)
-                .top_left_with_margin_on(ui.window, 20.0)
-                .color(color::WHITE)
-                .line_spacing(10.0)
-                .set(model.text, &mut ui);
-        }
-        _ => (),
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    // Receive any pending osc packets.
+    for (packet, addr) in model.receiver.try_iter() {
+        model.received_packets.push((addr, packet));
     }
-    model
+
+    // We'll display 10 packets at a time, so remove any excess.
+    let max_packets = 10;
+    while model.received_packets.len() > max_packets {
+        model.received_packets.remove(0);
+    }
+
+    // Create a string showing all the packets.
+    let mut packets_text = format!("Listening on port {}\nReceived packets:\n", PORT);
+    for &(addr, ref packet) in model.received_packets.iter().rev() {
+        packets_text.push_str(&format!("{}: {:?}\n", addr, packet));
+    }
+
+    // Use the UI to display the packet string.
+    model.ui.clear_with(color::DARK_BLUE);
+    let mut ui = model.ui.set_widgets();
+    widget::Text::new(&packets_text)
+        .top_left_with_margin_on(ui.window, 20.0)
+        .color(color::WHITE)
+        .line_spacing(10.0)
+        .set(model.text, &mut ui);
 }
 
 // Draw the state of your `Model` into the given `Frame` here.

--- a/examples/osc_sender.rs
+++ b/examples/osc_sender.rs
@@ -5,7 +5,7 @@ use nannou::prelude::*;
 use nannou::ui::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
 struct Model {
@@ -25,6 +25,8 @@ fn model(app: &App) -> Model {
     app.new_window()
         .with_title("OSC Sender")
         .with_dimensions(680, 480)
+        .event(event)
+        .view(view)
         .build()
         .unwrap();
 
@@ -41,55 +43,47 @@ fn model(app: &App) -> Model {
     Model { sender, ui, text }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
+fn event(_app: &App, model: &mut Model, event: WindowEvent) {
     match event {
-        Event::WindowEvent {
-            simple: Some(event),
-            ..
-        } => match event {
-            MouseMoved(pos) => {
-                let addr = "/example/mouse_moved/";
-                let args = vec![Type::Float(pos.x), Type::Float(pos.y)];
-                model.sender.send((addr, args)).ok();
-            }
-
-            MousePressed(button) => {
-                let addr = "/example/mouse_pressed/";
-                let button = format!("{:?}", button);
-                let args = vec![Type::String(button)];
-                model.sender.send((addr, args)).ok();
-            }
-
-            MouseReleased(button) => {
-                let addr = "/example/mouse_released/";
-                let button = format!("{:?}", button);
-                let args = vec![Type::String(button)];
-                model.sender.send((addr, args)).ok();
-            }
-
-            _other => (),
-        },
-
-        Event::Update(_update) => {
-            // Use the UI to show the user where packets are being sent.
-            model.ui.clear_with(color::DARK_RED);
-            let mut ui = model.ui.set_widgets();
-            let text = format!(
-                "Move or click the mouse to send\nmessages to the \
-                 receiver example!\n\nSending OSC packets to {}",
-                target_address_string()
-            );
-            widget::Text::new(&text)
-                .middle_of(ui.window)
-                .center_justify()
-                .color(color::WHITE)
-                .line_spacing(10.0)
-                .set(model.text, &mut ui);
+        MouseMoved(pos) => {
+            let addr = "/example/mouse_moved/";
+            let args = vec![Type::Float(pos.x), Type::Float(pos.y)];
+            model.sender.send((addr, args)).ok();
         }
 
-        _ => (),
+        MousePressed(button) => {
+            let addr = "/example/mouse_pressed/";
+            let button = format!("{:?}", button);
+            let args = vec![Type::String(button)];
+            model.sender.send((addr, args)).ok();
+        }
+
+        MouseReleased(button) => {
+            let addr = "/example/mouse_released/";
+            let button = format!("{:?}", button);
+            let args = vec![Type::String(button)];
+            model.sender.send((addr, args)).ok();
+        }
+
+        _other => (),
     }
-    model
+}
+
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    // Use the UI to show the user where packets are being sent.
+    model.ui.clear_with(color::DARK_RED);
+    let mut ui = model.ui.set_widgets();
+    let text = format!(
+        "Move or click the mouse to send\nmessages to the \
+         receiver example!\n\nSending OSC packets to {}",
+        target_address_string()
+    );
+    widget::Text::new(&text)
+        .middle_of(ui.window)
+        .center_justify()
+        .color(color::WHITE)
+        .line_spacing(10.0)
+        .set(model.text, &mut ui);
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -4,7 +4,7 @@ use nannou::prelude::*;
 use nannou::ui::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).simple_window(view).run();
+    nannou::app(model).update(update).simple_window(view).run();
 }
 
 struct Model {
@@ -59,77 +59,74 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn event(_app: &App, mut model: Model, event: Event) -> Model {
-    if let Event::Update(_update) = event {
-        // Calling `set_widgets` allows us to instantiate some widgets.
-        let ui = &mut model.ui.set_widgets();
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    // Calling `set_widgets` allows us to instantiate some widgets.
+    let ui = &mut model.ui.set_widgets();
 
-        fn slider(val: f32, min: f32, max: f32) -> widget::Slider<'static, f32> {
-            widget::Slider::new(val, min, max)
-                .w_h(200.0, 30.0)
-                .label_font_size(15)
-                .rgb(0.3, 0.3, 0.3)
-                .label_rgb(1.0, 1.0, 1.0)
-                .border(0.0)
-        }
-
-        for value in slider(model.resolution as f32, 3.0, 15.0)
-            .top_left_with_margin(20.0)
-            .label("Resolution")
-            .set(model.ids.resolution, ui)
-        {
-            model.resolution = value as usize;
-        }
-
-        for value in slider(model.scale, 10.0, 500.0)
-            .down(10.0)
-            .label("Scale")
-            .set(model.ids.scale, ui)
-        {
-            model.scale = value;
-        }
-
-        for value in slider(model.rotation, -PI, PI)
-            .down(10.0)
-            .label("Rotation")
-            .set(model.ids.rotation, ui)
-        {
-            model.rotation = value;
-        }
-
-        for _click in widget::Button::new()
-            .down(10.0)
-            .w_h(200.0, 60.0)
-            .label("Random Color")
+    fn slider(val: f32, min: f32, max: f32) -> widget::Slider<'static, f32> {
+        widget::Slider::new(val, min, max)
+            .w_h(200.0, 30.0)
             .label_font_size(15)
             .rgb(0.3, 0.3, 0.3)
             .label_rgb(1.0, 1.0, 1.0)
             .border(0.0)
-            .set(model.ids.random_color, ui)
-        {
-            model.color = Rgb::new(random(), random(), random());
-        }
-
-        for (x, y) in widget::XYPad::new(
-            model.position.x,
-            -200.0,
-            200.0,
-            model.position.y,
-            -200.0,
-            200.0,
-        ).down(10.0)
-            .w_h(200.0, 200.0)
-            .label("Position")
-            .label_font_size(15)
-            .rgb(0.3, 0.3, 0.3)
-            .label_rgb(1.0, 1.0, 1.0)
-            .border(0.0)
-            .set(model.ids.position, ui)
-        {
-            model.position = Point2::new(x, y);
-        }
     }
-    model
+
+    for value in slider(model.resolution as f32, 3.0, 15.0)
+        .top_left_with_margin(20.0)
+        .label("Resolution")
+        .set(model.ids.resolution, ui)
+    {
+        model.resolution = value as usize;
+    }
+
+    for value in slider(model.scale, 10.0, 500.0)
+        .down(10.0)
+        .label("Scale")
+        .set(model.ids.scale, ui)
+    {
+        model.scale = value;
+    }
+
+    for value in slider(model.rotation, -PI, PI)
+        .down(10.0)
+        .label("Rotation")
+        .set(model.ids.rotation, ui)
+    {
+        model.rotation = value;
+    }
+
+    for _click in widget::Button::new()
+        .down(10.0)
+        .w_h(200.0, 60.0)
+        .label("Random Color")
+        .label_font_size(15)
+        .rgb(0.3, 0.3, 0.3)
+        .label_rgb(1.0, 1.0, 1.0)
+        .border(0.0)
+        .set(model.ids.random_color, ui)
+    {
+        model.color = Rgb::new(random(), random(), random());
+    }
+
+    for (x, y) in widget::XYPad::new(
+        model.position.x,
+        -200.0,
+        200.0,
+        model.position.y,
+        -200.0,
+        200.0,
+    ).down(10.0)
+        .w_h(200.0, 200.0)
+        .label("Position")
+        .label_font_size(15)
+        .rgb(0.3, 0.3, 0.3)
+        .label_rgb(1.0, 1.0, 1.0)
+        .border(0.0)
+        .set(model.ids.position, ui)
+    {
+        model.position = Point2::new(x, y);
+    }
 }
 
 // Draw the state of your `Model` into the given `Frame` here.

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -3,10 +3,7 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model)
-        .event(event) // The function that will be called when the app receives events.
-        .view(view) // The function that will be called for drawing to the window.
-        .run();
+    nannou::app(model).run();
 }
 
 struct Model {
@@ -16,14 +13,19 @@ struct Model {
 
 fn model(app: &App) -> Model {
     // Create a new window! Store the ID so we can refer to it later.
-    let _window = app.new_window().with_dimensions(512, 512).with_title("nannou").build().unwrap();
+    let _window = app.new_window()
+        .with_dimensions(512, 512)
+        .with_title("nannou")
+        .view(view) // The function that will be called for presenting graphics to a frame.
+        .event(event) // The function that will be called when the window receives events.
+        .build()
+        .unwrap();
     Model { _window }
 }
 
 // Handle events related to the window and update the model if necessary
-fn event(_app: &App, model: Model, event: Event) -> Model {
+fn event(_app: &App, _model: &mut Model, event: WindowEvent) {
     println!("{:?}", event);
-    model
 }
 
 // Draw the state of your `Model` into the given `Frame` here.

--- a/examples/template_app.rs
+++ b/examples/template_app.rs
@@ -3,65 +3,58 @@ extern crate nannou;
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).update(update).run();
 }
 
-struct Model {}
+struct Model {
+    _window: window::Id,
+}
 
 fn model(app: &App) -> Model {
-    let _window = app.new_window().with_dimensions(720, 720).build().unwrap();
-    Model {}
+    let _window = app.new_window()
+        .with_dimensions(720, 720)
+        .view(view)
+        .event(window_event)
+        .build()
+        .unwrap();
+    Model { _window }
 }
 
-fn event(_app: &App, model: Model, event: Event) -> Model {
+fn update(_app: &App, _model: &mut Model, _update: Update) {
+}
+
+fn window_event(_app: &App, _model: &mut Model, event: WindowEvent) {
     match event {
-        Event::WindowEvent {
-            simple: Some(event),
-            ..
-        } => match event {
-            Moved(_pos) => {}
-
-            KeyPressed(_key) => {}
-
-            KeyReleased(_key) => {}
-
-            MouseMoved(_pos) => {}
-
-            MouseDragged(_pos, _button) => {}
-
-            MousePressed(_button) => {}
-
-            MouseReleased(_button) => {}
-
-            MouseEntered => {}
-
-            MouseExited => {}
-
-            Resized(_size) => {}
-
-            _other => (),
-        },
-
-        Event::Update(_dt) => {}
-
-        _ => (),
+        KeyPressed(_key) => {}
+        KeyReleased(_key) => {}
+        MouseMoved(_pos) => {}
+        MousePressed(_button) => {}
+        MouseReleased(_button) => {}
+        MouseEntered => {}
+        MouseExited => {}
+        MouseWheel(_amount, _phase) => {}
+        Moved(_pos) => {}
+        Resized(_size) => {}
+        Touch(_touch) => {}
+        TouchPressure(_pressure) => {}
+        HoveredFile(_path) => {}
+        DroppedFile(_path) => {}
+        HoveredFileCancelled => {}
+        Focused => {}
+        Unfocused => {}
+        Closed => {}
     }
-    model
 }
 
 fn view(app: &App, _model: &Model, frame: Frame) -> Frame {
     // Prepare to draw.
     let draw = app.draw();
-
     // Clear the background to pink.
     draw.background().color(LIGHT_PURPLE);
-
     // Draw a red ellipse with default size and position.
     draw.ellipse().color(DARK_BLUE);
-
     // Write to the window frame.
     draw.to_frame(app, &frame).unwrap();
-
     // Return the drawn frame.
     frame
 }

--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -19,11 +19,10 @@ use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 use nannou::vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).run();
 }
 
 struct Model {
-    _window: WindowId,
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
@@ -38,10 +37,9 @@ struct Vertex {
 nannou::vulkano::impl_vertex!(Vertex, position);
 
 fn model(app: &App) -> Model {
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(512, 512)
-        .with_title("nannou")
+        .view(view)
         .build()
         .unwrap();
 
@@ -148,18 +146,12 @@ fn model(app: &App) -> Model {
     let framebuffers = RefCell::new(Vec::new());
 
     Model {
-        _window,
         render_pass,
         pipeline,
         vertex_buffer,
         framebuffers,
         desciptor_set,
     }
-}
-
-fn event(_app: &App, model: Model, event: Event) -> Model {
-    if let Event::Update(_update) = event {}
-    model
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -19,14 +19,10 @@ use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 use nannou::vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 
 fn main() {
-    nannou::app(model)
-        .event(event)
-        .view(view)
-        .run();
+    nannou::app(model).run();
 }
 
 struct Model {
-    _window: WindowId,
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
@@ -42,10 +38,9 @@ struct Vertex {
 nannou::vulkano::impl_vertex!(Vertex, position);
 
 fn model(app: &App) -> Model {
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(220, 220)
-        .with_title("nannou")
+        .view(view)
         .build()
         .unwrap();
 
@@ -176,17 +171,12 @@ fn model(app: &App) -> Model {
     let framebuffers = RefCell::new(Vec::new());
 
     Model {
-        _window,
         render_pass,
         pipeline,
         vertex_buffer,
         framebuffers,
         desciptor_set,
     }
-}
-
-fn event(_app: &App, model: Model, _event: Event) -> Model {
-    model
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -19,14 +19,10 @@ use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 use nannou::vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 
 fn main() {
-    nannou::app(model)
-        .event(event)
-        .view(view)
-        .run();
+    nannou::app(model).run();
 }
 
 struct Model {
-    _window: WindowId,
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
@@ -42,10 +38,9 @@ struct Vertex {
 nannou::vulkano::impl_vertex!(Vertex, position);
 
 fn model(app: &App) -> Model {
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(512, 512)
-        .with_title("nannou")
+        .view(view)
         .build()
         .unwrap();
 
@@ -168,18 +163,12 @@ fn model(app: &App) -> Model {
     let framebuffers = RefCell::new(Vec::new());
 
     Model {
-        _window,
         render_pass,
         pipeline,
         vertex_buffer,
         framebuffers,
         desciptor_set,
     }
-}
-
-fn event(_app: &App, model: Model, event: Event) -> Model {
-    if let Event::Update(_update) = event {}
-    model
 }
 
 fn view(_app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/vulkan/vk_shader_include/mod.rs
+++ b/examples/vulkan/vk_shader_include/mod.rs
@@ -15,14 +15,10 @@ use nannou::vulkano::pipeline::viewport::Viewport;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 
 fn main() {
-    nannou::app(model)
-        .event(event)
-        .view(view)
-        .run();
+    nannou::app(model).run();
 }
 
 struct Model {
-    _window: WindowId,
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
@@ -37,10 +33,10 @@ struct Vertex {
 nannou::vulkano::impl_vertex!(Vertex, position);
 
 fn model(app: &App) -> Model {
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(1024, 512)
         .with_title("nannou")
+        .view(view)
         .build()
         .unwrap();
 
@@ -108,16 +104,11 @@ fn model(app: &App) -> Model {
     let framebuffers = RefCell::new(Vec::new());
 
     Model {
-        _window,
         render_pass,
         pipeline,
         vertex_buffer,
         framebuffers,
     }
-}
-
-fn event(_app: &App, model: Model, _event: Event) -> Model {
-    model
 }
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {

--- a/examples/vulkan/vk_triangle.rs
+++ b/examples/vulkan/vk_triangle.rs
@@ -15,11 +15,10 @@ use nannou::vulkano::pipeline::viewport::Viewport;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 
 fn main() {
-    nannou::app(model).event(event).view(view).run();
+    nannou::app(model).run();
 }
 
 struct Model {
-    _window: WindowId,
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
@@ -34,10 +33,9 @@ struct Vertex {
 nannou::vulkano::impl_vertex!(Vertex, position);
 
 fn model(app: &App) -> Model {
-    let _window = app
-        .new_window()
+    app.new_window()
         .with_dimensions(512, 512)
-        .with_title("nannou")
+        .view(view)
         .build()
         .unwrap();
 
@@ -140,18 +138,11 @@ fn model(app: &App) -> Model {
     let framebuffers = RefCell::new(Vec::new());
 
     Model {
-        _window,
         render_pass,
         pipeline,
         vertex_buffer,
         framebuffers,
     }
-}
-
-// Handle events related to the window and update the model if necessary
-fn event(_app: &App, model: Model, event: Event) -> Model {
-    if let Event::Update(_update) = event {}
-    model
 }
 
 // Draw the state of your `Model` into the given `Frame` here.

--- a/src/audio/receiver.rs
+++ b/src/audio/receiver.rs
@@ -92,7 +92,7 @@ where
                 channels,
                 sample_rate,
             };
-            model = capture(model, &buffer);
+            capture(&mut model, &buffer);
             std::mem::swap(samples, &mut buffer.interleaved_samples.into_vec());
             samples.clear();
         }

--- a/src/audio/requester.rs
+++ b/src/audio/requester.rs
@@ -123,14 +123,13 @@ where
 
             // Render the state of the model to the samples buffer.
             let interleaved_samples = std::mem::replace(samples, Vec::new()).into_boxed_slice();
-            let buffer = audio::Buffer {
+            let mut buffer = audio::Buffer {
                 interleaved_samples,
                 channels,
                 sample_rate,
             };
-            let (new_model, new_buffer) = render(model, buffer);
-            let mut new_samples = new_buffer.interleaved_samples.into_vec();
-            model = new_model;
+            render(&mut model, &mut buffer);
+            let mut new_samples = buffer.interleaved_samples.into_vec();
             std::mem::swap(samples, &mut new_samples);
 
             // Write the `frames` to output.

--- a/src/audio/stream/input.rs
+++ b/src/audio/stream/input.rs
@@ -7,8 +7,8 @@ use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
 /// The function that will be called when a captured `Buffer` is ready to be read.
-pub trait CaptureFn<M, S>: Fn(M, &Buffer<S>) -> M {}
-impl<M, S, F> CaptureFn<M, S> for F where F: Fn(M, &Buffer<S>) -> M {}
+pub trait CaptureFn<M, S>: Fn(&mut M, &Buffer<S>) {}
+impl<M, S, F> CaptureFn<M, S> for F where F: Fn(&mut M, &Buffer<S>) {}
 
 pub struct Builder<M, F, S = f32> {
     pub builder: super::Builder<M, S>,

--- a/src/audio/stream/output.rs
+++ b/src/audio/stream/output.rs
@@ -7,8 +7,8 @@ use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
 /// The function that will be called when a `Buffer` is ready to be rendered.
-pub trait RenderFn<M, S>: Fn(M, Buffer<S>) -> (M, Buffer<S>) {}
-impl<M, S, F> RenderFn<M, S> for F where F: Fn(M, Buffer<S>) -> (M, Buffer<S>) {}
+pub trait RenderFn<M, S>: Fn(&mut M, &mut Buffer<S>) {}
+impl<M, S, F> RenderFn<M, S> for F where F: Fn(&mut M, &mut Buffer<S>) {}
 
 pub struct Builder<M, F, S = f32> {
     pub builder: super::Builder<M, S>,

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,8 +1,8 @@
 //! Application, event loop and window event definitions and implementations.
 //!
 //! - [**Event**](./enum.Event.html) - the defualt application event type.
-//! - [**WindowEvent**](./struct.WindowEvent.html) - events related to a single window.
-//! - [**SimpleWindowEvent**](./struct.WindowEvent.html) - a stripped-back, simplified,
+//! - [**winit::WindowEvent**](./struct.WindowEvent.html) - events related to a single window.
+//! - [**WindowEvent**](./struct.WindowEvent.html) - a stripped-back, simplified,
 //!   newcomer-friendly version of the **raw**, low-level winit event.
 
 use geom::{self, Point2, Vector2};
@@ -13,7 +13,7 @@ use winit;
 use App;
 
 pub use winit::{
-    ElementState, KeyboardInput, ModifiersState, MouseButton, MouseScrollDelta, Touch, TouchPhase,
+    ElementState, KeyboardInput, ModifiersState, MouseButton, MouseScrollDelta, TouchPhase,
     VirtualKeyCode as Key,
 };
 
@@ -23,8 +23,8 @@ pub trait LoopEvent: From<Update> {
     fn from_winit_event(winit::Event, &App) -> Option<Self>;
 }
 
-/// Update event
-#[derive(Clone, Debug)]
+/// Update event, emitted on each pass of an application loop.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Update {
     /// The duration since the last update was emitted.
     ///
@@ -46,34 +46,57 @@ pub enum Event {
     WindowEvent {
         id: window::Id,
         raw: winit::WindowEvent,
-        simple: Option<SimpleWindowEvent>,
+        simple: Option<WindowEvent>,
     },
+
     /// A device-specific event has occurred for the device with the given Id.
     DeviceEvent(winit::DeviceId, winit::DeviceEvent),
+
     /// A timed update alongside the duration since the last update was emitted.
     ///
     /// The first update's delta will be the time since the `model` function returned.
     Update(Update),
+
     /// The application has been awakened.
     Awakened,
+
     /// The application has been suspended or resumed.
     ///
     /// The parameter is true if app was suspended, and false if it has been resumed.
     Suspended(bool),
 }
 
-/// The nannou window event type.
-///
-/// The **simple** field offers a stripped-back, simplified, newcomer-friendly version of the
-/// **raw**, low-level winit event.
-#[derive(Clone, Debug)]
-pub struct WindowEvent {
-    /// A simplified, interpreted version of the `raw` `winit::WindowEvent` emitted via winit.
-    ///
-    /// See the [SimpleWindowEvent](./enum.SimpleWindowEvent.html)
-    pub simple: Option<SimpleWindowEvent>,
-    /// The original event type produced by `winit`.
-    pub raw: winit::WindowEvent,
+/// The event associated with a touch at a single point.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct TouchEvent {
+    /// The unique ID associated with this touch, e.g. useful for distinguishing between fingers.
+    pub id: u64,
+    /// The state of the touch.
+    pub phase: TouchPhase,
+    /// The position of the touch.
+    pub position: Point2<geom::scalar::Default>,
+}
+
+/// Pressure on a touch pad.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct TouchpadPressure {
+    /// The unique ID associated with the device that emitted this event.
+    pub device_id: winit::DeviceId,
+    /// The amount of pressure applied.
+    pub pressure: f32,
+    /// Integer representing the click level.
+    pub stage: i64,
+}
+
+/// Motion along some axis of a device e.g. joystick or gamepad.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AxisMotion {
+    /// The unique ID of the device that emitted this event.
+    pub device_id: winit::DeviceId,
+    /// The axis on which motion occurred.
+    pub axis: winit::AxisId,
+    /// The motion value.
+    pub value: geom::scalar::Default,
 }
 
 /// A simplified version of winit's `WindowEvent` type to make it easier to get started.
@@ -87,7 +110,7 @@ pub struct WindowEvent {
 /// - positive `y` points upwards, negative `y` points downwards.
 /// - positive `z` points into the screen, negative `z` points out of the screen.
 #[derive(Clone, Debug, PartialEq)]
-pub enum SimpleWindowEvent {
+pub enum WindowEvent {
     /// The window has been moved to a new position.
     Moved(Point2<geom::scalar::Default>),
 
@@ -99,9 +122,6 @@ pub enum SimpleWindowEvent {
 
     /// The mouse moved to the given x, y position.
     MouseMoved(Point2<geom::scalar::Default>),
-
-    /// The given mouse button was dragged to the given x, y position.
-    MouseDragged(Point2<geom::scalar::Default>, MouseButton),
 
     /// The given mouse button was pressed.
     MousePressed(MouseButton),
@@ -131,29 +151,26 @@ pub enum SimpleWindowEvent {
     HoveredFileCancelled,
 
     /// Received a touch event.
-    Touch {
-        phase: TouchPhase,
-        position: Point2<geom::scalar::Default>,
-        id: u64,
-    },
+    Touch(TouchEvent),
 
     /// Touchpad pressure event.
     ///
     /// At the moment, only supported on Apple forcetouch-capable macbooks.
     /// The parameters are: pressure level (value between 0 and 1 representing how hard the touchpad
     /// is being pressed) and stage (integer representing the click level).
-    TouchpadPressure { pressure: f32, stage: i64 },
+    TouchPressure(TouchpadPressure),
 
-    /// The window gained or lost focus.
-    ///
-    /// The parameter is true if the window has gained focus, and false if it has lost focus.
-    Focused(bool),
+    /// The window gained focus.
+    Focused,
+
+    /// The window lost focus.
+    Unfocused,
 
     /// The window was closed and is no longer stored in the `App`.
     Closed,
 }
 
-impl SimpleWindowEvent {
+impl WindowEvent {
     /// Produce a simplified, new-user-friendly version of the given `winit::WindowEvent`.
     ///
     /// This strips rarely needed technical information from the event type such as information
@@ -171,7 +188,7 @@ impl SimpleWindowEvent {
         win_w: f64,
         win_h: f64,
     ) -> Option<Self> {
-        use self::SimpleWindowEvent::*;
+        use self::WindowEvent::*;
 
         // Translate the coordinates from top-left-origin-with-y-down to centre-origin-with-y-up.
         //
@@ -207,7 +224,7 @@ impl SimpleWindowEvent {
 
             winit::WindowEvent::HoveredFileCancelled => HoveredFileCancelled,
 
-            winit::WindowEvent::Focused(b) => Focused(b),
+            winit::WindowEvent::Focused(b) => if b { Focused } else { Unfocused },
 
             winit::WindowEvent::CursorMoved {
                 position, ..
@@ -239,16 +256,17 @@ impl SimpleWindowEvent {
                 let x = tx(x);
                 let y = ty(y);
                 let position = Point2 { x, y };
-                Touch {
+                let touch = TouchEvent {
                     phase,
                     position,
                     id,
-                }
+                };
+                WindowEvent::Touch(touch)
             }
 
             winit::WindowEvent::TouchpadPressure {
-                pressure, stage, ..
-            } => TouchpadPressure { pressure, stage },
+                device_id, pressure, stage,
+            } => TouchPressure(TouchpadPressure { device_id, pressure, stage }),
 
             winit::WindowEvent::KeyboardInput { input, .. } => match input.virtual_keycode {
                 Some(key) => match input.state {
@@ -286,7 +304,7 @@ impl LoopEvent for Event {
                     }
                 };
                 let raw = event.clone();
-                let simple = SimpleWindowEvent::from_winit_window_event(event, win_w, win_h);
+                let simple = WindowEvent::from_winit_window_event(event, win_w, win_h);
                 Event::WindowEvent {
                     id: window_id,
                     raw,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ extern crate toml;
 pub extern crate vulkano;
 pub extern crate vulkano_shaders;
 pub extern crate vulkano_win;
-extern crate winit;
+pub extern crate winit;
 
 pub use self::event::Event;
 pub use self::frame::Frame;
@@ -60,7 +60,7 @@ pub mod window;
 ///
 /// The Model that is returned by the function is the same model that will be passed to the
 /// given event and view functions.
-pub fn app<M>(model: app::ModelFn<M>) -> app::Builder<M, Event> {
+pub fn app<M: 'static>(model: app::ModelFn<M>) -> app::Builder<M, Event> {
     app::Builder::new(model)
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,8 +4,9 @@ pub use app::{self, App, LoopMode};
 pub use audio;
 pub use color::named::*;
 pub use color::{Hsl, Hsla, Hsv, Hsva, Rgb, Rgba};
-pub use event::SimpleWindowEvent::*;
-pub use event::{Event, Key};
+pub use event::WindowEvent::*;
+pub use event::{AxisMotion, Event, Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase,
+                TouchpadPressure, Update, WindowEvent};
 pub use frame::Frame;
 pub use geom::{
     self, pt2, pt3, vec2, vec3, vec4, Cuboid, Point2, Point3, Rect, Vector2, Vector3, Vector4,

--- a/src/window.rs
+++ b/src/window.rs
@@ -2,9 +2,14 @@
 //! This produces a [**Builder**](./struct.Builder.html) which can be used to build a window.
 
 use app::LoopMode;
+use event::{Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase, TouchpadPressure, WindowEvent};
+use frame::Frame;
 use geom;
+use geom::{Point2, Vector2};
+use std::any::Any;
 use std::{cmp, env, fmt, ops};
 use std::error::Error as StdError;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::AtomicBool;
 use vulkano::device::{self, Device};
@@ -34,7 +39,168 @@ pub struct Builder<'app> {
     window: winit::WindowBuilder,
     title_was_set: bool,
     swapchain_builder: SwapchainBuilder,
+    user_functions: UserFunctions,
 }
+
+/// For storing all user functions within the window.
+#[derive(Debug, Default)]
+pub(crate) struct UserFunctions {
+    pub(crate) view: Option<View>,
+    pub(crate) event: Option<EventFnAny>,
+    pub(crate) raw_event: Option<RawEventFnAny>,
+    pub(crate) key_pressed: Option<KeyPressedFnAny>,
+    pub(crate) key_released: Option<KeyReleasedFnAny>,
+    pub(crate) mouse_moved: Option<MouseMovedFnAny>,
+    pub(crate) mouse_pressed: Option<MousePressedFnAny>,
+    pub(crate) mouse_released: Option<MouseReleasedFnAny>,
+    pub(crate) mouse_entered: Option<MouseEnteredFnAny>,
+    pub(crate) mouse_exited: Option<MouseExitedFnAny>,
+    pub(crate) mouse_wheel: Option<MouseWheelFnAny>,
+    pub(crate) moved: Option<MovedFnAny>,
+    pub(crate) resized: Option<ResizedFnAny>,
+    pub(crate) touch: Option<TouchFnAny>,
+    pub(crate) touchpad_pressure: Option<TouchpadPressureFnAny>,
+    pub(crate) hovered_file: Option<HoveredFileFnAny>,
+    pub(crate) hovered_file_cancelled: Option<HoveredFileCancelledFnAny>,
+    pub(crate) dropped_file: Option<DroppedFileFnAny>,
+    pub(crate) focused: Option<FocusedFnAny>,
+    pub(crate) unfocused: Option<UnfocusedFnAny>,
+    pub(crate) closed: Option<ClosedFnAny>,
+}
+
+/// The user function type for drawing their model to the surface of a single window.
+pub type ViewFn<Model> = fn(&App, &Model, Frame) -> Frame;
+
+/// The same as `ViewFn`, but provides no user model to draw from.
+///
+/// Useful for simple, stateless sketching.
+pub type SketchFn = fn(&App, Frame) -> Frame;
+
+/// The user's view function, whether with a model or without one.
+#[derive(Clone)]
+pub(crate) enum View {
+    WithModel(ViewFnAny),
+    Sketch(SketchFn),
+}
+
+/// A function for processing raw winit window events.
+pub type RawEventFn<Model> = fn(&App, &mut Model, winit::WindowEvent);
+
+/// A function for processing window events.
+pub type EventFn<Model> = fn(&App, &mut Model, WindowEvent);
+
+/// A function for processing key press events.
+pub type KeyPressedFn<Model> = fn(&App, &mut Model, Key);
+
+/// A function for processing key release events.
+pub type KeyReleasedFn<Model> = fn(&App, &mut Model, Key);
+
+/// A function for processing mouse moved events.
+pub type MouseMovedFn<Model> = fn(&App, &mut Model, Point2);
+
+/// A function for processing mouse pressed events.
+pub type MousePressedFn<Model> = fn(&App, &mut Model, MouseButton);
+
+/// A function for processing mouse released events.
+pub type MouseReleasedFn<Model> = fn(&App, &mut Model, MouseButton);
+
+/// A function for processing mouse entered events.
+pub type MouseEnteredFn<Model> = fn(&App, &mut Model);
+
+/// A function for processing mouse exited events.
+pub type MouseExitedFn<Model> = fn(&App, &mut Model);
+
+/// A function for processing mouse wheel events.
+pub type MouseWheelFn<Model> = fn(&App, &mut Model, MouseScrollDelta, TouchPhase);
+
+/// A function for processing window moved events.
+pub type MovedFn<Model> = fn(&App, &mut Model, Vector2);
+
+/// A function for processing window resized events.
+pub type ResizedFn<Model> = fn(&App, &mut Model, Vector2);
+
+/// A function for processing touch events.
+pub type TouchFn<Model> = fn(&App, &mut Model, TouchEvent);
+
+/// A function for processing touchpad pressure events.
+pub type TouchpadPressureFn<Model> = fn(&App, &mut Model, TouchpadPressure);
+
+/// A function for processing hovered file events.
+pub type HoveredFileFn<Model> = fn(&App, &mut Model, PathBuf);
+
+/// A function for processing hovered file cancelled events.
+pub type HoveredFileCancelledFn<Model> = fn(&App, &mut Model);
+
+/// A function for processing dropped file events.
+pub type DroppedFileFn<Model> = fn(&App, &mut Model, PathBuf);
+
+/// A function for processing window focused events.
+pub type FocusedFn<Model> = fn(&App, &mut Model);
+
+/// A function for processing window unfocused events.
+pub type UnfocusedFn<Model> = fn(&App, &mut Model);
+
+/// A function for processing window closed events.
+pub type ClosedFn<Model> = fn(&App, &mut Model);
+
+// A macro for generating a handle to a function that can be stored within the Window without
+// requiring a type param. $TFn is the function pointer type that will be wrapped by $TFnAny.
+macro_rules! fn_any {
+    ($TFn:ident<M>, $TFnAny:ident) => {
+        // A handle to a function that can be stored without requiring a type param.
+        #[derive(Clone)]
+        pub(crate) struct $TFnAny {
+            fn_ptr: Arc<Any>
+        }
+
+        impl $TFnAny {
+            // Create the `$TFnAny` from a view function pointer.
+            pub fn from_fn_ptr<M>(fn_ptr: $TFn<M>) -> Self
+            where
+                M: 'static,
+            {
+                let fn_ptr = Arc::new(fn_ptr) as Arc<Any>;
+                $TFnAny { fn_ptr }
+            }
+        
+            // Retrieve the view function pointer from the `$TFnAny`.
+            pub fn to_fn_ptr<M>(&self) -> Option<&$TFn<M>>
+            where
+                M: 'static,
+            {
+                self.fn_ptr.downcast_ref::<$TFn<M>>()
+            }
+        }
+
+        impl fmt::Debug for $TFnAny {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "{}", stringify!($TFnAny))
+            }
+        }
+    };
+}
+
+fn_any!(ViewFn<M>, ViewFnAny);
+fn_any!(EventFn<M>, EventFnAny);
+fn_any!(RawEventFn<M>, RawEventFnAny);
+fn_any!(KeyPressedFn<M>, KeyPressedFnAny);
+fn_any!(KeyReleasedFn<M>, KeyReleasedFnAny);
+fn_any!(MouseMovedFn<M>, MouseMovedFnAny);
+fn_any!(MousePressedFn<M>, MousePressedFnAny);
+fn_any!(MouseReleasedFn<M>, MouseReleasedFnAny);
+fn_any!(MouseEnteredFn<M>, MouseEnteredFnAny);
+fn_any!(MouseExitedFn<M>, MouseExitedFnAny);
+fn_any!(MouseWheelFn<M>, MouseWheelFnAny);
+fn_any!(MovedFn<M>, MovedFnAny);
+fn_any!(ResizedFn<M>, ResizedFnAny);
+fn_any!(TouchFn<M>, TouchFnAny);
+fn_any!(TouchpadPressureFn<M>, TouchpadPressureFnAny);
+fn_any!(HoveredFileFn<M>, HoveredFileFnAny);
+fn_any!(HoveredFileCancelledFn<M>, HoveredFileCancelledFnAny);
+fn_any!(DroppedFileFn<M>, DroppedFileFnAny);
+fn_any!(FocusedFn<M>, FocusedFnAny);
+fn_any!(UnfocusedFn<M>, UnfocusedFnAny);
+fn_any!(ClosedFn<M>, ClosedFnAny);
 
 /// An OpenGL window.
 ///
@@ -46,6 +212,7 @@ pub struct Window {
     pub(crate) surface: Arc<Surface>,
     pub(crate) swapchain: Arc<WindowSwapchain>,
     pub(crate) frame_count: u64,
+    pub(crate) user_functions: UserFunctions,
     // If the user specified one of the following parameters, use these when recreating the
     // swapchain rather than our heuristics.
     pub(crate) user_specified_present_mode: Option<PresentMode>,
@@ -353,6 +520,7 @@ impl<'app> Builder<'app> {
             window: winit::WindowBuilder::new(),
             title_was_set: false,
             swapchain_builder: Default::default(),
+            user_functions: Default::default(),
         }
     }
 
@@ -374,6 +542,230 @@ impl<'app> Builder<'app> {
         self
     }
 
+    /// Provide a simple function for drawing to the window.
+    ///
+    /// This is similar to `view` but does not provide access to user data via a Model type. This
+    /// is useful for sketches where you don't require tracking any state.
+    pub fn sketch(mut self, sketch_fn: SketchFn) -> Self {
+        self.user_functions.view = Some(View::Sketch(sketch_fn));
+        self
+    }
+
+    /// The `view` function that the app will call to allow you to present your Model to the
+    /// surface of the window on your display.
+    pub fn view<M>(mut self, view_fn: ViewFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.view = Some(View::WithModel(ViewFnAny::from_fn_ptr(view_fn)));
+        self
+    }
+
+    /// A function for updating your model on `WindowEvent`s associated with this window.
+    ///
+    /// These include events such as key presses, mouse movement, clicks, resizing, etc.
+    ///
+    /// ## Event Function Call Order
+    ///
+    /// In nannou, if multiple functions require being called for a single kind of event, the more
+    /// general event function will always be called before the more specific event function.
+    ///
+    /// If an `event` function was also submitted to the `App`, that function will always be called
+    /// immediately before window-specific event functions. Similarly, if a function associated
+    /// with a more specific event type (e.g. `key_pressed`) was given, that function will be
+    /// called *after* this function will be called.
+    ///
+    /// ## Specific Events Variants
+    ///
+    /// Note that if you only care about a certain kind of event, you can submit a function that
+    /// only gets called for that specific event instead. For example, if you only care about key
+    /// presses, you may wish to use the `key_pressed` method instead.
+    pub fn event<M>(mut self, event_fn: EventFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.event = Some(EventFnAny::from_fn_ptr(event_fn));
+        self
+    }
+
+    /// The same as the `event` method, but allows for processing raw `winit::WindowEvent`s rather
+    /// than Nannou's simplified `event::WindowEvent`s.
+    ///
+    /// ## Event Function Call Order
+    ///
+    /// If both `raw_event` and `event` functions have been provided, the given `raw_event`
+    /// function will always be called immediately before the given `event` function.
+    pub fn raw_event<M>(mut self, raw_event_fn: RawEventFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.raw_event = Some(RawEventFnAny::from_fn_ptr(raw_event_fn));
+        self
+    }
+
+    /// A function for processing key press events associated with this window.
+    pub fn key_pressed<M>(mut self, f: KeyPressedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.key_pressed = Some(KeyPressedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing key release events associated with this window.
+    pub fn key_released<M>(mut self, f: KeyReleasedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.key_released = Some(KeyReleasedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing mouse moved events associated with this window.
+    pub fn mouse_moved<M>(mut self, f: MouseMovedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.mouse_moved = Some(MouseMovedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing mouse pressed events associated with this window.
+    pub fn mouse_pressed<M>(mut self, f: MousePressedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.mouse_pressed = Some(MousePressedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing mouse released events associated with this window.
+    pub fn mouse_released<M>(mut self, f: MouseReleasedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.mouse_released = Some(MouseReleasedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing mouse wheel events associated with this window.
+    pub fn mouse_wheel<M>(mut self, f: MouseWheelFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.mouse_wheel = Some(MouseWheelFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing mouse entered events associated with this window.
+    pub fn mouse_entered<M>(mut self, f: MouseEnteredFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.mouse_entered = Some(MouseEnteredFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing mouse exited events associated with this window.
+    pub fn mouse_exited<M>(mut self, f: MouseExitedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.mouse_exited = Some(MouseExitedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing touch events associated with this window.
+    pub fn touch<M>(mut self, f: TouchFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.touch = Some(TouchFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing touchpad pressure events associated with this window.
+    pub fn touchpad_pressure<M>(mut self, f: TouchpadPressureFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.touchpad_pressure = Some(TouchpadPressureFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing window moved events associated with this window.
+    pub fn moved<M>(mut self, f: MovedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.moved = Some(MovedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing window resized events associated with this window.
+    pub fn resized<M>(mut self, f: ResizedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.resized = Some(ResizedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing hovered file events associated with this window.
+    pub fn hovered_file<M>(mut self, f: HoveredFileFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.hovered_file = Some(HoveredFileFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing hovered file cancelled events associated with this window.
+    pub fn hovered_file_cancelled<M>(mut self, f: HoveredFileCancelledFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.hovered_file_cancelled =
+            Some(HoveredFileCancelledFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing dropped file events associated with this window.
+    pub fn dropped_file<M>(mut self, f: DroppedFileFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.dropped_file = Some(DroppedFileFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing the focused event associated with this window.
+    pub fn focused<M>(mut self, f: FocusedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.focused = Some(FocusedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing the unfocused event associated with this window.
+    pub fn unfocused<M>(mut self, f: UnfocusedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.unfocused = Some(UnfocusedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing the window closed event associated with this window.
+    pub fn closed<M>(mut self, f: ClosedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.closed = Some(ClosedFnAny::from_fn_ptr(f));
+        self
+    }
+
     /// Builds the window, inserts it into the `App`'s display map and returns the unique ID.
     pub fn build(self) -> Result<Id, BuildError> {
         let Builder {
@@ -382,6 +774,7 @@ impl<'app> Builder<'app> {
             mut window,
             title_was_set,
             swapchain_builder,
+            user_functions,
         } = self;
 
         // If the title was not set, default to the "nannou - <exe_name>".
@@ -507,6 +900,7 @@ impl<'app> Builder<'app> {
             surface,
             swapchain,
             frame_count,
+            user_functions,
             user_specified_present_mode,
             user_specified_image_count,
         };
@@ -530,6 +924,7 @@ impl<'app> Builder<'app> {
             window,
             title_was_set,
             swapchain_builder,
+            user_functions,
         } = self;
         let window = map(window);
         Builder {
@@ -538,6 +933,7 @@ impl<'app> Builder<'app> {
             window,
             title_was_set,
             swapchain_builder,
+            user_functions,
         }
     }
 
@@ -861,6 +1257,20 @@ impl Window {
     }
 }
 
+// Debug implementations for function wrappers.
+
+impl fmt::Debug for View {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let variant = match *self {
+            View::WithModel(ref v) => format!("WithModel({:?})", v),
+            View::Sketch(_) => "Sketch".to_string(),
+        };
+        write!(f, "View::{}", variant)
+    }
+}
+
+// Deref implementations.
+
 impl ops::Deref for WindowSwapchain {
     type Target = Arc<Swapchain>;
     fn deref(&self) -> &Self::Target {
@@ -878,6 +1288,8 @@ impl fmt::Debug for WindowSwapchain {
         )
     }
 }
+
+// Error implementations.
 
 impl StdError for BuildError {
     fn description(&self) -> &str {


### PR DESCRIPTION
An `all_functions.rs` example has been added that shows all functions
that can be registered with the app and model.

All other examples have been updated to take advantage of the new event
functions.

Functions that update the model, including the existing App `event`
function, now provide the model via `&mut` rather than by value to be
returned.

@JoshuaBatty might wanna check out all the updated NoC examples, so much nicer!