### PR TITLE
Fallback to `Fifo` present mode if `Mailbox` is unavailable

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -573,11 +573,11 @@ where
         if loop_mode != LoopMode::default() {
             let mut windows = app.windows.borrow_mut();
             for window in windows.values_mut() {
-                let min_image_count = window
+                let capabilities = window
                     .surface
                     .capabilities(window.swapchain.device().physical_device())
-                    .expect("failed to get surface capabilities")
-                    .min_image_count;
+                    .expect("failed to get surface capabilities");
+                let min_image_count = capabilities.min_image_count;
                 let user_specified_present_mode = window.user_specified_present_mode;
                 let user_specified_image_count = window.user_specified_image_count;
                 let (present_mode, image_count) = window::preferred_present_mode_and_image_count(
@@ -585,6 +585,7 @@ where
                     min_image_count,
                     user_specified_present_mode,
                     user_specified_image_count,
+                    &capabilities.present_modes,
                 );
                 if window.swapchain.present_mode() != present_mode
                 || window.swapchain.num_images() != image_count {


### PR DESCRIPTION
Nannou will now fall back to the `Fifo` present mode if `Mailbox` is
not supported by the swapchain when switching the `Wait` or `Rate`
`LoopMode`s.

This should fix the issue on macos where certain examples that use the
`Wait` or `Rate` loop modes would `panic!` with an
`UnsupportedPresentMode` error.

Closes #262.

@freesig could you confirm that this fixes the `simple_ui.rs` example
for you? It's probably also worth checking that the `loop_mode.rs` works
now too as that example switches between all of the different loop modes
one at a time on keypress.

Closes #262