### PR TITLE
Remove `state::time::Duration` in favour of a `time::DurationF64` trait.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   methods and more documentation.
 - Add `Window::grab_cursor` and `Window::hide_cursor` methods.
 - Add `window::SwapchainFramebuffers` helper type.
+- Remove the `state::time::Duration` type in favour of a `DurationF64` trait.
 
 # Version 0.8.0 (2018-07-19)
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,7 @@ use std::sync::atomic::{self, AtomicBool};
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::{Duration, Instant};
+use time::DurationF64;
 use ui;
 use vulkano;
 use vulkano::device::DeviceOwned;

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,7 +6,6 @@
 //!   newcomer-friendly version of the **raw**, low-level winit event.
 
 use geom::{self, Point2, Vector2};
-use state;
 use std::path::PathBuf;
 use window;
 use winit;
@@ -29,11 +28,11 @@ pub struct Update {
     /// The duration since the last update was emitted.
     ///
     /// The first update's delta will be the time since the given `model` function returned.
-    pub since_last: state::time::Duration,
+    pub since_last: std::time::Duration,
     /// The duration since the start of the app loop.
     ///
     /// Specifically, this is the duration of time since the given `model` function returned.
-    pub since_start: state::time::Duration,
+    pub since_start: std::time::Duration,
 }
 
 /// The default application **Event** type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod osc;
 pub mod prelude;
 pub mod rand;
 pub mod state;
+pub mod time;
 pub mod ui;
 pub mod window;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,6 +20,7 @@ pub use math::{
 };
 pub use osc;
 pub use rand::{random, random_f32, random_f64, random_range};
+pub use time::DurationF64;
 pub use ui;
 pub use window::{self, Id as WindowId};
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -282,91 +282,12 @@ pub mod mouse {
 
 /// Tracked durations related to the App.
 pub mod time {
-    use std::{ops, time};
-    use std::cmp::Ordering;
-
     /// The state of time tracked by the App.
     #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
     pub struct Time {
         /// The duration since the app started running.
-        pub since_start: Duration,
+        pub since_start: std::time::Duration,
         /// The duration since the previous update.
-        pub since_prev_update: Duration,
-    }
-
-    /// A wrapper around a std duration with simpler methods.
-    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
-    pub struct Duration {
-        /// The inner std duration.
-        pub duration: time::Duration,
-    }
-
-    impl From<time::Duration> for Duration {
-        fn from(duration: time::Duration) -> Self {
-            Duration { duration }
-        }
-    }
-
-    impl Into<time::Duration> for Duration {
-        fn into(self) -> time::Duration {
-            self.duration
-        }
-    }
-
-    impl ops::Deref for Duration {
-        type Target = time::Duration;
-        fn deref(&self) -> &Self::Target {
-            &self.duration
-        }
-    }
-
-    impl ops::DerefMut for Duration {
-        fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut self.duration
-        }
-    }
-
-    impl PartialEq<time::Duration> for Duration {
-        fn eq(&self, other: &time::Duration) -> bool {
-            self.duration == *other
-        }
-    }
-
-    impl PartialOrd<time::Duration> for Duration {
-        fn partial_cmp(&self, other: &time::Duration) -> Option<Ordering> {
-            self.duration.partial_cmp(other)
-        }
-    }
-
-    impl Duration {
-        /// A simple way of retrieving the duration as weeks.
-        pub fn weeks(&self) -> f64 {
-            self.days() / 7.0
-        }
-
-        /// A simple way of retrieving the duration as days.
-        pub fn days(&self) -> f64 {
-            self.hrs() / 24.0
-        }
-
-        /// A simple way of retrieving the duration as hrs.
-        pub fn hrs(&self) -> f64 {
-            self.mins() / 60.0
-        }
-
-        /// A simple way of retrieving the duration as minutes.
-        pub fn mins(&self) -> f64 {
-            self.secs() / 60.0
-        }
-
-        /// A simple way of retrieving the duration in seconds.
-        pub fn secs(&self) -> f64 {
-            self.as_secs() as f64 + self.subsec_nanos() as f64 * 1e-9
-        }
-
-        /// A simple way of retrieving the duration in milliseconds.
-        pub fn ms(&self) -> f64 {
-            self.secs() * 1_000.0
-        }
+        pub since_prev_update: std::time::Duration,
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,44 @@
+//! Extensions and utilities for working with time.
+
+/// An extension for the `std::time::Duration` type providing some simple methods for easy access
+/// to an `f64` representation of seconds, ms, mins, hrs, and other units of time.
+///
+/// While these measurements make it easier to work with sketches and artworks, it's worth noting
+/// that resolution may be lost, especially at high values.
+pub trait DurationF64 {
+    /// A simple way of retrieving the duration in seconds.
+    fn secs(&self) -> f64;
+
+    /// A simple way of retrieving the duration in milliseconds.
+    ///
+    /// By default, this is implemented as `self.secs() * 1_000.0`.
+    fn ms(&self) -> f64 {
+        self.secs() * 1_000.0
+    }
+
+    /// A simple way of retrieving the duration as minutes.
+    fn mins(&self) -> f64 {
+        self.secs() / 60.0
+    }
+
+    /// A simple way of retrieving the duration as hrs.
+    fn hrs(&self) -> f64 {
+        self.secs() / 3_600.0
+    }
+
+    /// A simple way of retrieving the duration as days.
+    fn days(&self) -> f64 {
+        self.secs() / 86_400.0
+    }
+
+    /// A simple way of retrieving the duration as weeks.
+    fn weeks(&self) -> f64 {
+        self.secs() / 604_800.0
+    }
+}
+
+impl DurationF64 for std::time::Duration {
+    fn secs(&self) -> f64 {
+        self.as_secs() as f64 + self.subsec_nanos() as f64 * 1e-9
+    }
+}


### PR DESCRIPTION
The idea behind the `Duration` type was to extend the std `Duration`
with simple methods for retrieving useful time units with a `f64`
representation. This approach was unwieldy and confusing to use in
practise as it required constantly converting between the `std` and
nannou `Duration` types.

Having the new `DurationF64` trait in the prelude should simplify things
by extending the `std::time::Duration` type the methods directly.

Closes #255 
Closes #234.