### PR TITLE
Create a `SwapchainFramebuffers` type

### DIFF
--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -10,13 +10,12 @@ use nannou::vulkano::command_buffer::DynamicState;
 use nannou::vulkano::descriptor::descriptor_set::{DescriptorSet, PersistentDescriptorSet};
 use nannou::vulkano::device::DeviceOwned;
 use nannou::vulkano::format::Format;
-use nannou::vulkano::framebuffer::{
-    Framebuffer, FramebufferAbstract, FramebufferCreationError, RenderPassAbstract, Subpass,
-};
+use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
 use nannou::vulkano::image::{Dimensions, ImmutableImage};
 use nannou::vulkano::pipeline::viewport::Viewport;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 use nannou::vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
+use nannou::window::SwapchainFramebuffers;
 
 fn main() {
     nannou::app(model).run();
@@ -26,7 +25,7 @@ struct Model {
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    framebuffers: RefCell<Vec<Arc<FramebufferAbstract + Send + Sync>>>,
+    framebuffers: RefCell<SwapchainFramebuffers>,
     desciptor_set: Arc<DescriptorSet + Send + Sync>,
 }
 
@@ -143,7 +142,7 @@ fn model(app: &App) -> Model {
             .unwrap(),
     );
 
-    let framebuffers = RefCell::new(Vec::new());
+    let framebuffers = RefCell::new(SwapchainFramebuffers::default());
 
     Model {
         render_pass,
@@ -167,20 +166,10 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         scissors: None,
     };
 
-    // Update the framebuffers if necessary.
-    while frame.swapchain_image_index() >= model.framebuffers.borrow().len() {
-        let fb =
-            create_framebuffer(model.render_pass.clone(), frame.swapchain_image().clone()).unwrap();
-        model.framebuffers.borrow_mut().push(Arc::new(fb));
-    }
-
-    // If the dimensions for the current framebuffer do not match, recreate it.
-    if frame.swapchain_image_is_new() {
-        let fb = &mut model.framebuffers.borrow_mut()[frame.swapchain_image_index()];
-        let new_fb =
-            create_framebuffer(model.render_pass.clone(), frame.swapchain_image().clone()).unwrap();
-        *fb = Arc::new(new_fb);
-    }
+    // Update framebuffers so that count matches swapchain image count and dimensions match.
+    model.framebuffers.borrow_mut()
+        .update(&frame, model.render_pass.clone(), |builder, image| builder.add(image))
+        .unwrap();
 
     let clear_values = vec![[0.0, 1.0, 0.0, 1.0].into()];
 
@@ -246,14 +235,4 @@ void main() {
     f_color = texture(tex, tex_coords) + c;
 }"
     }
-}
-
-fn create_framebuffer(
-    render_pass: Arc<RenderPassAbstract + Send + Sync>,
-    swapchain_image: Arc<nannou::window::SwapchainImage>,
-) -> Result<Arc<FramebufferAbstract + Send + Sync>, FramebufferCreationError> {
-    let fb = Framebuffer::start(render_pass)
-        .add(swapchain_image)?
-        .build()?;
-    Ok(Arc::new(fb) as _)
 }

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -10,13 +10,12 @@ use nannou::vulkano::command_buffer::DynamicState;
 use nannou::vulkano::descriptor::descriptor_set::{DescriptorSet, PersistentDescriptorSet};
 use nannou::vulkano::device::DeviceOwned;
 use nannou::vulkano::format::Format;
-use nannou::vulkano::framebuffer::{
-    Framebuffer, FramebufferAbstract, FramebufferCreationError, RenderPassAbstract, Subpass,
-};
+use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
 use nannou::vulkano::image::{Dimensions, ImmutableImage};
 use nannou::vulkano::pipeline::viewport::Viewport;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 use nannou::vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
+use nannou::window::SwapchainFramebuffers;
 
 fn main() {
     nannou::app(model).run();
@@ -26,7 +25,7 @@ struct Model {
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    framebuffers: RefCell<Vec<Arc<FramebufferAbstract + Send + Sync>>>,
+    framebuffers: RefCell<SwapchainFramebuffers>,
     desciptor_set: Arc<DescriptorSet + Send + Sync>,
 }
 
@@ -160,7 +159,7 @@ fn model(app: &App) -> Model {
             .unwrap(),
     );
 
-    let framebuffers = RefCell::new(Vec::new());
+    let framebuffers = RefCell::new(SwapchainFramebuffers::default());
 
     Model {
         render_pass,
@@ -184,18 +183,10 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
         scissors: None,
     };
 
-    while frame.swapchain_image_index() >= model.framebuffers.borrow().len() {
-        let fb =
-            create_framebuffer(model.render_pass.clone(), frame.swapchain_image().clone()).unwrap();
-        model.framebuffers.borrow_mut().push(Arc::new(fb));
-    }
-
-    if frame.swapchain_image_is_new() {
-        let fb = &mut model.framebuffers.borrow_mut()[frame.swapchain_image_index()];
-        let new_fb =
-            create_framebuffer(model.render_pass.clone(), frame.swapchain_image().clone()).unwrap();
-        *fb = Arc::new(new_fb);
-    }
+    // Update framebuffers so that count matches swapchain image count and dimensions match.
+    model.framebuffers.borrow_mut()
+        .update(&frame, model.render_pass.clone(), |builder, image| builder.add(image))
+        .unwrap();
 
     let clear_values = vec![[0.0, 1.0, 0.0, 1.0].into()];
 
@@ -280,15 +271,4 @@ void main() {
     f_color = c;
 }"
     }
-}
-
-// Create the framebuffer for the image.
-fn create_framebuffer(
-    render_pass: Arc<RenderPassAbstract + Send + Sync>,
-    swapchain_image: Arc<nannou::window::SwapchainImage>,
-) -> Result<Arc<FramebufferAbstract + Send + Sync>, FramebufferCreationError> {
-    let fb = Framebuffer::start(render_pass)
-        .add(swapchain_image)?
-        .build()?;
-    Ok(Arc::new(fb) as _)
 }

--- a/examples/vulkan/vk_teapot_camera.rs
+++ b/examples/vulkan/vk_teapot_camera.rs
@@ -10,14 +10,13 @@ use nannou::vulkano::command_buffer::DynamicState;
 use nannou::vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use nannou::vulkano::device::{Device, DeviceOwned};
 use nannou::vulkano::format::Format;
-use nannou::vulkano::framebuffer::{
-    Framebuffer, FramebufferAbstract, FramebufferCreationError, RenderPassAbstract, Subpass,
-};
+use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
 use nannou::vulkano::image::attachment::AttachmentImage;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract,
                                 GraphicsPipelineCreationError};
 use nannou::vulkano::pipeline::vertex::TwoBuffersDefinition;
 use nannou::vulkano::pipeline::viewport::Viewport;
+use nannou::window::SwapchainFramebuffers;
 use std::cell::RefCell;
 use std::sync::Arc;
 
@@ -37,7 +36,7 @@ struct Graphics {
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     graphics_pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     depth_image: Arc<AttachmentImage>,
-    framebuffers: Vec<Arc<FramebufferAbstract + Send + Sync>>,
+    framebuffers: SwapchainFramebuffers,
 }
 
 // A simple first person camera.
@@ -164,7 +163,7 @@ fn model(app: &App) -> Model {
     let depth_image = AttachmentImage::transient(device.clone(), [w, h], Format::D16Unorm)
         .unwrap();
 
-    let framebuffers = Vec::new();
+    let framebuffers = SwapchainFramebuffers::default();
 
     let graphics = RefCell::new(Graphics {
         vertex_buffer,
@@ -301,25 +300,12 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
         ).unwrap();
     }
 
-    // Create new framebuffers if we don't have one for each swapchain image.
-    while frame.swapchain_image_index() >= graphics.framebuffers.len() {
-        let fb = create_framebuffer(
-            graphics.render_pass.clone(),
-            frame.swapchain_image().clone(),
-            graphics.depth_image.clone(),
-        ).unwrap();
-        graphics.framebuffers.push(Arc::new(fb));
-    }
-
-    // If the dimensions for the current framebuffer do not match, recreate it.
-    if frame.swapchain_image_is_new() {
-        let new_fb = create_framebuffer(
-            graphics.render_pass.clone(),
-            frame.swapchain_image().clone(),
-            graphics.depth_image.clone(),
-        ).unwrap();
-        graphics.framebuffers[frame.swapchain_image_index()] = Arc::new(new_fb);
-    }
+    // Update framebuffers so that count matches swapchain image count and dimensions match.
+    let render_pass = graphics.render_pass.clone();
+    let depth_image = graphics.depth_image.clone();
+    graphics.framebuffers
+        .update(&frame, render_pass, |builder, image| builder.add(image)?.add(depth_image.clone()))
+        .unwrap();
 
     // Create a uniform buffer slice with the world, view and projection matrices.
     let uniform_buffer_slice = {
@@ -405,19 +391,6 @@ fn create_graphics_pipeline(
         .render_pass(Subpass::from(render_pass.clone(), 0).unwrap())
         .build(device.clone())?;
     Ok(Arc::new(pipeline) as Arc<_>)
-}
-
-// Create the framebuffer for the image.
-fn create_framebuffer(
-    render_pass: Arc<RenderPassAbstract + Send + Sync>,
-    swapchain_image: Arc<nannou::window::SwapchainImage>,
-    depth_image: Arc<AttachmentImage>,
-) -> Result<Arc<FramebufferAbstract + Send + Sync>, FramebufferCreationError> {
-    let fb = Framebuffer::start(render_pass)
-        .add(swapchain_image)?
-        .add(depth_image)?
-        .build()?;
-    Ok(Arc::new(fb) as _)
 }
 
 // GLSL Shaders


### PR DESCRIPTION
This significantly simplifies the process of creating and maintaining
swapchain image framebuffers, currently probably the most tedious part
of using raw vulkan with nannou. See the docs for the new
`window::SwapchainFramebuffers` type and its `update` method for more
details on how it works under the hood.

This significantly simplifies the `ui` and `draw` backends, as well as
the raw vulkan examples as a result. The easiest way to see the impact
of this PR is probably to check the diff for the vk examples.

cc @JoshuaBatty should be a good start on this simplification process!