### PR TITLE
Add `FramebufferObject` type to simplify working with framebuffers.

### DIFF
--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -24,7 +24,7 @@ struct Model {
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    framebuffer: RefCell<ViewFramebuffer>,
+    view_fbo: RefCell<ViewFbo>,
     desciptor_set: Arc<DescriptorSet + Send + Sync>,
 }
 
@@ -166,13 +166,13 @@ fn model(app: &App) -> Model {
             .unwrap(),
     );
 
-    let framebuffer = RefCell::new(ViewFramebuffer::default());
+    let view_fbo = RefCell::new(ViewFbo::default());
 
     Model {
         render_pass,
         pipeline,
         vertex_buffer,
-        framebuffer,
+        view_fbo,
         desciptor_set,
     }
 }
@@ -190,8 +190,8 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         scissors: None,
     };
 
-    // Update framebuffer in case of window resize.
-    model.framebuffer.borrow_mut()
+    // Update view_fbo in case of window resize.
+    model.view_fbo.borrow_mut()
         .update(&frame, model.render_pass.clone(), |builder, image| builder.add(image))
         .unwrap();
 
@@ -205,7 +205,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     frame
         .add_commands()
         .begin_render_pass(
-            model.framebuffer.borrow().as_ref().unwrap().clone(),
+            model.view_fbo.borrow().expect_inner(),
             false,
             clear_values,
         )

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -24,7 +24,7 @@ struct Model {
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    framebuffer: RefCell<ViewFramebuffer>,
+    view_fbo: RefCell<ViewFbo>,
     desciptor_set: Arc<DescriptorSet + Send + Sync>,
 }
 
@@ -158,13 +158,13 @@ fn model(app: &App) -> Model {
             .unwrap(),
     );
 
-    let framebuffer = RefCell::new(ViewFramebuffer::default());
+    let view_fbo = RefCell::new(ViewFbo::default());
 
     Model {
         render_pass,
         pipeline,
         vertex_buffer,
-        framebuffer,
+        view_fbo,
         desciptor_set,
     }
 }
@@ -182,8 +182,8 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
         scissors: None,
     };
 
-    // Update framebuffer in case of window resize.
-    model.framebuffer.borrow_mut()
+    // Update view_fbo in case of window resize.
+    model.view_fbo.borrow_mut()
         .update(&frame, model.render_pass.clone(), |builder, image| builder.add(image))
         .unwrap();
 
@@ -191,11 +191,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
 
     frame
         .add_commands()
-        .begin_render_pass(
-            model.framebuffer.borrow().as_ref().unwrap().clone(),
-            false,
-            clear_values,
-        )
+        .begin_render_pass(model.view_fbo.borrow().expect_inner(), false, clear_values)
         .unwrap()
         .draw(
             model.pipeline.clone(),

--- a/examples/vulkan/vk_shader_include/mod.rs
+++ b/examples/vulkan/vk_shader_include/mod.rs
@@ -20,7 +20,7 @@ struct Model {
     render_pass: Arc<RenderPassAbstract + Send + Sync>,
     pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    framebuffer: RefCell<ViewFramebuffer>,
+    view_fbo: RefCell<ViewFbo>,
 }
 
 #[derive(Debug, Clone)]
@@ -99,13 +99,13 @@ fn model(app: &App) -> Model {
             .unwrap(),
     );
 
-    let framebuffer = RefCell::new(ViewFramebuffer::default());
+    let view_fbo = RefCell::new(ViewFbo::default());
 
     Model {
         render_pass,
         pipeline,
         vertex_buffer,
-        framebuffer,
+        view_fbo,
     }
 }
 
@@ -122,8 +122,8 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         scissors: None,
     };
 
-    // Update the framebuffer in case of window resize.
-    model.framebuffer.borrow_mut()
+    // Update the view_fbo in case of window resize.
+    model.view_fbo.borrow_mut()
         .update(&frame, model.render_pass.clone(), |builder, image| builder.add(image))
         .unwrap();
 
@@ -137,11 +137,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
 
     frame
         .add_commands()
-        .begin_render_pass(
-            model.framebuffer.borrow().as_ref().unwrap().clone(),
-            false,
-            clear_values,
-        )
+        .begin_render_pass(model.view_fbo.borrow().expect_inner(), false, clear_values)
         .unwrap()
         .draw(
             model.pipeline.clone(),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,10 +7,11 @@ pub use color::{Hsl, Hsla, Hsv, Hsva, Rgb, Rgba};
 pub use event::WindowEvent::*;
 pub use event::{AxisMotion, Event, Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase,
                 TouchpadPressure, Update, WindowEvent};
-pub use frame::{Frame, RawFrame, ViewFramebuffer};
+pub use frame::{Frame, RawFrame, ViewFbo, ViewFramebufferObject};
 pub use geom::{
     self, pt2, pt3, vec2, vec3, vec4, Cuboid, Point2, Point3, Rect, Vector2, Vector3, Vector4,
 };
+pub use gpu::{Fbo, FramebufferObject};
 pub use io::{load_from_json, load_from_toml, safe_file_save, save_to_json, save_to_toml};
 pub use math::num_traits::*;
 pub use math::prelude::*;


### PR DESCRIPTION
Also includes an `Fbo` alias for the new `FramebufferObject` type.

The `ViewFramebuffer` type has been replaced with a
`ViewFramebufferObject` type along with a `ViewFbo` type alias.
This new type uses the `Fbo` internally, greatly simlifying the
implementation.

Closes #214.

cc @JoshuaBatty this should simplify all the post-processing stuff heaps!