### PR TITLE
Add a `SamplerBuilder` type for modular Sampler build process

### DIFF
--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -5,6 +5,7 @@ use nannou::vulkano;
 use std::cell::RefCell;
 use std::sync::Arc;
 
+use nannou::gpu::SamplerBuilder;
 use nannou::vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use nannou::vulkano::command_buffer::DynamicState;
 use nannou::vulkano::descriptor::descriptor_set::{DescriptorSet, PersistentDescriptorSet};
@@ -14,7 +15,6 @@ use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
 use nannou::vulkano::image::{Dimensions, ImmutableImage};
 use nannou::vulkano::pipeline::viewport::Viewport;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
-use nannou::vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 
 fn main() {
     nannou::app(model).run();
@@ -105,20 +105,7 @@ fn model(app: &App) -> Model {
         .unwrap()
     };
 
-    let sampler = Sampler::new(
-        device.clone(),
-        Filter::Linear,
-        Filter::Linear,
-        MipmapMode::Nearest,
-        SamplerAddressMode::ClampToEdge,
-        SamplerAddressMode::ClampToEdge,
-        SamplerAddressMode::ClampToEdge,
-        0.0,
-        1.0,
-        0.0,
-        0.0,
-    )
-    .unwrap();
+    let sampler = SamplerBuilder::new().build(device.clone()).unwrap();
 
     let pipeline = Arc::new(
         GraphicsPipeline::start()

--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -5,6 +5,7 @@ use nannou::vulkano;
 use std::cell::RefCell;
 use std::sync::Arc;
 
+use nannou::gpu::SamplerBuilder;
 use nannou::vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use nannou::vulkano::command_buffer::DynamicState;
 use nannou::vulkano::descriptor::descriptor_set::{DescriptorSet, PersistentDescriptorSet};
@@ -14,7 +15,6 @@ use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
 use nannou::vulkano::image::{Dimensions, ImmutableImage};
 use nannou::vulkano::pipeline::viewport::Viewport;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
-use nannou::vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 
 fn main() {
     nannou::app(model).run();
@@ -130,20 +130,7 @@ fn model(app: &App) -> Model {
         .unwrap()
     };
 
-    let sampler = Sampler::new(
-        device.clone(),
-        Filter::Linear,
-        Filter::Linear,
-        MipmapMode::Nearest,
-        SamplerAddressMode::ClampToEdge,
-        SamplerAddressMode::ClampToEdge,
-        SamplerAddressMode::ClampToEdge,
-        0.0,
-        1.0,
-        0.0,
-        0.0,
-    )
-    .unwrap();
+    let sampler = SamplerBuilder::new().build(device.clone()).unwrap();
 
     let pipeline = Arc::new(
         GraphicsPipeline::start()

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -5,6 +5,7 @@ use nannou::vulkano;
 use std::cell::RefCell;
 use std::sync::Arc;
 
+use nannou::gpu::SamplerBuilder;
 use nannou::vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use nannou::vulkano::command_buffer::DynamicState;
 use nannou::vulkano::descriptor::descriptor_set::{DescriptorSet, PersistentDescriptorSet};
@@ -14,7 +15,6 @@ use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
 use nannou::vulkano::image::{Dimensions, ImmutableImage};
 use nannou::vulkano::pipeline::viewport::Viewport;
 use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
-use nannou::vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 
 fn main() {
     nannou::app(model).run();
@@ -112,20 +112,7 @@ fn model(app: &App) -> Model {
             .unwrap()
         };
 
-        let sampler = Sampler::new(
-            device.clone(),
-            Filter::Linear,
-            Filter::Linear,
-            MipmapMode::Nearest,
-            SamplerAddressMode::ClampToEdge,
-            SamplerAddressMode::ClampToEdge,
-            SamplerAddressMode::ClampToEdge,
-            0.0,
-            1.0,
-            0.0,
-            0.0,
-        )
-        .unwrap();
+        let sampler = SamplerBuilder::new().build(device.clone()).unwrap();
 
         textures.push(texture);
         samplers.push(sampler);


### PR DESCRIPTION
Allows for building a `Sampler` type by chaining together a series of
parameters, or falling back to defaults. Defaults values can be
retrieved via the `SamplerBuilder::DEFAULT_*` associated consts.

Closes #255

cc @JoshuaBatty another handy tool for simplifying post-processing
boilerplate