### PR TITLE
Add intermediary image to `Frame` for user graphics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,9 @@ path = "examples/basics/7_modules/7_modules.rs"
 name = "vk_triangle"
 path = "examples/vulkan/vk_triangle.rs"
 [[example]]
+name = "vk_triangle_raw_frame"
+path = "examples/vulkan/vk_triangle_raw_frame.rs"
+[[example]]
 name = "vk_teapot"
 path = "examples/vulkan/vk_teapot.rs"
 [[example]]

--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -15,7 +15,6 @@ use nannou::vulkano::image::{Dimensions, ImmutableImage};
 use nannou::vulkano::pipeline::viewport::Viewport;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 use nannou::vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
-use nannou::window::SwapchainFramebuffers;
 
 fn main() {
     nannou::app(model).run();
@@ -25,7 +24,7 @@ struct Model {
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    framebuffers: RefCell<SwapchainFramebuffers>,
+    framebuffer: RefCell<ViewFramebuffer>,
     desciptor_set: Arc<DescriptorSet + Send + Sync>,
 }
 
@@ -78,7 +77,7 @@ fn model(app: &App) -> Model {
                     load: Clear,
                     store: Store,
                     format: app.main_window().swapchain().format(),
-                    samples: 1,
+                    samples: app.main_window().msaa_samples(),
                     initial_layout: ImageLayout::PresentSrc,
                     final_layout: ImageLayout::PresentSrc,
                 }
@@ -167,13 +166,13 @@ fn model(app: &App) -> Model {
             .unwrap(),
     );
 
-    let framebuffers = RefCell::new(SwapchainFramebuffers::default());
+    let framebuffer = RefCell::new(ViewFramebuffer::default());
 
     Model {
         render_pass,
         pipeline,
         vertex_buffer,
-        framebuffers,
+        framebuffer,
         desciptor_set,
     }
 }
@@ -191,8 +190,8 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         scissors: None,
     };
 
-    // Update framebuffers so that count matches swapchain image count and dimensions match.
-    model.framebuffers.borrow_mut()
+    // Update framebuffer in case of window resize.
+    model.framebuffer.borrow_mut()
         .update(&frame, model.render_pass.clone(), |builder, image| builder.add(image))
         .unwrap();
 
@@ -206,7 +205,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     frame
         .add_commands()
         .begin_render_pass(
-            model.framebuffers.borrow()[frame.swapchain_image_index()].clone(),
+            model.framebuffer.borrow().as_ref().unwrap().clone(),
             false,
             clear_values,
         )

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -15,7 +15,6 @@ use nannou::vulkano::image::{Dimensions, ImmutableImage};
 use nannou::vulkano::pipeline::viewport::Viewport;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 use nannou::vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
-use nannou::window::SwapchainFramebuffers;
 
 fn main() {
     nannou::app(model).run();
@@ -25,7 +24,7 @@ struct Model {
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    framebuffers: RefCell<SwapchainFramebuffers>,
+    framebuffer: RefCell<ViewFramebuffer>,
     desciptor_set: Arc<DescriptorSet + Send + Sync>,
 }
 
@@ -78,7 +77,7 @@ fn model(app: &App) -> Model {
                     load: Clear,
                     store: Store,
                     format: app.main_window().swapchain().format(),
-                    samples: 1,
+                    samples: app.main_window().msaa_samples(),
                     initial_layout: ImageLayout::PresentSrc,
                     final_layout: ImageLayout::PresentSrc,
                 }
@@ -159,13 +158,13 @@ fn model(app: &App) -> Model {
             .unwrap(),
     );
 
-    let framebuffers = RefCell::new(SwapchainFramebuffers::default());
+    let framebuffer = RefCell::new(ViewFramebuffer::default());
 
     Model {
         render_pass,
         pipeline,
         vertex_buffer,
-        framebuffers,
+        framebuffer,
         desciptor_set,
     }
 }
@@ -183,8 +182,8 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
         scissors: None,
     };
 
-    // Update framebuffers so that count matches swapchain image count and dimensions match.
-    model.framebuffers.borrow_mut()
+    // Update framebuffer in case of window resize.
+    model.framebuffer.borrow_mut()
         .update(&frame, model.render_pass.clone(), |builder, image| builder.add(image))
         .unwrap();
 
@@ -193,7 +192,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     frame
         .add_commands()
         .begin_render_pass(
-            model.framebuffers.borrow()[frame.swapchain_image_index()].clone(),
+            model.framebuffer.borrow().as_ref().unwrap().clone(),
             false,
             clear_values,
         )

--- a/examples/vulkan/vk_teapot.rs
+++ b/examples/vulkan/vk_teapot.rs
@@ -16,7 +16,6 @@ use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract,
                                 GraphicsPipelineCreationError};
 use nannou::vulkano::pipeline::vertex::TwoBuffersDefinition;
 use nannou::vulkano::pipeline::viewport::Viewport;
-use nannou::window::SwapchainFramebuffers;
 use std::cell::RefCell;
 use std::sync::Arc;
 
@@ -38,7 +37,7 @@ struct Graphics {
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     graphics_pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     depth_image: Arc<AttachmentImage>,
-    framebuffers: SwapchainFramebuffers,
+    framebuffer: ViewFramebuffer,
 }
 
 #[derive(Copy, Clone)]
@@ -93,7 +92,7 @@ fn model(app: &App) -> Model {
                     load: Clear,
                     store: Store,
                     format: app.main_window().swapchain().format(),
-                    samples: 1,
+                    samples: app.main_window().msaa_samples(),
                     initial_layout: ImageLayout::PresentSrc,
                     final_layout: ImageLayout::PresentSrc,
                 },
@@ -101,7 +100,7 @@ fn model(app: &App) -> Model {
                     load: Clear,
                     store: DontCare,
                     format: Format::D16Unorm,
-                    samples: 1,
+                    samples: app.main_window().msaa_samples(),
                 }
             },
             pass: {
@@ -121,10 +120,14 @@ fn model(app: &App) -> Model {
         [w as f32, h as f32],
     ).unwrap();
 
-    let depth_image = AttachmentImage::transient(device.clone(), [w, h], Format::D16Unorm)
-        .unwrap();
+    let depth_image = AttachmentImage::transient_multisampled(
+        device.clone(),
+        [w, h],
+        app.main_window().msaa_samples(),
+        Format::D16Unorm,
+    ).unwrap();
 
-    let framebuffers = SwapchainFramebuffers::default();
+    let framebuffer = ViewFramebuffer::default();
 
     let graphics = RefCell::new(Graphics {
         vertex_buffer,
@@ -136,7 +139,7 @@ fn model(app: &App) -> Model {
         render_pass,
         graphics_pipeline,
         depth_image,
-        framebuffers,
+        framebuffer,
     });
 
     Model { graphics }
@@ -159,17 +162,18 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
             [w as f32, h as f32],
         ).unwrap();
 
-        graphics.depth_image = AttachmentImage::transient(
+        graphics.depth_image = AttachmentImage::transient_multisampled(
             device.clone(),
             [w, h],
+            frame.image_msaa_samples(),
             Format::D16Unorm,
         ).unwrap();
     }
 
-    // Update framebuffers so that count matches swapchain image count and dimensions match.
+    // Update framebuffer so that count matches swapchain image count and dimensions match.
     let render_pass = graphics.render_pass.clone();
     let depth_image = graphics.depth_image.clone();
-    graphics.framebuffers
+    graphics.framebuffer
         .update(&frame, render_pass, |builder, image| builder.add(image)?.add(depth_image.clone()))
         .unwrap();
 
@@ -218,7 +222,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     frame
         .add_commands()
         .begin_render_pass(
-            graphics.framebuffers[frame.swapchain_image_index()].clone(),
+            graphics.framebuffer.as_ref().unwrap().clone(),
             false,
             clear_values,
         )

--- a/examples/vulkan/vk_triangle.rs
+++ b/examples/vulkan/vk_triangle.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use nannou::vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use nannou::vulkano::command_buffer::DynamicState;
 use nannou::vulkano::device::DeviceOwned;
-use nannou::vulkano::framebuffer::{Framebuffer, FramebufferAbstract, RenderPassAbstract, Subpass};
+use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
 use nannou::vulkano::pipeline::viewport::Viewport;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -936,8 +936,13 @@ impl App {
         let draw = self.draw_state.draw.borrow_mut();
         draw.reset();
         if self.draw_state.renderer.borrow().is_none() {
-            let renderer = draw::backend::vulkano::Renderer::new(device, color_format, DEPTH_FORMAT)
-                .expect("failed to create `Draw` renderer for vulkano backend");
+            let msaa_samples = window.msaa_samples();
+            let renderer = draw::backend::vulkano::Renderer::new(
+                device,
+                color_format,
+                DEPTH_FORMAT,
+                msaa_samples,
+            ).expect("failed to create `Draw` renderer for vulkano backend");
             *self.draw_state.renderer.borrow_mut() = Some(RefCell::new(renderer));
         }
         let renderer = self.draw_state.renderer.borrow_mut();

--- a/src/draw/backend/vulkano.rs
+++ b/src/draw/backend/vulkano.rs
@@ -2,6 +2,7 @@
 
 use draw;
 use frame::Frame;
+use gpu;
 use math::{BaseFloat, NumCast};
 use std::error::Error as StdError;
 use std::fmt;
@@ -553,10 +554,7 @@ where
 /// The target is 4, but we fall back to the limit if its lower.
 pub fn msaa_samples(physical_device: &PhysicalDevice) -> u32 {
     const TARGET_SAMPLES: u32 = 4;
-    let color = physical_device.limits().framebuffer_color_sample_counts();
-    let depth = physical_device.limits().framebuffer_depth_sample_counts();
-    let limit = std::cmp::min(color, depth);
-    std::cmp::min(limit, TARGET_SAMPLES)
+    gpu::msaa_samples_limited(physical_device, TARGET_SAMPLES)
 }
 
 // Error Implementations

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -1,0 +1,391 @@
+//! Items related to the **Frame** type, describing a single frame of graphics for a single window.
+
+use draw::properties::color::IntoRgba;
+use std::error::Error as StdError;
+use std::{fmt, ops};
+use std::sync::Arc;
+use vulkano;
+use vulkano::command_buffer::BeginRenderPassError;
+use vulkano::device::{Device, DeviceOwned};
+use vulkano::format::{ClearValue, Format};
+use vulkano::framebuffer::{FramebufferCreationError, RenderPassAbstract, RenderPassCreationError};
+use vulkano::image::{AttachmentImage, ImageCreationError, ImageUsage};
+use window::SwapchainFramebuffers;
+
+pub mod raw;
+
+pub use self::raw::{AddCommands, RawFrame};
+
+/// A **Frame** to which the user can draw graphics before it is presented to the display.
+///
+/// **Frame**s are delivered to the user for drawing via the user's **view** function.
+///
+/// See the **RawFrame** docs for more details on how the implementation works under the hood. The
+/// **Frame** type differs in that rather than drawing directly to the swapchain image the user may
+/// draw to an intermediary image. There are several advantages of drawing to an intermediary
+/// image.
+pub struct Frame {
+    raw_frame: RawFrame,
+    data: RenderData,
+}
+
+/// Data necessary for rendering the **Frame**'s `image` to the the `swapchain_image` of the inner
+/// raw frame.
+pub(crate) struct RenderData {
+    render_pass: Arc<RenderPassAbstract + Send + Sync>,
+    // The intermediary image to which the user will draw.
+    //
+    // The number of multisampling samples may be specified by the user when constructing the
+    // window with which the `Frame` is associated.
+    intermediary_image: Arc<AttachmentImage>,
+    intermediary_image_is_new: bool,
+    swapchain_framebuffers: SwapchainFramebuffers,
+}
+
+/// Errors that might occur during creation of the `RenderData` for a frame.
+#[derive(Debug)]
+pub enum RenderDataCreationError {
+    RenderPassCreation(RenderPassCreationError),
+    ImageCreation(ImageCreationError),
+}
+
+/// Errors that might occur during creation of the `Frame`.
+#[derive(Debug)]
+pub enum FrameCreationError {
+    ImageCreation(ImageCreationError),
+    FramebufferCreation(FramebufferCreationError),
+}
+
+/// Errors that might occur during `Frame::finish`.
+#[derive(Debug)]
+pub enum FrameFinishError {
+    BeginRenderPass(BeginRenderPassError),
+}
+
+impl Frame {
+    /// The default number of multisample anti-aliasing samples used if the window with which the
+    /// `Frame` is associated supports it.
+    pub const DEFAULT_MSAA_SAMPLES: u32 = 4;
+
+    /// Initialise a new empty frame ready for "drawing".
+    pub(crate) fn new_empty(
+        raw_frame: RawFrame,
+        mut data: RenderData,
+    ) -> Result<Self, FrameCreationError> {
+        // If the image dimensions differ to that of the swapchain image, recreate it.
+        let image_dims = raw_frame.swapchain_image().dimensions();
+
+        if AttachmentImage::dimensions(&data.intermediary_image) != image_dims {
+            let msaa_samples = vulkano::image::ImageAccess::samples(&data.intermediary_image);
+            data.intermediary_image = create_intermediary_image(
+                raw_frame.swapchain_image().swapchain().device().clone(),
+                image_dims,
+                msaa_samples,
+                raw_frame.swapchain_image().swapchain().format(),
+            )?;
+            data.intermediary_image_is_new = true;
+        }
+
+        {
+            let RenderData {
+                ref mut swapchain_framebuffers,
+                ref intermediary_image,
+                ref render_pass,
+                ..
+            } = data;
+
+            // Ensure framebuffers are up to date with the frame's swapchain image and render pass.
+            swapchain_framebuffers.update(&raw_frame, render_pass.clone(), |builder, image| {
+                builder.add(intermediary_image.clone())?.add(image)
+            })?;
+        }
+
+        Ok(Frame { raw_frame, data })
+    }
+
+    /// Called after the user's `view` function returns, this consumes the `Frame`, adds commands
+    /// for drawing the `intermediary_image` to the `swapchain_image` and returns the inner
+    /// `RenderData` and `RawFrame` so that the `RenderData` may be stored back within the `Window`
+    /// and the `RawFrame` may be `finish`ed.
+    pub(crate) fn finish(self) -> Result<(RenderData, RawFrame), FrameFinishError> {
+        let Frame { mut data, raw_frame } = self;
+
+        // The framebuffer for the current swapchain image.
+        let framebuffer = data.swapchain_framebuffers[raw_frame.swapchain_image_index()].clone();
+
+        // Neither the intermediary image nor swapchain image require clearing upon load.
+        let clear_values = vec![ClearValue::None, ClearValue::None];
+        let is_secondary = false;
+
+        raw_frame
+            .add_commands()
+            .begin_render_pass(framebuffer, is_secondary, clear_values)?
+            .end_render_pass()
+            .expect("failed to add `end_render_pass` command");
+
+        // The intermediary image is no longer "new".
+        data.intermediary_image_is_new = false;
+
+        Ok((data, raw_frame))
+    }
+
+    /// The image to which all graphics should be drawn this frame.
+    ///
+    /// After the **view** function returns, this image will be resolved to the swapchain image for
+    /// this frame and then that swapchain image will be presented to the screen.
+    pub fn image(&self) -> &Arc<AttachmentImage> {
+        &self.data.intermediary_image
+    }
+
+    /// If the **Frame**'s image is new because it is the first frame or because it was recently
+    /// recreated to match the dimensions of the window's swapchain, this will return `true`.
+    ///
+    /// This is useful for determining whether or not a user's framebuffer might need
+    /// reconstruction in the case that it targets the frame's image.
+    pub fn image_is_new(&self) -> bool {
+        self.raw_frame.nth() == 0 || self.data.intermediary_image_is_new
+    }
+
+    /// Clear the image with the given color.
+    pub fn clear<C>(&self, color: C)
+    where
+        C: IntoRgba<f32>,
+    {
+        let rgba = color.into_rgba();
+        let value = ClearValue::Float([rgba.red, rgba.green, rgba.blue, rgba.alpha]);
+        let image = self.data.intermediary_image.clone();
+        self.add_commands()
+            .clear_color_image(image, value)
+            .expect("failed to submit `clear_color_image` command");
+    }
+}
+
+impl RenderData {
+    /// Initialise the render data.
+    ///
+    /// Creates an `AttachmentImage` with the given parameters.
+    ///
+    /// If `msaa_samples` is greater than 1 a `multisampled` image will be created. Otherwise the
+    /// a regular non-multisampled image will be created.
+    pub(crate) fn new(
+        device: Arc<Device>,
+        dimensions: [u32; 2],
+        msaa_samples: u32,
+        format: Format,
+    ) -> Result<Self, RenderDataCreationError> {
+        let render_pass = create_render_pass(device.clone(), format, msaa_samples)?;
+        let intermediary_image = create_intermediary_image(device, dimensions, msaa_samples, format)?;
+        let swapchain_framebuffers = Default::default();
+        let intermediary_image_is_new = true;
+        Ok(RenderData {
+            render_pass,
+            intermediary_image,
+            swapchain_framebuffers,
+            intermediary_image_is_new,
+        })
+    }
+}
+
+impl ops::Deref for Frame {
+    type Target = RawFrame;
+    fn deref(&self) -> &Self::Target {
+        &self.raw_frame
+    }
+}
+
+impl From<RenderPassCreationError> for RenderDataCreationError {
+    fn from(err: RenderPassCreationError) -> Self {
+        RenderDataCreationError::RenderPassCreation(err)
+    }
+}
+
+impl From<ImageCreationError> for RenderDataCreationError {
+    fn from(err: ImageCreationError) -> Self {
+        RenderDataCreationError::ImageCreation(err)
+    }
+}
+
+impl From<ImageCreationError> for FrameCreationError {
+    fn from(err: ImageCreationError) -> Self {
+        FrameCreationError::ImageCreation(err)
+    }
+}
+
+impl From<FramebufferCreationError> for FrameCreationError {
+    fn from(err: FramebufferCreationError) -> Self {
+        FrameCreationError::FramebufferCreation(err)
+    }
+}
+
+impl From<BeginRenderPassError> for FrameFinishError {
+    fn from(err: BeginRenderPassError) -> Self {
+        FrameFinishError::BeginRenderPass(err)
+    }
+}
+
+impl StdError for RenderDataCreationError {
+    fn description(&self) -> &str {
+        match *self {
+            RenderDataCreationError::RenderPassCreation(ref err) => err.description(),
+            RenderDataCreationError::ImageCreation(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            RenderDataCreationError::RenderPassCreation(ref err) => Some(err),
+            RenderDataCreationError::ImageCreation(ref err) => Some(err),
+        }
+    }
+}
+
+impl StdError for FrameCreationError {
+    fn description(&self) -> &str {
+        match *self {
+            FrameCreationError::ImageCreation(ref err) => err.description(),
+            FrameCreationError::FramebufferCreation(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            FrameCreationError::ImageCreation(ref err) => Some(err),
+            FrameCreationError::FramebufferCreation(ref err) => Some(err),
+        }
+    }
+}
+
+impl StdError for FrameFinishError {
+    fn description(&self) -> &str {
+        match *self {
+            FrameFinishError::BeginRenderPass(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            FrameFinishError::BeginRenderPass(ref err) => Some(err),
+        }
+    }
+}
+
+impl fmt::Display for RenderDataCreationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl fmt::Display for FrameCreationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl fmt::Display for FrameFinishError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl fmt::Debug for RenderData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "RenderData")
+    }
+}
+
+// A function to simplify creating the `AttachmentImage` used as the intermediary image render
+// target.
+//
+// If `msaa_samples` is 0 or 1, a non-multisampled image will be created.
+fn create_intermediary_image(
+    device: Arc<Device>,
+    dimensions: [u32; 2],
+    msaa_samples: u32,
+    format: Format,
+) -> Result<Arc<AttachmentImage>, ImageCreationError> {
+    let usage = ImageUsage {
+        transfer_source: true,
+        transfer_destination: true,
+        color_attachment: true,
+        //sampled: true,
+        ..ImageUsage::none()
+    };
+    match msaa_samples {
+        0 | 1 => AttachmentImage::with_usage(device, dimensions, format, usage),
+        _ => {
+            AttachmentImage::multisampled_with_usage(
+                device,
+                dimensions,
+                msaa_samples,
+                format,
+                usage,
+            )
+        },
+    }
+}
+
+// Create the render pass for drawing the intermediary image to the swapchain image.
+fn create_render_pass(
+    device: Arc<Device>,
+    color_format: Format,
+    msaa_samples: u32,
+) -> Result<Arc<RenderPassAbstract + Send + Sync>, RenderPassCreationError> {
+    match msaa_samples {
+        // Render pass without multisampling.
+        0 | 1 => {
+            let rp = single_pass_renderpass!(
+                device,
+                attachments: {
+                    intermediary_color: {
+                        load: Load,
+                        store: Store,
+                        format: color_format,
+                        samples: 1,
+                    },
+                    swapchain_color: {
+                        load: DontCare,
+                        store: Store,
+                        format: color_format,
+                        samples: 1,
+                        initial_layout: ImageLayout::PresentSrc,
+                        final_layout: ImageLayout::PresentSrc,
+                    }
+                },
+                pass: {
+                    color: [swapchain_color],
+                    depth_stencil: {}
+                }
+            )?;
+            Ok(Arc::new(rp) as Arc<RenderPassAbstract + Send + Sync>)
+        }
+
+        // Renderpass with multisampling.
+        _ => {
+            let rp = single_pass_renderpass!(
+                device,
+                attachments: {
+                    intermediary_color: {
+                        load: Load,
+                        store: Store,
+                        format: color_format,
+                        samples: msaa_samples,
+                    },
+                    swapchain_color: {
+                        load: DontCare,
+                        store: Store,
+                        format: color_format,
+                        samples: 1,
+                        initial_layout: ImageLayout::PresentSrc,
+                        final_layout: ImageLayout::PresentSrc,
+                    }
+                },
+                pass: {
+                    color: [intermediary_color],
+                    depth_stencil: {}
+                    resolve: [swapchain_color],
+                }
+            )?;
+            Ok(Arc::new(rp) as Arc<RenderPassAbstract + Send + Sync>)
+        }
+    }
+}

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -85,7 +85,7 @@ pub enum FrameFinishError {
 impl Frame {
     /// The default number of multisample anti-aliasing samples used if the window with which the
     /// `Frame` is associated supports it.
-    pub const DEFAULT_MSAA_SAMPLES: u32 = 4;
+    pub const DEFAULT_MSAA_SAMPLES: u32 = 8;
 
     /// Initialise a new empty frame ready for "drawing".
     pub(crate) fn new_empty(
@@ -164,6 +164,16 @@ impl Frame {
     /// reconstruction in the case that it targets the frame's image.
     pub fn image_is_new(&self) -> bool {
         self.raw_frame.nth() == 0 || self.data.intermediary_image_is_new
+    }
+
+    /// The color format of the `Frame`'s intermediary image.
+    pub fn image_format(&self) -> Format {
+        vulkano::image::ImageAccess::format(self.image())
+    }
+
+    /// The number of MSAA samples of the `Frame`'s intermediary image.
+    pub fn image_msaa_samples(&self) -> u32 {
+        vulkano::image::ImageAccess::samples(self.image())
     }
 
     /// Clear the image with the given color.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod color;
 pub mod draw;
 pub mod ease;
 pub mod event;
-mod frame;
+pub mod frame;
 pub mod geom;
 pub mod gpu;
 pub mod image;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,7 +7,7 @@ pub use color::{Hsl, Hsla, Hsv, Hsva, Rgb, Rgba};
 pub use event::WindowEvent::*;
 pub use event::{AxisMotion, Event, Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase,
                 TouchpadPressure, Update, WindowEvent};
-pub use frame::{Frame, RawFrame};
+pub use frame::{Frame, RawFrame, ViewFramebuffer};
 pub use geom::{
     self, pt2, pt3, vec2, vec3, vec4, Cuboid, Point2, Point3, Rect, Vector2, Vector3, Vector4,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,7 +7,7 @@ pub use color::{Hsl, Hsla, Hsv, Hsva, Rgb, Rgba};
 pub use event::WindowEvent::*;
 pub use event::{AxisMotion, Event, Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase,
                 TouchpadPressure, Update, WindowEvent};
-pub use frame::Frame;
+pub use frame::{Frame, RawFrame};
 pub use geom::{
     self, pt2, pt3, vec2, vec3, vec4, Cuboid, Point2, Point3, Rect, Vector2, Vector3, Vector4,
 };

--- a/src/window.rs
+++ b/src/window.rs
@@ -3,7 +3,7 @@
 
 use app::LoopMode;
 use event::{Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase, TouchpadPressure, WindowEvent};
-use frame::Frame;
+use frame::{self, Frame, RawFrame};
 use geom;
 use geom::{Point2, Vector2};
 use gpu;
@@ -44,6 +44,7 @@ pub struct Builder<'app> {
     title_was_set: bool,
     swapchain_builder: SwapchainBuilder,
     user_functions: UserFunctions,
+    msaa_samples: Option<u32>,
 }
 
 /// For storing all user functions within the window.
@@ -75,6 +76,12 @@ pub(crate) struct UserFunctions {
 /// The user function type for drawing their model to the surface of a single window.
 pub type ViewFn<Model> = fn(&App, &Model, Frame) -> Frame;
 
+/// The user function type for drawing their model to the surface of a single window.
+///
+/// Unlike the `ViewFn`, the `RawViewFn` is designed for drawing directly to a window's swapchain
+/// images rather than to a convenient intermediary image.
+pub type RawViewFn<Model> = fn(&App, &Model, RawFrame) -> RawFrame;
+
 /// The same as `ViewFn`, but provides no user model to draw from.
 ///
 /// Useful for simple, stateless sketching.
@@ -84,6 +91,7 @@ pub type SketchFn = fn(&App, Frame) -> Frame;
 #[derive(Clone)]
 pub(crate) enum View {
     WithModel(ViewFnAny),
+    WithModelRaw(RawViewFnAny),
     Sketch(SketchFn),
 }
 
@@ -185,6 +193,7 @@ macro_rules! fn_any {
 }
 
 fn_any!(ViewFn<M>, ViewFnAny);
+fn_any!(RawViewFn<M>, RawViewFnAny);
 fn_any!(EventFn<M>, EventFnAny);
 fn_any!(RawEventFn<M>, RawEventFnAny);
 fn_any!(KeyPressedFn<M>, KeyPressedFnAny);
@@ -215,6 +224,8 @@ pub struct Window {
     pub(crate) queue: Arc<device::Queue>,
     pub(crate) surface: Arc<Surface>,
     pub(crate) swapchain: Arc<WindowSwapchain>,
+    // Data for rendering a `Frame`'s intermediary image to a swapchain image.
+    pub(crate) frame_render_data: Option<frame::RenderData>,
     pub(crate) frame_count: u64,
     pub(crate) user_functions: UserFunctions,
     // If the user specified one of the following parameters, use these when recreating the
@@ -297,7 +308,7 @@ impl SwapchainFramebuffers {
     /// Ensure the framebuffers are up to date with the render pass and frame's swapchain image.
     pub fn update<F, A>(
         &mut self,
-        frame: &Frame,
+        frame: &RawFrame,
         render_pass: Arc<RenderPassAbstract + Send + Sync>,
         builder: F,
     ) -> Result<(), FramebufferCreationError>
@@ -347,6 +358,7 @@ pub enum BuildError {
     DeviceCreation(vulkano::device::DeviceCreationError),
     SwapchainCreation(SwapchainCreationError),
     SwapchainCapabilities(vulkano::swapchain::CapabilitiesError),
+    RenderDataCreation(frame::RenderDataCreationError),
     SurfaceDoesNotSupportCompositeAlphaOpaque,
 }
 
@@ -605,6 +617,7 @@ impl<'app> Builder<'app> {
             title_was_set: false,
             swapchain_builder: Default::default(),
             user_functions: Default::default(),
+            msaa_samples: None,
         }
     }
 
@@ -626,6 +639,33 @@ impl<'app> Builder<'app> {
         self
     }
 
+    /// Specify the number of samples per pixel for the multisample anti-aliasing render pass.
+    ///
+    /// If `msaa_samples` is unspecified, the first default value that nannou will attempt to use
+    /// can be found via the `Frame::DEFAULT_MSAA_SAMPLES` constant. If however this value is not
+    /// supported by the window's swapchain, nannou will fallback to the next smaller power of 2
+    /// that is supported. If MSAA is not supported at all, then the default will be 1.
+    ///
+    /// **Note:** This parameter has no meaning if the window uses a **raw_view** function for
+    /// rendering graphics to the window rather than a **view** function. This is because the
+    /// **raw_view** function provides a **RawFrame** with direct access to the swapchain image
+    /// itself and thus must manage their own MSAA pass.
+    ///
+    /// On the other hand, the `view` function provides the `Frame` type which allows the user to
+    /// render to a multisampled intermediary image allowing Nannou to take care of resolving the
+    /// multisampled image to the swapchain image. In order to avoid confusion, The `Window::build`
+    /// method will `panic!` if the user tries to specify `msaa_samples` as well as a `raw_view`
+    /// method.
+    ///
+    /// *TODO: Perhaps it would be worth adding two separate methods for specifying msaa samples.
+    /// One for forcing a certain number of samples and returning an error otherwise, and another
+    /// for attempting to use the given number of samples but falling back to a supported value in
+    /// the case that the specified number is not supported.*
+    pub fn msaa_samples(mut self, msaa_samples: u32) -> Self {
+        self.msaa_samples = Some(msaa_samples);
+        self
+    }
+
     /// Provide a simple function for drawing to the window.
     ///
     /// This is similar to `view` but does not provide access to user data via a Model type. This
@@ -635,13 +675,27 @@ impl<'app> Builder<'app> {
         self
     }
 
-    /// The `view` function that the app will call to allow you to present your Model to the
+    /// The **view** function that the app will call to allow you to present your Model to the
     /// surface of the window on your display.
     pub fn view<M>(mut self, view_fn: ViewFn<M>) -> Self
     where
         M: 'static,
     {
         self.user_functions.view = Some(View::WithModel(ViewFnAny::from_fn_ptr(view_fn)));
+        self
+    }
+
+    /// The **view** function that the app will call to allow you to present your Model to the
+    /// surface of the window on your display.
+    ///
+    /// Unlike the **ViewFn**, the **RawViewFn** provides a **RawFrame** that is designed for
+    /// drawing directly to a window's swapchain images, rather than to a convenient intermediary
+    /// image.
+    pub fn raw_view<M>(mut self, raw_view_fn: RawViewFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.view = Some(View::WithModelRaw(RawViewFnAny::from_fn_ptr(raw_view_fn)));
         self
     }
 
@@ -859,6 +913,7 @@ impl<'app> Builder<'app> {
             title_was_set,
             swapchain_builder,
             user_functions,
+            msaa_samples,
         } = self;
 
         // If the title was not set, default to the "nannou - <exe_name>".
@@ -967,6 +1022,23 @@ impl<'app> Builder<'app> {
             )?
         };
 
+        // If we're using an intermediary image for rendering frames to swapchain images, create
+        // the necessary render data.
+        let frame_render_data = match user_functions.view {
+            Some(View::WithModel(_)) | Some(View::Sketch(_)) | None => {
+                let target_msaa_samples = msaa_samples.unwrap_or(Frame::DEFAULT_MSAA_SAMPLES);
+                let msaa_samples = gpu::msaa_samples_limited(&physical_device, target_msaa_samples);
+                let render_data = frame::RenderData::new(
+                    device.clone(),
+                    swapchain.dimensions(),
+                    msaa_samples,
+                    swapchain.format(),
+                )?;
+                Some(render_data)
+            }
+            Some(View::WithModelRaw(_)) => None,
+        };
+
         let window_id = surface.window().id();
         let needs_recreation = AtomicBool::new(false);
         let previous_frame_end = Mutex::new(None);
@@ -982,6 +1054,7 @@ impl<'app> Builder<'app> {
             queue,
             surface,
             swapchain,
+            frame_render_data,
             frame_count,
             user_functions,
             user_specified_present_mode,
@@ -1008,6 +1081,7 @@ impl<'app> Builder<'app> {
             title_was_set,
             swapchain_builder,
             user_functions,
+            msaa_samples,
         } = self;
         let window = map(window);
         Builder {
@@ -1017,6 +1091,7 @@ impl<'app> Builder<'app> {
             title_was_set,
             swapchain_builder,
             user_functions,
+            msaa_samples,
         }
     }
 
@@ -1324,26 +1399,7 @@ impl Window {
 
     // Custom methods.
 
-    /// Attempts to determine whether or not the window is currently fullscreen.
-    ///
-    /// TODO: This currently relies on comparing `outer_size_pixels` to the dimensions of the
-    /// `current_monitor`, which may not be exactly accurate on some platforms or even conceptually
-    /// correct in the case that a title bar is included or something. This should probably be a
-    /// method upstream within the `winit` crate itself. Alternatively we could attempt to manually
-    /// track whether or not the window is fullscreen ourselves, however this could get quite
-    /// complicated quite quickly.
-    pub fn is_fullscreen(&self) -> bool {
-        let (w, h) = self.outer_size_pixels();
-        let (mw, mh): (u32, u32) = self.current_monitor().get_dimensions().into();
-        w == mw && h == mh
-    }
-
-    /// The number of times `view` has been called with a `Frame` for this window.
-    pub fn elapsed_frames(&self) -> u64 {
-        self.frame_count
-    }
-
-    /// A utility function to simplify the recreation of a swapchain.
+    // A utility function to simplify the recreation of a swapchain.
     pub(crate) fn replace_swapchain(
         &mut self,
         new_swapchain: Arc<Swapchain>,
@@ -1362,6 +1418,26 @@ impl Window {
             images: new_images,
             previous_frame_end: Mutex::new(previous_frame_end),
         });
+        // TODO: Update frame_render_data?
+    }
+
+    /// Attempts to determine whether or not the window is currently fullscreen.
+    ///
+    /// TODO: This currently relies on comparing `outer_size_pixels` to the dimensions of the
+    /// `current_monitor`, which may not be exactly accurate on some platforms or even conceptually
+    /// correct in the case that a title bar is included or something. This should probably be a
+    /// method upstream within the `winit` crate itself. Alternatively we could attempt to manually
+    /// track whether or not the window is fullscreen ourselves, however this could get quite
+    /// complicated quite quickly.
+    pub fn is_fullscreen(&self) -> bool {
+        let (w, h) = self.outer_size_pixels();
+        let (mw, mh): (u32, u32) = self.current_monitor().get_dimensions().into();
+        w == mw && h == mh
+    }
+
+    /// The number of times `view` has been called with a `Frame` for this window.
+    pub fn elapsed_frames(&self) -> u64 {
+        self.frame_count
     }
 }
 
@@ -1371,6 +1447,7 @@ impl fmt::Debug for View {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let variant = match *self {
             View::WithModel(ref v) => format!("WithModel({:?})", v),
+            View::WithModelRaw(ref v) => format!("WithModelRaw({:?})", v),
             View::Sketch(_) => "Sketch".to_string(),
         };
         write!(f, "View::{}", variant)
@@ -1406,6 +1483,7 @@ impl StdError for BuildError {
             BuildError::DeviceCreation(ref err) => err.description(),
             BuildError::SwapchainCreation(ref err) => err.description(),
             BuildError::SwapchainCapabilities(ref err) => err.description(),
+            BuildError::RenderDataCreation(ref err) => err.description(),
             BuildError::SurfaceDoesNotSupportCompositeAlphaOpaque =>
                 "`CompositeAlpha::Opaque` not supported by window surface",
         }
@@ -1439,5 +1517,11 @@ impl From<vulkano::swapchain::SwapchainCreationError> for BuildError {
 impl From<vulkano::swapchain::CapabilitiesError> for BuildError {
     fn from(e: vulkano::swapchain::CapabilitiesError) -> Self {
         BuildError::SwapchainCapabilities(e)
+    }
+}
+
+impl From<frame::RenderDataCreationError> for BuildError {
+    fn from(e: frame::RenderDataCreationError) -> Self {
+        BuildError::RenderDataCreation(e)
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,6 +18,7 @@ use vulkano::device::{self, Device};
 use vulkano::format::Format;
 use vulkano::framebuffer::{AttachmentsList, Framebuffer, FramebufferAbstract, FramebufferBuilder,
                            FramebufferCreationError, RenderPassAbstract};
+use vulkano::image::ImageAccess;
 use vulkano::instance::PhysicalDevice;
 use vulkano::swapchain::{ColorSpace, CompositeAlpha, PresentMode, SupportedPresentModes,
                          SurfaceTransform, SwapchainCreationError};
@@ -301,8 +302,8 @@ pub struct SwapchainFramebuffers {
     framebuffers: Vec<Arc<FramebufferAbstract + Send + Sync>>,
 }
 
-type SwapchainFramebufferBuilder<A> = FramebufferBuilder<Arc<RenderPassAbstract + Send + Sync>, A>;
-type FramebufferBuildResult<A> = Result<SwapchainFramebufferBuilder<A>, FramebufferCreationError>;
+pub type SwapchainFramebufferBuilder<A> = FramebufferBuilder<Arc<RenderPassAbstract + Send + Sync>, A>;
+pub type FramebufferBuildResult<A> = Result<SwapchainFramebufferBuilder<A>, FramebufferCreationError>;
 
 impl SwapchainFramebuffers {
     /// Ensure the framebuffers are up to date with the render pass and frame's swapchain image.
@@ -1395,6 +1396,18 @@ impl Window {
     /// and its images may be recreated at any moment in time.
     pub fn swapchain_images(&self) -> &[Arc<SwapchainImage>] {
         &self.swapchain.images
+    }
+
+    /// The number of samples used in the MSAA for the image associated with the `view` function's
+    /// `Frame` type.
+    ///
+    /// **Note:** If the user specified a `raw_view` function rather than a `view` function, this
+    /// value will always return `1`.
+    pub fn msaa_samples(&self) -> u32 {
+        self.frame_render_data
+            .as_ref()
+            .map(|d| d.intermediary_image.samples())
+            .unwrap_or(1)
     }
 
     // Custom methods.


### PR DESCRIPTION
This new `Frame` image acts as an intermediary buffer between the user's
graphics and the swapchain image for presentation.

See #224 for more details.

This is a **WIP** as the `draw` and `ui` graphics interop have not been
updated to account for the updated `Frame` type. Many of the `vk_*`
examples also still require updating.