### PR TITLE
Add `Window::grab_cursor` and `Window::hide_cursor` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   matching on the raw `Event` type. This has simplified a lot of the examples.
   See the `app::Builder` and `window::Builder` docs for the newly available
   methods and more documentation.
+- Add `Window::grab_cursor` and `Window::hide_cursor` methods.
 
 # Version 0.8.0 (2018-07-19)
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1154,6 +1154,32 @@ impl Window {
         self.surface.window().set_cursor(state);
     }
 
+    /// Grabs the cursor, preventing it from leaving the window.
+    ///
+    /// ## Platform-specific
+    ///
+    /// On macOS, this presently merely locks the cursor in a fixed location, which looks visually
+    /// awkward.
+    ///
+    /// This has no effect on Android or iOS.
+    pub fn grab_cursor(&self, grab: bool) -> Result<(), String> {
+        self.surface.window().grab_cursor(grab)
+    }
+
+    /// Hides the cursor, making it invisible but still usable.
+    ///
+    /// ## Platform-specific
+    ///
+    /// On Windows and X11, the cursor is only hidden within the confines of the window.
+    ///
+    /// On macOS, the cursor is hidden as long as the window has input focus, even if the cursor is
+    /// outside of the window.
+    ///
+    /// This has no effect on Android or iOS.
+    pub fn hide_cursor(&self, hide: bool) {
+        self.surface.window().hide_cursor(hide)
+    }
+
     /// Sets the window to maximized or back.
     pub fn set_maximized(&self, maximized: bool) {
         self.surface.window().set_maximized(maximized)


### PR DESCRIPTION
These map directly to the underlying winit window methods.