### PR TITLE
Prefer sRGB color formats when building swapchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add `Window::grab_cursor` and `Window::hide_cursor` methods.
 - Add `window::SwapchainFramebuffers` helper type.
 - Remove the `state::time::Duration` type in favour of a `DurationF64` trait.
+- Prefer sRGB colour formats when building swapchain
 
 # Version 0.8.0 (2018-07-19)
 

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::panic::RefUnwindSafe;
 use std::sync::Arc;
+use vulkano::format::Format;
 use vulkano::instance::{ApplicationInfo, Instance, InstanceCreationError, InstanceExtensions};
 use vulkano::instance::debug::{DebugCallback, DebugCallbackCreationError, Message, MessageTypes};
 use vulkano::instance::loader::{FunctionPointers, Loader};
@@ -196,4 +197,41 @@ impl VulkanDebugCallbackBuilder {
 /// This is the same as calling `vulkano_win::required_extensions()`.
 pub fn required_windowing_extensions() -> InstanceExtensions {
     vulkano_win::required_extensions()
+}
+
+/// Whether or not the format is sRGB.
+pub fn format_is_srgb(format: Format) -> bool {
+    use vulkano::format::Format::*;
+    match format {
+        R8Srgb |
+        R8G8Srgb |
+        R8G8B8Srgb |
+        B8G8R8Srgb |
+        R8G8B8A8Srgb |
+        B8G8R8A8Srgb |
+        A8B8G8R8SrgbPack32 |
+        BC1_RGBSrgbBlock |
+        BC1_RGBASrgbBlock |
+        BC2SrgbBlock |
+        BC3SrgbBlock |
+        BC7SrgbBlock |
+        ETC2_R8G8B8SrgbBlock |
+        ETC2_R8G8B8A1SrgbBlock |
+        ETC2_R8G8B8A8SrgbBlock |
+        ASTC_4x4SrgbBlock |
+        ASTC_5x4SrgbBlock |
+        ASTC_5x5SrgbBlock |
+        ASTC_6x5SrgbBlock |
+        ASTC_6x6SrgbBlock |
+        ASTC_8x5SrgbBlock |
+        ASTC_8x6SrgbBlock |
+        ASTC_8x8SrgbBlock |
+        ASTC_10x5SrgbBlock |
+        ASTC_10x6SrgbBlock |
+        ASTC_10x8SrgbBlock |
+        ASTC_10x10SrgbBlock |
+        ASTC_12x10SrgbBlock |
+        ASTC_12x12SrgbBlock => true,
+        _ => false,
+    }
 }


### PR DESCRIPTION
See the vulkano `ColorSpace` documentation
[here](https://docs.rs/vulkano/0.11.1/vulkano/swapchain/enum.ColorSpace.html)
for the motivation behind this change.