### PR TITLE
Embrace the `vk` prefix. Re-export vulkano via a new `vk` module.

### DIFF
--- a/examples/vulkan/vk_debug.rs
+++ b/examples/vulkan/vk_debug.rs
@@ -2,12 +2,12 @@
 //!
 //! Use `Default::default()` to simply use the default callback which will enable all message types
 //! including error, warning, performance_warning, information and debug. See the
-//! `nannou::gpu::VulkanDebugCallbackBuilder` docs for more information on how to customise this.
+//! `nannou::vk::DebugCallbackBuilder` docs for more information on how to customise this.
 //!
 //! If you require specifying custom validation layers, please see
-//! `nannou::app::Builder::vulkan_instance` and the `nannou::gpu::VulkanInstanceBuilder` which will
+//! `nannou::app::Builder::vulkan_instance` and the `nannou::vk::InstanceBuilder` which will
 //! allow you to specify your own custom set of validation layers. To determine what layers are
-//! available on a system, see the `nannou::vulkano::instance::layers_list` function.
+//! available on a system, see the `nannou::vk::instance::layers_list` function.
 
 extern crate nannou;
 
@@ -15,7 +15,7 @@ use nannou::prelude::*;
 
 fn main() {
     nannou::app(model)
-        .vulkan_debug_callback(Default::default()) // The vulkan debug callback.
+        .vk_debug_callback(Default::default()) // The vulkan debug callback.
         .simple_window(view)
         .run();
 }

--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -1,38 +1,26 @@
 extern crate nannou;
 
 use nannou::prelude::*;
-use nannou::vulkano;
 use std::cell::RefCell;
 use std::sync::Arc;
-
-use nannou::gpu::SamplerBuilder;
-use nannou::vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
-use nannou::vulkano::command_buffer::DynamicState;
-use nannou::vulkano::descriptor::descriptor_set::{DescriptorSet, PersistentDescriptorSet};
-use nannou::vulkano::device::DeviceOwned;
-use nannou::vulkano::format::Format;
-use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
-use nannou::vulkano::image::{Dimensions, ImmutableImage};
-use nannou::vulkano::pipeline::viewport::Viewport;
-use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 
 fn main() {
     nannou::app(model).run();
 }
 
 struct Model {
-    render_pass: Arc<RenderPassAbstract + Send + Sync>,
-    pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
-    vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
+    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
     view_fbo: RefCell<ViewFbo>,
-    desciptor_set: Arc<DescriptorSet + Send + Sync>,
+    desciptor_set: Arc<vk::DescriptorSet + Send + Sync>,
 }
 
 #[derive(Debug, Clone)]
 struct Vertex {
     position: [f32; 2],
 }
-nannou::vulkano::impl_vertex!(Vertex, position);
+vk::impl_vertex!(Vertex, position);
 
 fn model(app: &App) -> Model {
     app.new_window()
@@ -43,9 +31,9 @@ fn model(app: &App) -> Model {
 
     let device = app.main_window().swapchain().device().clone();
 
-    let vertex_buffer = CpuAccessibleBuffer::from_iter(
+    let vertex_buffer = vk::CpuAccessibleBuffer::from_iter(
         device.clone(),
-        BufferUsage::all(),
+        vk::BufferUsage::all(),
         [
             Vertex {
                 position: [-1.0, -1.0],
@@ -69,7 +57,7 @@ fn model(app: &App) -> Model {
     let fragment_shader = fs::Shader::load(device.clone()).unwrap();
 
     let render_pass = Arc::new(
-        nannou::vulkano::single_pass_renderpass!(
+        vk::single_pass_renderpass!(
             device.clone(),
             attachments: {
                 color: {
@@ -96,32 +84,32 @@ fn model(app: &App) -> Model {
         let (width, height) = image.dimensions();
         let image_data = image.into_raw().clone();
 
-        ImmutableImage::from_iter(
+        vk::ImmutableImage::from_iter(
             image_data.iter().cloned(),
-            Dimensions::Dim2d { width, height },
-            Format::R8G8B8A8Srgb,
+            vk::image::Dimensions::Dim2d { width, height },
+            vk::Format::R8G8B8A8Srgb,
             app.main_window().swapchain_queue().clone(),
         )
         .unwrap()
     };
 
-    let sampler = SamplerBuilder::new().build(device.clone()).unwrap();
+    let sampler = vk::SamplerBuilder::new().build(device.clone()).unwrap();
 
     let pipeline = Arc::new(
-        GraphicsPipeline::start()
+        vk::GraphicsPipeline::start()
             .vertex_input_single_buffer::<Vertex>()
             .vertex_shader(vertex_shader.main_entry_point(), ())
             .triangle_strip()
             .viewports_dynamic_scissors_irrelevant(1)
             .fragment_shader(fragment_shader.main_entry_point(), ())
             .blend_alpha_blending()
-            .render_pass(Subpass::from(render_pass.clone(), 0).unwrap())
+            .render_pass(vk::Subpass::from(render_pass.clone(), 0).unwrap())
             .build(device.clone())
             .unwrap(),
     );
 
     let desciptor_set = Arc::new(
-        PersistentDescriptorSet::start(pipeline.clone(), 0)
+        vk::PersistentDescriptorSet::start(pipeline.clone(), 0)
             .add_sampled_image(texture.clone(), sampler.clone())
             .unwrap()
             .build()
@@ -141,12 +129,12 @@ fn model(app: &App) -> Model {
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
-    let viewport = Viewport {
+    let viewport = vk::Viewport {
         origin: [0.0, 0.0],
         dimensions: [w as _, h as _],
         depth_range: 0.0..1.0,
     };
-    let dynamic_state = DynamicState {
+    let dynamic_state = vk::DynamicState {
         line_width: None,
         viewports: Some(vec![viewport]),
         scissors: None,
@@ -182,7 +170,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
 }
 
 mod vs {
-    nannou::vulkano_shaders::shader! {
+    nannou::vk::shaders::shader! {
     ty: "vertex",
         src: "
 #version 450
@@ -198,7 +186,7 @@ void main() {
 }
 
 mod fs {
-    nannou::vulkano_shaders::shader! {
+    nannou::vk::shaders::shader! {
     ty: "fragment",
         src: "
 #version 450

--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -1,31 +1,19 @@
 extern crate nannou;
 
 use nannou::prelude::*;
-use nannou::vulkano;
 use std::cell::RefCell;
 use std::sync::Arc;
-
-use nannou::gpu::SamplerBuilder;
-use nannou::vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
-use nannou::vulkano::command_buffer::DynamicState;
-use nannou::vulkano::descriptor::descriptor_set::{DescriptorSet, PersistentDescriptorSet};
-use nannou::vulkano::device::DeviceOwned;
-use nannou::vulkano::format::Format;
-use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
-use nannou::vulkano::image::{Dimensions, ImmutableImage};
-use nannou::vulkano::pipeline::viewport::Viewport;
-use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 
 fn main() {
     nannou::app(model).run();
 }
 
 struct Model {
-    render_pass: Arc<RenderPassAbstract + Send + Sync>,
-    pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
-    vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
+    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
     view_fbo: RefCell<ViewFbo>,
-    desciptor_set: Arc<DescriptorSet + Send + Sync>,
+    desciptor_set: Arc<vk::DescriptorSet + Send + Sync>,
 }
 
 #[derive(Debug, Clone)]
@@ -33,7 +21,7 @@ struct Vertex {
     position: [f32; 2],
 }
 
-nannou::vulkano::impl_vertex!(Vertex, position);
+vk::impl_vertex!(Vertex, position);
 
 fn model(app: &App) -> Model {
     app.new_window()
@@ -44,33 +32,16 @@ fn model(app: &App) -> Model {
 
     let device = app.main_window().swapchain().device().clone();
 
-    let vertex_buffer = CpuAccessibleBuffer::from_iter(
-        device.clone(),
-        BufferUsage::all(),
-        [
-            Vertex {
-                position: [-1.0, -1.0],
-            },
-            Vertex {
-                position: [-1.0, 1.0],
-            },
-            Vertex {
-                position: [1.0, -1.0],
-            },
-            Vertex {
-                position: [1.0, 1.0],
-            },
-        ]
-        .iter()
-        .cloned(),
-    )
-    .unwrap();
+    let positions = [[-1.0, -1.0], [-1.0, 1.0], [1.0, -1.0], [1.0, 1.0]];
+    let data = positions.iter().map(|&position| Vertex { position });
+    let usage = vk::BufferUsage::all();
+    let vertex_buffer = vk::CpuAccessibleBuffer::from_iter(device.clone(), usage, data).unwrap();
 
     let vertex_shader = vs::Shader::load(device.clone()).unwrap();
     let fragment_shader = fs::Shader::load(device.clone()).unwrap();
 
     let render_pass = Arc::new(
-        nannou::vulkano::single_pass_renderpass!(
+        vk::single_pass_renderpass!(
             device.clone(),
             attachments: {
                 color: {
@@ -117,36 +88,36 @@ fn model(app: &App) -> Model {
             .iter()
             .flat_map(|(_, img)| img.iter().cloned())
             .collect();
-        ImmutableImage::from_iter(
+        vk::ImmutableImage::from_iter(
             image_data.into_iter(),
-            Dimensions::Dim2dArray {
+            vk::image::Dimensions::Dim2dArray {
                 width,
                 height,
                 array_layers,
             },
-            Format::R8G8B8A8Srgb,
+            vk::Format::R8G8B8A8Srgb,
             app.main_window().swapchain_queue().clone(),
         )
         .unwrap()
     };
 
-    let sampler = SamplerBuilder::new().build(device.clone()).unwrap();
+    let sampler = vk::SamplerBuilder::new().build(device.clone()).unwrap();
 
     let pipeline = Arc::new(
-        GraphicsPipeline::start()
+        vk::GraphicsPipeline::start()
             .vertex_input_single_buffer::<Vertex>()
             .vertex_shader(vertex_shader.main_entry_point(), ())
             .triangle_strip()
             .viewports_dynamic_scissors_irrelevant(1)
             .fragment_shader(fragment_shader.main_entry_point(), ())
             .blend_alpha_blending()
-            .render_pass(Subpass::from(render_pass.clone(), 0).unwrap())
+            .render_pass(vk::Subpass::from(render_pass.clone(), 0).unwrap())
             .build(device.clone())
             .unwrap(),
     );
 
     let desciptor_set = Arc::new(
-        PersistentDescriptorSet::start(pipeline.clone(), 0)
+        vk::PersistentDescriptorSet::start(pipeline.clone(), 0)
             .add_sampled_image(texture.clone(), sampler.clone())
             .unwrap()
             .build()
@@ -166,12 +137,12 @@ fn model(app: &App) -> Model {
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
-    let viewport = Viewport {
+    let viewport = vk::Viewport {
         origin: [0.0, 0.0],
         dimensions: [w as _, h as _],
         depth_range: 0.0..1.0,
     };
-    let dynamic_state = DynamicState {
+    let dynamic_state = vk::DynamicState {
         line_width: None,
         viewports: Some(vec![viewport]),
         scissors: None,
@@ -220,7 +191,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
 }
 
 mod vs {
-    nannou::vulkano_shaders::shader! {
+    nannou::vk::shaders::shader! {
     ty: "vertex",
         src: "
 #version 450
@@ -236,7 +207,7 @@ void main() {
 }
 
 mod fs {
-    nannou::vulkano_shaders::shader! {
+    nannou::vk::shaders::shader! {
     ty: "fragment",
         src: "
 #version 450

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -1,31 +1,19 @@
 extern crate nannou;
 
 use nannou::prelude::*;
-use nannou::vulkano;
 use std::cell::RefCell;
 use std::sync::Arc;
-
-use nannou::gpu::SamplerBuilder;
-use nannou::vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
-use nannou::vulkano::command_buffer::DynamicState;
-use nannou::vulkano::descriptor::descriptor_set::{DescriptorSet, PersistentDescriptorSet};
-use nannou::vulkano::device::DeviceOwned;
-use nannou::vulkano::format::Format;
-use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
-use nannou::vulkano::image::{Dimensions, ImmutableImage};
-use nannou::vulkano::pipeline::viewport::Viewport;
-use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 
 fn main() {
     nannou::app(model).run();
 }
 
 struct Model {
-    render_pass: Arc<RenderPassAbstract + Send + Sync>,
-    pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
-    vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
+    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
     view_fbo: RefCell<ViewFbo>,
-    desciptor_set: Arc<DescriptorSet + Send + Sync>,
+    desciptor_set: Arc<vk::DescriptorSet + Send + Sync>,
 }
 
 #[derive(Debug, Clone)]
@@ -33,7 +21,7 @@ struct Vertex {
     position: [f32; 2],
 }
 
-nannou::vulkano::impl_vertex!(Vertex, position);
+vk::impl_vertex!(Vertex, position);
 
 fn model(app: &App) -> Model {
     app.new_window()
@@ -44,9 +32,9 @@ fn model(app: &App) -> Model {
 
     let device = app.main_window().swapchain().device().clone();
 
-    let vertex_buffer = CpuAccessibleBuffer::from_iter(
+    let vertex_buffer = vk::CpuAccessibleBuffer::from_iter(
         device.clone(),
-        BufferUsage::all(),
+        vk::BufferUsage::all(),
         [
             Vertex {
                 position: [-1.0, -1.0],
@@ -70,7 +58,7 @@ fn model(app: &App) -> Model {
     let fragment_shader = fs::Shader::load(device.clone()).unwrap();
 
     let render_pass = Arc::new(
-        nannou::vulkano::single_pass_renderpass!(
+        vk::single_pass_renderpass!(
             device.clone(),
             attachments: {
                 color: {
@@ -103,36 +91,36 @@ fn model(app: &App) -> Model {
             let image = image::open(logo_path).unwrap().to_rgba();
             let (width, height) = image.dimensions();
             let image_data = image.into_raw().clone();
-            ImmutableImage::from_iter(
+            vk::ImmutableImage::from_iter(
                 image_data.iter().cloned(),
-                Dimensions::Dim2d { width, height },
-                Format::R8G8B8A8Srgb,
+                vk::image::Dimensions::Dim2d { width, height },
+                vk::Format::R8G8B8A8Srgb,
                 app.main_window().swapchain_queue().clone(),
             )
             .unwrap()
         };
 
-        let sampler = SamplerBuilder::new().build(device.clone()).unwrap();
+        let sampler = vk::SamplerBuilder::new().build(device.clone()).unwrap();
 
         textures.push(texture);
         samplers.push(sampler);
     }
 
     let pipeline = Arc::new(
-        GraphicsPipeline::start()
+        vk::GraphicsPipeline::start()
             .vertex_input_single_buffer::<Vertex>()
             .vertex_shader(vertex_shader.main_entry_point(), ())
             .triangle_strip()
             .viewports_dynamic_scissors_irrelevant(1)
             .fragment_shader(fragment_shader.main_entry_point(), ())
             .blend_alpha_blending()
-            .render_pass(Subpass::from(render_pass.clone(), 0).unwrap())
+            .render_pass(vk::Subpass::from(render_pass.clone(), 0).unwrap())
             .build(device.clone())
             .unwrap(),
     );
 
     let desciptor_set = Arc::new(
-        PersistentDescriptorSet::start(pipeline.clone(), 0)
+        vk::PersistentDescriptorSet::start(pipeline.clone(), 0)
             .add_sampled_image(textures[0].clone(), samplers[0].clone())
             .unwrap()
             .add_sampled_image(textures[1].clone(), samplers[1].clone())
@@ -158,12 +146,12 @@ fn model(app: &App) -> Model {
 
 fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
-    let viewport = Viewport {
+    let viewport = vk::Viewport {
         origin: [0.0, 0.0],
         dimensions: [w as _, h as _],
         depth_range: 0.0..1.0,
     };
-    let dynamic_state = DynamicState {
+    let dynamic_state = vk::DynamicState {
         line_width: None,
         viewports: Some(vec![viewport]),
         scissors: None,
@@ -195,7 +183,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
 }
 
 mod vs {
-    nannou::vulkano_shaders::shader! {
+    nannou::vk::shaders::shader! {
     ty: "vertex",
         src: "
 #version 450
@@ -211,7 +199,7 @@ void main() {
 }
 
 mod fs {
-    nannou::vulkano_shaders::shader! {
+    nannou::vk::shaders::shader! {
     ty: "fragment",
         src: "
 #version 450

--- a/examples/vulkan/vk_quad_warp/controls.rs
+++ b/examples/vulkan/vk_quad_warp/controls.rs
@@ -63,7 +63,7 @@ pub(crate) fn update(model: &mut Model) {
         .x(corners.top_left.pos.x as f64)
         .y(corners.top_left.pos.y as f64)
         .set(model.ids.top_left_corner, ui);
-    
+
     widget::Text::new(&format!("top left: {:?}", corners.top_left.pos))
         .font_size(12)
         .rgb(1.0, 0.3, 0.0)
@@ -75,7 +75,7 @@ pub(crate) fn update(model: &mut Model) {
         .x_position(position::Position::Absolute(corners.top_right.pos.x as f64))
         .y_position(position::Position::Absolute(corners.top_right.pos.y as f64))
         .set(model.ids.top_right_corner, ui);
-    
+
     widget::Text::new(&format!("top right: {:?}", corners.top_right.pos))
         .font_size(12)
         .rgb(1.0, 0.3, 0.0)
@@ -87,7 +87,7 @@ pub(crate) fn update(model: &mut Model) {
         .x_position(position::Position::Absolute(corners.bottom_left.pos.x as f64))
         .y_position(position::Position::Absolute(corners.bottom_left.pos.y as f64))
         .set(model.ids.bottom_left_corner, ui);
-    
+
     widget::Text::new(&format!("bottom left: {:?}", corners.bottom_left.pos))
         .font_size(12)
         .rgb(1.0, 0.3, 0.0)
@@ -99,7 +99,7 @@ pub(crate) fn update(model: &mut Model) {
         .x_position(position::Position::Absolute(corners.bottom_right.pos.x as f64))
         .y_position(position::Position::Absolute(corners.bottom_right.pos.y as f64))
         .set(model.ids.bottom_right_corner, ui);
-    
+
     widget::Text::new(&format!("bottom right: {:?}", corners.bottom_right.pos))
         .font_size(12)
         .rgb(1.0, 0.3, 0.0)
@@ -107,9 +107,9 @@ pub(crate) fn update(model: &mut Model) {
         .set(model.ids.br_text, ui);
 
     let points = vec![
-        corners.top_left.pos, 
-        corners.top_right.pos, 
-        corners.bottom_right.pos, 
+        corners.top_left.pos,
+        corners.top_right.pos,
+        corners.bottom_right.pos,
         corners.bottom_left.pos,
         corners.top_left.pos];
     widget::PointPath::new(points.into_iter().map(|v| [v.x as f64, v.y as f64]))
@@ -129,7 +129,7 @@ pub(crate) fn event(_app: &App, model: &mut Model, event: WindowEvent) {
     let ref mut corners = model.controls.corners;
     match event {
         MouseMoved(pos) => {
-            let pos = pt2(clamp(pos.x, corners.dims.x.start, corners.dims.x.end), 
+            let pos = pt2(clamp(pos.x, corners.dims.x.start, corners.dims.x.end),
             clamp(pos.y, corners.dims.y.end, corners.dims.y.start));
             if corners.top_left.drag {
                 corners.top_left.pos = pos;

--- a/examples/vulkan/vk_teapot_camera.rs
+++ b/examples/vulkan/vk_teapot_camera.rs
@@ -1,21 +1,7 @@
 extern crate nannou;
 
-use nannou::prelude::*;
-
 use nannou::math::cgmath::{self, Matrix3, Matrix4, Rad, Point3, Vector3};
-use nannou::vulkano;
-use nannou::vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
-use nannou::vulkano::buffer::cpu_pool::CpuBufferPool;
-use nannou::vulkano::command_buffer::DynamicState;
-use nannou::vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use nannou::vulkano::device::{Device, DeviceOwned};
-use nannou::vulkano::format::Format;
-use nannou::vulkano::framebuffer::{RenderPassAbstract, Subpass};
-use nannou::vulkano::image::attachment::AttachmentImage;
-use nannou::vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract,
-                                GraphicsPipelineCreationError};
-use nannou::vulkano::pipeline::vertex::TwoBuffersDefinition;
-use nannou::vulkano::pipeline::viewport::Viewport;
+use nannou::prelude::*;
 use std::cell::RefCell;
 use std::sync::Arc;
 
@@ -26,15 +12,15 @@ struct Model {
 }
 
 struct Graphics {
-    vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    normal_buffer: Arc<CpuAccessibleBuffer<[Normal]>>,
-    index_buffer: Arc<CpuAccessibleBuffer<[u16]>>,
-    uniform_buffer: CpuBufferPool<vs::ty::Data>,
+    vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
+    normal_buffer: Arc<vk::CpuAccessibleBuffer<[Normal]>>,
+    index_buffer: Arc<vk::CpuAccessibleBuffer<[u16]>>,
+    uniform_buffer: vk::CpuBufferPool<vs::ty::Data>,
     vertex_shader: vs::Shader,
     fragment_shader: fs::Shader,
-    render_pass: Arc<RenderPassAbstract + Send + Sync>,
-    graphics_pipeline: Arc<GraphicsPipelineAbstract + Send + Sync>,
-    depth_image: Arc<AttachmentImage>,
+    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
+    graphics_pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    depth_image: Arc<vk::AttachmentImage>,
     view_fbo: ViewFbo,
 }
 
@@ -58,9 +44,9 @@ struct Normal {
     normal: (f32, f32, f32)
 }
 
-nannou::vulkano::impl_vertex!(Vertex, position);
+vk::impl_vertex!(Vertex, position);
 
-nannou::vulkano::impl_vertex!(Normal, normal);
+vk::impl_vertex!(Normal, normal);
 
 impl Camera {
     // Calculate the direction vector from the pitch and yaw.
@@ -102,29 +88,29 @@ fn model(app: &App) -> Model {
 
     let device = app.main_window().swapchain().device().clone();
 
-    let vertex_buffer = CpuAccessibleBuffer::from_iter(
+    let vertex_buffer = vk::CpuAccessibleBuffer::from_iter(
         device.clone(),
-        BufferUsage::all(),
+        vk::BufferUsage::all(),
         VERTICES.iter().cloned(),
     ).unwrap();
-    let normal_buffer = CpuAccessibleBuffer::from_iter(
+    let normal_buffer = vk::CpuAccessibleBuffer::from_iter(
         device.clone(),
-        BufferUsage::all(),
+        vk::BufferUsage::all(),
         NORMALS.iter().cloned(),
     ).unwrap();
-    let index_buffer = CpuAccessibleBuffer::from_iter(
+    let index_buffer = vk::CpuAccessibleBuffer::from_iter(
         device.clone(),
-        BufferUsage::all(),
+        vk::BufferUsage::all(),
         INDICES.iter().cloned(),
     ).unwrap();
 
-    let uniform_buffer = CpuBufferPool::<vs::ty::Data>::new(device.clone(), BufferUsage::all());
+    let uniform_buffer = vk::CpuBufferPool::<vs::ty::Data>::new(device.clone(), vk::BufferUsage::all());
 
     let vertex_shader = vs::Shader::load(device.clone()).unwrap();
     let fragment_shader = fs::Shader::load(device.clone()).unwrap();
 
     let render_pass = Arc::new(
-        nannou::vulkano::single_pass_renderpass!(
+        vk::single_pass_renderpass!(
             device.clone(),
             attachments: {
                 color: {
@@ -138,7 +124,7 @@ fn model(app: &App) -> Model {
                 depth: {
                     load: Clear,
                     store: DontCare,
-                    format: Format::D16Unorm,
+                    format: vk::Format::D16Unorm,
                     samples: app.main_window().msaa_samples(),
                 }
             },
@@ -159,11 +145,11 @@ fn model(app: &App) -> Model {
         [w as f32, h as f32],
     ).unwrap();
 
-    let depth_image = AttachmentImage::transient_multisampled(
+    let depth_image = vk::AttachmentImage::transient_multisampled(
         device.clone(),
         [w, h],
         app.main_window().msaa_samples(),
-        Format::D16Unorm,
+        vk::Format::D16Unorm,
     ).unwrap();
 
     let view_fbo = ViewFbo::default();
@@ -296,11 +282,11 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
             [w as f32, h as f32],
         ).unwrap();
 
-        graphics.depth_image = AttachmentImage::transient_multisampled(
+        graphics.depth_image = vk::AttachmentImage::transient_multisampled(
             device.clone(),
             [w, h],
             frame.image_msaa_samples(),
-            Format::D16Unorm,
+            vk::Format::D16Unorm,
         ).unwrap();
     }
 
@@ -337,7 +323,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     };
 
     let descriptor_set = Arc::new(
-        PersistentDescriptorSet::start(graphics.graphics_pipeline.clone(), 0)
+        vk::PersistentDescriptorSet::start(graphics.graphics_pipeline.clone(), 0)
             .add_buffer(uniform_buffer_slice)
             .unwrap()
             .build()
@@ -355,7 +341,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
         .unwrap()
         .draw_indexed(
             graphics.graphics_pipeline.clone(),
-            &DynamicState::none(),
+            &vk::DynamicState::none(),
             vec![graphics.vertex_buffer.clone(), graphics.normal_buffer.clone()],
             graphics.index_buffer.clone(),
             descriptor_set,
@@ -370,25 +356,25 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
 
 // Create the graphics pipeline.
 fn create_graphics_pipeline(
-    device: Arc<Device>,
+    device: Arc<vk::Device>,
     vertex_shader: &vs::Shader,
     fragment_shader: &fs::Shader,
-    render_pass: Arc<RenderPassAbstract + Send + Sync>,
+    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
     dimensions: [f32; 2],
-) -> Result<Arc<GraphicsPipelineAbstract + Send + Sync>, GraphicsPipelineCreationError> {
-    let pipeline = GraphicsPipeline::start()
-        .vertex_input(TwoBuffersDefinition::<Vertex, Normal>::new())
+) -> Result<Arc<vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError> {
+    let pipeline = vk::GraphicsPipeline::start()
+        .vertex_input(vk::TwoBuffersDefinition::<Vertex, Normal>::new())
         .vertex_shader(vertex_shader.main_entry_point(), ())
         .triangle_list()
         .viewports_dynamic_scissors_irrelevant(1)
-        .viewports(Some(Viewport {
+        .viewports(Some(vk::Viewport {
             origin: [0.0, 0.0],
             dimensions,
             depth_range: 0.0..1.0,
         }))
         .fragment_shader(fragment_shader.main_entry_point(), ())
         .depth_stencil_simple_depth()
-        .render_pass(Subpass::from(render_pass.clone(), 0).unwrap())
+        .render_pass(vk::Subpass::from(render_pass.clone(), 0).unwrap())
         .build(device.clone())?;
     Ok(Arc::new(pipeline) as Arc<_>)
 }
@@ -396,7 +382,7 @@ fn create_graphics_pipeline(
 // GLSL Shaders
 
 mod vs {
-    nannou::vulkano_shaders::shader! {
+    nannou::vk::shaders::shader! {
         ty: "vertex",
         src: "
 #version 450
@@ -422,7 +408,7 @@ void main() {
 }
 
 mod fs {
-    nannou::vulkano_shaders::shader! {
+    nannou::vk::shaders::shader! {
         ty: "fragment",
         src: "
 #version 450

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ pub mod ease;
 pub mod event;
 pub mod frame;
 pub mod geom;
-pub mod gpu;
 pub mod image;
 pub mod io;
 pub mod math;
@@ -51,6 +50,7 @@ pub mod rand;
 pub mod state;
 pub mod time;
 pub mod ui;
+pub mod vk;
 pub mod window;
 
 /// Begin building the `App`.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,6 @@ pub use frame::{Frame, RawFrame, ViewFbo, ViewFramebufferObject};
 pub use geom::{
     self, pt2, pt3, vec2, vec3, vec4, Cuboid, Point2, Point3, Rect, Vector2, Vector3, Vector4,
 };
-pub use gpu::{Fbo, FramebufferObject};
 pub use io::{load_from_json, load_from_toml, safe_file_save, save_to_json, save_to_toml};
 pub use math::num_traits::*;
 pub use math::prelude::*;
@@ -23,6 +22,7 @@ pub use osc;
 pub use rand::{random, random_f32, random_f64, random_range};
 pub use time::DurationF64;
 pub use ui;
+pub use vk::{self, DeviceOwned as VulkanDeviceOwned, GpuFuture};
 pub use window::{self, Id as WindowId};
 
 // The following constants have "regular" names for the `DefaultScalar` type and type suffixes for

--- a/src/vk.rs
+++ b/src/vk.rs
@@ -1,26 +1,146 @@
-//! Items related to interaction with GPUs via Vulkan.
+//! Items related to Vulkan and the Rust API used by Nannou called Vulkano.
+//!
+//! This module re-exports the entire `vulkano` crate along with all of its documentation while
+//! also adding some additional helper types.
+//!
+//! Individual items from throughout the vulkano crate have been re-exported within this module for
+//! ease of access via the `vk::` prefix, removing the need for a lot of boilerplate when coding.
+//! However, as a result, the documentation for this module is quite noisey! You can find cleaner
+//! information about how the different areas of Vulkan interoperate by checking out the
+//! module-level documentation for that area. For example, read about Framebuffers and RenderPasses
+//! in the `nannou::vk::framebuffer` module, or read about the CommandBuffer within the
+//! `nannou::vk::command_buffer` module.
+//!
+//! For more information on extensions to the vulkano crate added by nannou, scroll past the
+//! "Re-exports" items below.
 
+// Re-export `vulkano` along with its docs under this short-hand `vk` module.
+#[doc(inline)]
+pub use vulkano::*;
+
+// Re-export type and trait names whose meaning are still obvious outside of their module.
+pub use vulkano::{
+    buffer::{
+        BufferAccess, BufferInner, BufferSlice, BufferUsage, TypedBufferAccess,
+        CpuAccessibleBuffer, CpuBufferPool, DeviceLocalBuffer, ImmutableBuffer,
+        BufferCreationError, BufferView, BufferViewRef
+    },
+    buffer::cpu_pool::{
+        CpuBufferPoolChunk, CpuBufferPoolSubbuffer,
+    },
+    command_buffer::{
+        AutoCommandBuffer, AutoCommandBufferBuilder, CommandBufferExecFuture,
+        DispatchIndirectCommand, DrawIndirectCommand, DynamicState,
+        AutoCommandBufferBuilderContextError, ExecuteCommandsError, StateCacherOutcome,
+        UpdateBufferError, CommandBuffer,
+    },
+    descriptor::{
+        DescriptorSet, PipelineLayoutAbstract,
+    },
+    descriptor::descriptor::{
+        DescriptorBufferDesc, DescriptorDesc, DescriptorImageDesc, ShaderStages,
+        DescriptorDescSupersetError, DescriptorDescTy, DescriptorImageDescArray,
+        DescriptorImageDescDimensions, DescriptorType, ShaderStagesSupersetError,
+    },
+    descriptor::descriptor_set::{
+        DescriptorSetsCollection, DescriptorWrite, DescriptorsCount, FixedSizeDescriptorSet,
+        FixedSizeDescriptorSetBuilder, FixedSizeDescriptorSetBuilderArray,
+        FixedSizeDescriptorSetsPool, PersistentDescriptorSet, PersistentDescriptorSetBuf,
+        PersistentDescriptorSetBufView, PersistentDescriptorSetBuilder,
+        PersistentDescriptorSetBuilderArray, PersistentDescriptorSetImg,
+        PersistentDescriptorSetSampler, StdDescriptorPool, StdDescriptorPoolAlloc,
+        UnsafeDescriptorPool, UnsafeDescriptorPoolAllocIter, UnsafeDescriptorSet,
+        UnsafeDescriptorSetLayout, DescriptorPoolAllocError, PersistentDescriptorSetBuildError,
+        PersistentDescriptorSetError, DescriptorPool, DescriptorPoolAlloc, DescriptorSetDesc,
+    },
+    descriptor::pipeline_layout::{
+        EmptyPipelineDesc, PipelineLayout, PipelineLayoutDescPcRange, PipelineLayoutDescUnion,
+        PipelineLayoutSys, RuntimePipelineDesc, PipelineLayoutCreationError,
+        PipelineLayoutLimitsError, PipelineLayoutNotSupersetError, RuntimePipelineDescError,
+        PipelineLayoutDesc, PipelineLayoutPushConstantsCompatible, PipelineLayoutSetsCompatible,
+        PipelineLayoutSuperset,
+    },
+    device::{
+        Device, DeviceExtensions, DeviceOwned, DeviceCreationError, RawDeviceExtensions, Queue,
+        QueuesIter,
+    },
+    format::{
+        ClearValue, Format, FormatTy, AcceptsPixels, ClearValuesTuple, FormatDesc,
+        PossibleCompressedFormatDesc, PossibleDepthFormatDesc, PossibleDepthStencilFormatDesc,
+        PossibleFloatFormatDesc, PossibleFloatOrCompressedFormatDesc, PossibleSintFormatDesc,
+        PossibleStencilFormatDesc, PossibleUintFormatDesc, StrongStorage,
+    },
+    framebuffer::{
+        AttachmentDescription, Framebuffer, FramebufferBuilder, FramebufferSys,
+        PassDependencyDescription, PassDescription, RenderPass, RenderPassDescAttachments,
+        RenderPassDescDependencies, RenderPassDescSubpasses, RenderPassSys, Subpass,
+        FramebufferCreationError, IncompatibleRenderPassAttachmentError, LoadOp,
+        RenderPassCreationError, StoreOp, SubpassContents, AttachmentsList, FramebufferAbstract,
+        RenderPassAbstract, RenderPassCompatible, RenderPassDesc, RenderPassDescClearValues,
+        RenderPassSubpassInterface,
+    },
+    image::{
+        AttachmentImage, ImmutableImage, SwapchainImage,
+        ImageCreationError, ImageAccess, ImageInner, ImageViewAccess, ImageUsage, StorageImage,
+        ImageDimensions, ImageLayout, MipmapsCount,
+    },
+    image::immutable::{
+        ImmutableImageInitialization,
+    },
+    image::traits::{
+        ImageAccessFromUndefinedLayout, AttachmentImageView, ImageClearValue, ImageContent,
+    },
+    instance::{
+        ApplicationInfo, Instance, InstanceExtensions, Limits, PhysicalDevice, PhysicalDevicesIter,
+        QueueFamiliesIter, QueueFamily, RawInstanceExtensions, Version, InstanceCreationError,
+        PhysicalDeviceType,
+    },
+    pipeline::{
+        ComputePipeline, ComputePipelineSys, GraphicsPipeline, GraphicsPipelineBuilder,
+        GraphicsPipelineSys, ComputePipelineCreationError, GraphicsPipelineCreationError,
+        ComputePipelineAbstract, GraphicsPipelineAbstract,
+    },
+    pipeline::blend::{
+        AttachmentBlend, Blend, AttachmentsBlend, BlendFactor, BlendOp, LogicOp,
+    },
+    pipeline::depth_stencil::{
+        DepthStencil, Stencil, DepthBounds, StencilOp,
+    },
+    pipeline::vertex::{
+        AttributeInfo, BufferlessDefinition, BufferlessVertices, OneVertexOneInstanceDefinition,
+        SingleBufferDefinition, SingleInstanceBufferDefinition, TwoBuffersDefinition,
+        VertexMemberInfo, IncompatibleVertexDefinitionError, VertexMemberTy, Vertex,
+        VertexDefinition, VertexMember, VertexSource,
+    },
+    pipeline::viewport::{
+        Scissor, Viewport, ViewportsState,
+    },
+    query::{
+        OcclusionQueriesPool, QueryPipelineStatisticFlags, UnsafeQueriesRange, UnsafeQuery,
+        UnsafeQueryPool, QueryPoolCreationError, QueryType,
+    },
+    sampler::{
+        Compare as DepthStencilCompare, Sampler, SamplerAddressMode, SamplerCreationError,
+        UnnormalizedSamplerAddressMode,
+    },
+    swapchain::{
+        Surface, Swapchain, SwapchainAcquireFuture, SwapchainCreationError,
+    },
+    sync::{
+        Fence, FenceSignalFuture, JoinFuture, NowFuture, Semaphore, SemaphoreSignalFuture,
+        GpuFuture,
+    },
+};
+pub use vulkano_shaders as shaders;
+pub use vulkano_win as win;
+
+use crate::vk;
+use crate::vk::instance::debug::{DebugCallback, DebugCallbackCreationError, Message, MessageTypes};
+use crate::vk::instance::loader::{FunctionPointers, Loader};
 use std::borrow::Cow;
 use std::ops;
 use std::panic::RefUnwindSafe;
 use std::sync::Arc;
-use vulkano::device::Device;
-use vulkano::format::Format;
-use vulkano::framebuffer::{AttachmentsList, Framebuffer, FramebufferAbstract, FramebufferBuilder,
-                           FramebufferCreationError, RenderPassAbstract};
-use vulkano::instance::{ApplicationInfo, Instance, InstanceCreationError, InstanceExtensions,
-                        PhysicalDevice};
-use vulkano::instance::debug::{DebugCallback, DebugCallbackCreationError, Message, MessageTypes};
-use vulkano::instance::loader::{FunctionPointers, Loader};
-use vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode, SamplerCreationError};
-use vulkano::VulkanObject;
-use vulkano_win;
-
-#[cfg(all(target_os = "macos", not(test)))]
-use moltenvk_deps;
-
-#[cfg(all(target_os = "macos", not(test)))]
-use vulkano::instance::loader::DynamicLibraryLoader;
 
 /// The default application name used with the default `ApplicationInfo`.
 pub const DEFAULT_APPLICATION_NAME: &'static str = "nannou-app";
@@ -56,7 +176,7 @@ pub type FramebufferBuilderResult<R, A> =
 
 /// A builder struct that makes the process of building an instance more modular.
 #[derive(Default)]
-pub struct VulkanInstanceBuilder {
+pub struct InstanceBuilder {
     pub app_info: Option<ApplicationInfo<'static>>,
     pub extensions: Option<InstanceExtensions>,
     pub layers: Vec<String>,
@@ -65,7 +185,7 @@ pub struct VulkanInstanceBuilder {
 
 /// A builder struct that makes the process of building a debug callback more modular.
 #[derive(Default)]
-pub struct VulkanDebugCallbackBuilder {
+pub struct DebugCallbackBuilder {
     pub message_types: Option<MessageTypes>,
     pub user_callback: Option<BoxedUserCallback>,
 }
@@ -73,9 +193,9 @@ pub struct VulkanDebugCallbackBuilder {
 /// A builder struct that makes the process of building a **Sampler** more modular.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct SamplerBuilder {
-    pub mag_filter: Option<Filter>,
-    pub min_filter: Option<Filter>,
-    pub mipmap_mode: Option<MipmapMode>,
+    pub mag_filter: Option<vk::sampler::Filter>,
+    pub min_filter: Option<vk::sampler::Filter>,
+    pub mipmap_mode: Option<vk::sampler::MipmapMode>,
     pub address_u: Option<SamplerAddressMode>,
     pub address_v: Option<SamplerAddressMode>,
     pub address_w: Option<SamplerAddressMode>,
@@ -102,9 +222,9 @@ impl FramebufferObject {
         builder: F,
     ) -> Result<(), FramebufferCreationError>
     where
-        R: 'static + RenderPassAbstract + Send + Sync,
+        R: 'static + vk::framebuffer::RenderPassAbstract + Send + Sync,
         F: FnOnce(FramebufferBuilder<R, ()>) -> FramebufferBuilderResult<R, A>,
-        A: 'static + AttachmentsList + Send + Sync,
+        A: 'static + vk::framebuffer::AttachmentsList + Send + Sync,
     {
         let needs_creation = self.framebuffer.is_none()
             || !self.dimensions_match(dimensions)
@@ -132,11 +252,11 @@ impl FramebufferObject {
     /// Whether or not the given renderpass matches the framebuffer's render pass.
     pub fn render_passes_match<R>(&self, render_pass: R) -> bool
     where
-        R: RenderPassAbstract,
+        R: vk::framebuffer::RenderPassAbstract,
     {
         self.framebuffer
             .as_ref()
-            .map(|fb| RenderPassAbstract::inner(fb).internal_object())
+            .map(|fb| vk::framebuffer::RenderPassAbstract::inner(fb).internal_object())
             .map(|obj| obj == render_pass.inner().internal_object())
             .unwrap_or(false)
     }
@@ -150,7 +270,7 @@ impl FramebufferObject {
     }
 }
 
-impl VulkanInstanceBuilder {
+impl InstanceBuilder {
     /// Begin building a vulkano instance.
     pub fn new() -> Self {
         Default::default()
@@ -215,15 +335,9 @@ impl VulkanInstanceBuilder {
         self
     }
 
-    /// Add custom vulkan loader
-    pub fn add_loader(mut self, loader: FunctionPointers<Box<dyn Loader + Send + Sync>>) -> Self {
-        self.loader = Some(loader);
-        self
-    }
-
     /// Build the vulkan instance with the existing parameters.
     pub fn build(self) -> Result<Arc<Instance>, InstanceCreationError> {
-        let VulkanInstanceBuilder {
+        let InstanceBuilder {
             app_info,
             extensions,
             layers,
@@ -240,7 +354,7 @@ impl VulkanInstanceBuilder {
     }
 }
 
-impl VulkanDebugCallbackBuilder {
+impl DebugCallbackBuilder {
     /// Begin building a vulkan debug callback.
     pub fn new() -> Self {
         Default::default()
@@ -270,7 +384,7 @@ impl VulkanDebugCallbackBuilder {
         self,
         instance: &Arc<Instance>,
     ) -> Result<DebugCallback, DebugCallbackCreationError> {
-        let VulkanDebugCallbackBuilder {
+        let DebugCallbackBuilder {
             message_types,
             user_callback,
         } = self;
@@ -308,16 +422,16 @@ impl VulkanDebugCallbackBuilder {
 }
 
 impl SamplerBuilder {
-    pub const DEFAULT_MAG_FILTER: Filter = Filter::Linear;
-    pub const DEFAULT_MIN_FILTER: Filter = Filter::Linear;
-    pub const DEFAULT_MIPMAP_MODE: MipmapMode = MipmapMode::Nearest;
+    pub const DEFAULT_MAG_FILTER: vk::sampler::Filter = vk::sampler::Filter::Linear;
+    pub const DEFAULT_MIN_FILTER: vk::sampler::Filter = vk::sampler::Filter::Linear;
+    pub const DEFAULT_MIPMAP_MODE: vk::sampler::MipmapMode = vk::sampler::MipmapMode::Nearest;
     pub const DEFAULT_ADDRESS_U: SamplerAddressMode = SamplerAddressMode::ClampToEdge;
     pub const DEFAULT_ADDRESS_V: SamplerAddressMode = SamplerAddressMode::ClampToEdge;
     pub const DEFAULT_ADDRESS_W: SamplerAddressMode = SamplerAddressMode::ClampToEdge;
     pub const DEFAULT_MIP_LOD_BIAS: f32 = 0.0;
     pub const DEFAULT_MAX_ANISOTROPY: f32 = 1.0;
     pub const DEFAULT_MIN_LOD: f32 = 0.0;
-    pub const DEFAULT_MAX_LOD: f32 = 0.0;
+    pub const DEFAULT_MAX_LOD: f32 = 1.0;
 
     /// Begin building a new vulkan **Sampler**.
     pub fn new() -> Self {
@@ -326,20 +440,20 @@ impl SamplerBuilder {
 
     /// How the implementation should sample from the image when it is respectively larger than the
     /// original.
-    pub fn mag_filter(mut self, filter: Filter) -> Self {
+    pub fn mag_filter(mut self, filter: vk::sampler::Filter) -> Self {
         self.mag_filter = Some(filter);
         self
     }
 
     /// How the implementation should sample from the image when it is respectively smaller than
     /// the original.
-    pub fn min_filter(mut self, filter: Filter) -> Self {
+    pub fn min_filter(mut self, filter: vk::sampler::Filter) -> Self {
         self.min_filter = Some(filter);
         self
     }
 
     /// How the implementation should choose which mipmap to use.
-    pub fn mipmap_mode(mut self, mode: MipmapMode) -> Self {
+    pub fn mipmap_mode(mut self, mode: vk::sampler::MipmapMode) -> Self {
         self.mipmap_mode = Some(mode);
         self
     }
@@ -432,14 +546,14 @@ impl ops::Deref for FramebufferObject {
 
 /// The default set of required extensions used by Nannou.
 ///
-/// This is the same as calling `vulkano_win::required_extensions()`.
+/// This is the same as calling `vk::win::required_extensions()`.
 pub fn required_windowing_extensions() -> InstanceExtensions {
     vulkano_win::required_extensions()
 }
 
 /// Whether or not the format is sRGB.
 pub fn format_is_srgb(format: Format) -> bool {
-    use vulkano::format::Format::*;
+    use vk::format::Format::*;
     match format {
         R8Srgb |
         R8G8Srgb |
@@ -489,7 +603,10 @@ pub fn msaa_samples_limited(physical_device: &PhysicalDevice, target_msaa_sample
 }
 
 #[cfg(all(target_os = "macos", not(test)))]
-pub fn check_moltenvk(vulkan_builder: VulkanInstanceBuilder, settings: Option<moltenvk_deps::Install>) -> VulkanInstanceBuilder {
+pub fn check_moltenvk(
+    vulkan_builder: InstanceBuilder,
+    settings: Option<moltenvk_deps::Install>,
+) -> InstanceBuilder {
     let settings = match settings {
         Some(s) => s,
         None => Default::default(),
@@ -515,9 +632,8 @@ pub fn check_moltenvk(vulkan_builder: VulkanInstanceBuilder, settings: Option<mo
     }
 }
 
-
 pub fn required_extensions_with_loader<L>(ptrs: &FunctionPointers<L>)
-    -> InstanceExtensions 
+    -> InstanceExtensions
     where L: Loader
 {
     let ideal = InstanceExtensions {

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,23 +6,13 @@ use event::{Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase, Touchpad
 use frame::{self, Frame, RawFrame};
 use geom;
 use geom::{Point2, Vector2};
-use gpu;
 use std::any::Any;
 use std::{cmp, env, fmt, ops};
 use std::error::Error as StdError;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::AtomicBool;
-use vulkano::VulkanObject;
-use vulkano::device::{self, Device, DeviceExtensions};
-use vulkano::format::Format;
-use vulkano::framebuffer::{AttachmentsList, Framebuffer, FramebufferAbstract, FramebufferBuilder,
-                           FramebufferCreationError, RenderPassAbstract};
-use vulkano::instance::PhysicalDevice;
-use vulkano::swapchain::{ColorSpace, CompositeAlpha, PresentMode, SupportedPresentModes,
-                         SurfaceTransform, SwapchainCreationError};
-use vulkano::sync::{FenceSignalFuture, GpuFuture};
-use vulkano_win::{VkSurfaceBuild};
+use vk::{self, VulkanObject, win::VkSurfaceBuild};
 use winit::{self, MonitorId, MouseCursor};
 use winit::dpi::LogicalSize;
 use App;
@@ -39,9 +29,9 @@ pub const DEFAULT_DIMENSIONS: LogicalSize = LogicalSize { width: 1024.0, height:
 /// OpenGL context parameters can be specified via the `context` method.
 pub struct Builder<'app> {
     app: &'app App,
-    vulkan_physical_device: Option<PhysicalDevice<'app>>,
-    vulkan_device_extensions: Option<DeviceExtensions>,
-    vulkan_device_queue: Option<Arc<device::Queue>>,
+    vk_physical_device: Option<vk::PhysicalDevice<'app>>,
+    vk_device_extensions: Option<vk::DeviceExtensions>,
+    vk_device_queue: Option<Arc<vk::Queue>>,
     window: winit::WindowBuilder,
     title_was_set: bool,
     swapchain_builder: SwapchainBuilder,
@@ -223,7 +213,7 @@ fn_any!(ClosedFn<M>, ClosedFnAny);
 /// nannou-friendly API.
 #[derive(Debug)]
 pub struct Window {
-    pub(crate) queue: Arc<device::Queue>,
+    pub(crate) queue: Arc<vk::Queue>,
     pub(crate) surface: Arc<Surface>,
     msaa_samples: u32,
     pub(crate) swapchain: Arc<WindowSwapchain>,
@@ -233,21 +223,21 @@ pub struct Window {
     pub(crate) user_functions: UserFunctions,
     // If the user specified one of the following parameters, use these when recreating the
     // swapchain rather than our heuristics.
-    pub(crate) user_specified_present_mode: Option<PresentMode>,
+    pub(crate) user_specified_present_mode: Option<vk::swapchain::PresentMode>,
     pub(crate) user_specified_image_count: Option<u32>,
 }
 
 /// The surface type associated with a winit window.
-pub type Surface = vulkano::swapchain::Surface<winit::Window>;
+pub type Surface = vk::swapchain::Surface<winit::Window>;
 
 /// The swapchain type associated with a winit window surface.
-pub type Swapchain = vulkano::swapchain::Swapchain<winit::Window>;
+pub type Swapchain = vk::swapchain::Swapchain<winit::Window>;
 
 /// The vulkan image type associated with a winit window surface.
-pub type SwapchainImage = vulkano::image::swapchain::SwapchainImage<winit::Window>;
+pub type SwapchainImage = vk::image::swapchain::SwapchainImage<winit::Window>;
 
 /// The future representing the moment that the GPU will have access to the swapchain image.
-pub type SwapchainAcquireFuture = vulkano::swapchain::SwapchainAcquireFuture<winit::Window>;
+pub type SwapchainAcquireFuture = vk::swapchain::SwapchainAcquireFuture<winit::Window>;
 
 /// A swapchain and its images associated with a single window.
 pub(crate) struct WindowSwapchain {
@@ -266,7 +256,7 @@ pub(crate) struct WindowSwapchain {
     //
     // Destroying the `GpuFuture` blocks until the GPU is finished executing it. In order to avoid
     // that, we store the submission of the previous frame here.
-    pub(crate) previous_frame_end: Mutex<Option<FenceSignalFuture<Box<GpuFuture>>>>,
+    pub(crate) previous_frame_end: Mutex<Option<vk::FenceSignalFuture<Box<vk::GpuFuture>>>>,
 }
 
 /// Swapchain building parameters for which Nannou will provide a default if unspecified.
@@ -274,17 +264,17 @@ pub(crate) struct WindowSwapchain {
 /// See the builder methods for more details on each parameter.
 ///
 /// Valid parameters can be determined prior to building by checking the result of
-/// [vulkano::swapchain::Surface::capabilities](https://docs.rs/vulkano/latest/vulkano/swapchain/struct.Surface.html#method.capabilities).
+/// [vk::swapchain::Surface::capabilities](https://docs.rs/vulkano/latest/vulkano/swapchain/struct.Surface.html#method.capabilities).
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct SwapchainBuilder {
-    pub format: Option<Format>,
-    pub color_space: Option<ColorSpace>,
+    pub format: Option<vk::Format>,
+    pub color_space: Option<vk::swapchain::ColorSpace>,
     pub layers: Option<u32>,
-    pub present_mode: Option<PresentMode>,
-    pub composite_alpha: Option<CompositeAlpha>,
+    pub present_mode: Option<vk::swapchain::PresentMode>,
+    pub composite_alpha: Option<vk::swapchain::CompositeAlpha>,
     pub clipped: Option<bool>,
     pub image_count: Option<u32>,
-    pub surface_transform: Option<SurfaceTransform>,
+    pub surface_transform: Option<vk::swapchain::SurfaceTransform>,
 }
 
 /// A helper type for managing framebuffers associated with a window's swapchain images.
@@ -301,28 +291,30 @@ pub struct SwapchainBuilder {
 ///   recently been recreated and the framebuffers should be recreated accordingly.
 #[derive(Default)]
 pub struct SwapchainFramebuffers {
-    framebuffers: Vec<Arc<FramebufferAbstract + Send + Sync>>,
+    framebuffers: Vec<Arc<vk::FramebufferAbstract + Send + Sync>>,
 }
 
-pub type SwapchainFramebufferBuilder<A> = FramebufferBuilder<Arc<RenderPassAbstract + Send + Sync>, A>;
-pub type FramebufferBuildResult<A> = Result<SwapchainFramebufferBuilder<A>, FramebufferCreationError>;
+pub type SwapchainFramebufferBuilder<A> =
+    vk::FramebufferBuilder<Arc<vk::RenderPassAbstract + Send + Sync>, A>;
+pub type FramebufferBuildResult<A> =
+    Result<SwapchainFramebufferBuilder<A>, vk::FramebufferCreationError>;
 
 impl SwapchainFramebuffers {
     /// Ensure the framebuffers are up to date with the render pass and frame's swapchain image.
     pub fn update<F, A>(
         &mut self,
         frame: &RawFrame,
-        render_pass: Arc<RenderPassAbstract + Send + Sync>,
+        render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
         builder: F,
-    ) -> Result<(), FramebufferCreationError>
+    ) -> Result<(), vk::FramebufferCreationError>
     where
         F: Fn(SwapchainFramebufferBuilder<()>, Arc<SwapchainImage>) -> FramebufferBuildResult<A>,
-        A: 'static + AttachmentsList + Send + Sync,
+        A: 'static + vk::AttachmentsList + Send + Sync,
     {
         let mut just_created = false;
         while frame.swapchain_image_index() >= self.framebuffers.len() {
             let builder = builder(
-                Framebuffer::start(render_pass.clone()),
+                vk::Framebuffer::start(render_pass.clone()),
                 frame.swapchain_image().clone(),
             )?;
             let fb = builder.build()?;
@@ -331,13 +323,13 @@ impl SwapchainFramebuffers {
         }
 
         // If the dimensions for the current framebuffer do not match, recreate it.
-        let old_rp = RenderPassAbstract::inner(&self.framebuffers[frame.swapchain_image_index()])
+        let old_rp = vk::RenderPassAbstract::inner(&self.framebuffers[frame.swapchain_image_index()])
             .internal_object();
         let new_rp = render_pass.inner().internal_object();
         if !just_created && (frame.swapchain_image_is_new() || old_rp != new_rp) {
             let fb = &mut self.framebuffers[frame.swapchain_image_index()];
             let builder = builder(
-                Framebuffer::start(render_pass.clone()),
+                vk::Framebuffer::start(render_pass.clone()),
                 frame.swapchain_image().clone(),
             )?;
             let new_fb = builder.build()?;
@@ -348,7 +340,7 @@ impl SwapchainFramebuffers {
 }
 
 impl ops::Deref for SwapchainFramebuffers {
-    type Target = [Arc<FramebufferAbstract + Send + Sync>];
+    type Target = [Arc<vk::FramebufferAbstract + Send + Sync>];
     fn deref(&self) -> &Self::Target {
         &self.framebuffers
     }
@@ -357,20 +349,23 @@ impl ops::Deref for SwapchainFramebuffers {
 /// The errors that might occur while constructing a `Window`.
 #[derive(Debug)]
 pub enum BuildError {
-    SurfaceCreation(vulkano_win::CreationError),
-    DeviceCreation(vulkano::device::DeviceCreationError),
-    SwapchainCreation(SwapchainCreationError),
-    SwapchainCapabilities(vulkano::swapchain::CapabilitiesError),
+    SurfaceCreation(vk::win::CreationError),
+    DeviceCreation(vk::DeviceCreationError),
+    SwapchainCreation(vk::SwapchainCreationError),
+    SwapchainCapabilities(vk::swapchain::CapabilitiesError),
     RenderDataCreation(frame::RenderDataCreationError),
     SurfaceDoesNotSupportCompositeAlphaOpaque,
 }
 
 impl SwapchainBuilder {
     pub const DEFAULT_CLIPPED: bool = true;
-    pub const DEFAULT_COLOR_SPACE: ColorSpace = ColorSpace::SrgbNonLinear;
-    pub const DEFAULT_COMPOSITE_ALPHA: CompositeAlpha = CompositeAlpha::Opaque;
+    pub const DEFAULT_COLOR_SPACE: vk::swapchain::ColorSpace =
+        vk::swapchain::ColorSpace::SrgbNonLinear;
+    pub const DEFAULT_COMPOSITE_ALPHA: vk::swapchain::CompositeAlpha =
+        vk::swapchain::CompositeAlpha::Opaque;
     pub const DEFAULT_LAYERS: u32 = 1;
-    pub const DEFAULT_SURFACE_TRANSFORM: SurfaceTransform = SurfaceTransform::Identity;
+    pub const DEFAULT_SURFACE_TRANSFORM: vk::swapchain::SurfaceTransform =
+        vk::swapchain::SurfaceTransform::Identity;
 
     /// A new empty **SwapchainBuilder** with all parameters set to `None`.
     pub fn new() -> Self {
@@ -400,7 +395,7 @@ impl SwapchainBuilder {
     /// space.
     ///
     /// See the [vulkano docs](https://docs.rs/vulkano/latest/vulkano/format/enum.Format.html).
-    pub fn format(mut self, format: Format) -> Self {
+    pub fn format(mut self, format: vk::Format) -> Self {
         self.format = Some(format);
         self
     }
@@ -414,7 +409,7 @@ impl SwapchainBuilder {
     /// space.
     ///
     /// See the [vulkano docs](https://docs.rs/vulkano/latest/vulkano/swapchain/enum.ColorSpace.html).
-    pub fn color_space(mut self, color_space: ColorSpace) -> Self {
+    pub fn color_space(mut self, color_space: vk::swapchain::ColorSpace) -> Self {
         self.color_space = Some(color_space);
         self
     }
@@ -424,7 +419,7 @@ impl SwapchainBuilder {
     /// By default, nannou uses `CompositeAlpha::Opaque`.
     ///
     /// See the [vulkano docs](https://docs.rs/vulkano/latest/vulkano/swapchain/enum.CompositeAlpha.html).
-    pub fn composite_alpha(mut self, composite_alpha: CompositeAlpha) -> Self {
+    pub fn composite_alpha(mut self, composite_alpha: vk::swapchain::CompositeAlpha) -> Self {
         self.composite_alpha = Some(composite_alpha);
         self
     }
@@ -437,7 +432,7 @@ impl SwapchainBuilder {
     /// `RefreshSync`, nannou will use the `Fifo` present m ode with an `image_count` of `2`.
     ///
     /// See the [vulkano docs](https://docs.rs/vulkano/latest/vulkano/swapchain/enum.PresentMode.html).
-    pub fn present_mode(mut self, present_mode: PresentMode) -> Self {
+    pub fn present_mode(mut self, present_mode: vk::swapchain::PresentMode) -> Self {
         self.present_mode = Some(present_mode);
         self
     }
@@ -466,7 +461,7 @@ impl SwapchainBuilder {
     /// A transformation to apply to the image before showing it on the screen.
     ///
     /// See the [vulkano docs](https://docs.rs/vulkano/latest/vulkano/swapchain/enum.SurfaceTransform.html).
-    pub fn surface_transform(mut self, surface_transform: SurfaceTransform) -> Self {
+    pub fn surface_transform(mut self, surface_transform: vk::swapchain::SurfaceTransform) -> Self {
         self.surface_transform = Some(surface_transform);
         self
     }
@@ -483,15 +478,15 @@ impl SwapchainBuilder {
     /// swapchain's size.
     pub(crate) fn build<S>(
         self,
-        device: Arc<Device>,
+        device: Arc<vk::Device>,
         surface: Arc<Surface>,
         sharing_mode: S,
         loop_mode: &LoopMode,
         fallback_dimensions: Option<[u32; 2]>,
         old_swapchain: Option<&Arc<Swapchain>>,
-    ) -> Result<(Arc<Swapchain>, Vec<Arc<SwapchainImage>>), SwapchainCreationError>
+    ) -> Result<(Arc<Swapchain>, Vec<Arc<SwapchainImage>>), vk::SwapchainCreationError>
     where
-        S: Into<vulkano::sync::SharingMode>,
+        S: Into<vk::sync::SharingMode>,
     {
         let capabilities = surface.capabilities(device.physical_device())
             .expect("failed to retrieve surface capabilities");
@@ -511,7 +506,7 @@ impl SwapchainBuilder {
                 capabilities
                     .supported_formats
                     .iter()
-                    .filter(|&&(fmt, cs)| gpu::format_is_srgb(fmt) && cs == color_space)
+                    .filter(|&&(fmt, cs)| vk::format_is_srgb(fmt) && cs == color_space)
                     .next()
                     .or_else(|| {
                         // Otherwise just try and math the color space.
@@ -522,7 +517,7 @@ impl SwapchainBuilder {
                             .next()
                     })
                     .map(|&(fmt, _cs)| fmt)
-                    .ok_or(SwapchainCreationError::UnsupportedFormat)?
+                    .ok_or(vk::SwapchainCreationError::UnsupportedFormat)?
             }
         };
 
@@ -541,7 +536,7 @@ impl SwapchainBuilder {
             Some(alpha) => alpha,
             None => match capabilities.supported_composite_alpha.opaque {
                 true => Self::DEFAULT_COMPOSITE_ALPHA,
-                false => return Err(SwapchainCreationError::UnsupportedCompositeAlpha),
+                false => return Err(vk::SwapchainCreationError::UnsupportedCompositeAlpha),
             }
         };
 
@@ -573,10 +568,10 @@ impl SwapchainBuilder {
 pub fn preferred_present_mode_and_image_count(
     loop_mode: &LoopMode,
     min_image_count: u32,
-    present_mode: Option<PresentMode>,
+    present_mode: Option<vk::swapchain::PresentMode>,
     image_count: Option<u32>,
-    supported_present_modes: &SupportedPresentModes,
-) -> (PresentMode, u32) {
+    supported_present_modes: &vk::swapchain::SupportedPresentModes,
+) -> (vk::swapchain::PresentMode, u32) {
     match (present_mode, image_count) {
         (Some(pm), Some(ic)) => (pm, ic),
         (None, _) => match *loop_mode {
@@ -584,26 +579,26 @@ pub fn preferred_present_mode_and_image_count(
                 let image_count = image_count.unwrap_or_else(|| {
                     cmp::max(min_image_count, 2)
                 });
-                (PresentMode::Fifo, image_count)
+                (vk::swapchain::PresentMode::Fifo, image_count)
             }
             LoopMode::Wait { .. } | LoopMode::Rate { .. } => {
                 if supported_present_modes.mailbox {
                     let image_count = image_count
                         .unwrap_or_else(|| cmp::max(min_image_count, 3));
-                    (PresentMode::Mailbox, image_count)
+                    (vk::swapchain::PresentMode::Mailbox, image_count)
                 } else {
                     let image_count = image_count
                         .unwrap_or_else(|| cmp::max(min_image_count, 2));
-                    (PresentMode::Fifo, image_count)
+                    (vk::swapchain::PresentMode::Fifo, image_count)
                 }
             }
         }
         (Some(present_mode), None) => {
             let image_count = match present_mode {
-                PresentMode::Immediate => min_image_count,
-                PresentMode::Mailbox => cmp::max(min_image_count, 3),
-                PresentMode::Fifo => cmp::max(min_image_count, 2),
-                PresentMode::Relaxed => cmp::max(min_image_count, 2),
+                vk::swapchain::PresentMode::Immediate => min_image_count,
+                vk::swapchain::PresentMode::Mailbox => cmp::max(min_image_count, 3),
+                vk::swapchain::PresentMode::Fifo => cmp::max(min_image_count, 2),
+                vk::swapchain::PresentMode::Relaxed => cmp::max(min_image_count, 2),
             };
             (present_mode, image_count)
         }
@@ -615,9 +610,9 @@ impl<'app> Builder<'app> {
     pub fn new(app: &'app App) -> Self {
         Builder {
             app,
-            vulkan_physical_device: None,
-            vulkan_device_extensions: None,
-            vulkan_device_queue: None,
+            vk_physical_device: None,
+            vk_device_extensions: None,
+            vk_device_queue: None,
             window: winit::WindowBuilder::new(),
             title_was_set: false,
             swapchain_builder: Default::default(),
@@ -633,8 +628,8 @@ impl<'app> Builder<'app> {
     }
 
     /// The physical device to associate with the window surface's swapchain.
-    pub fn vulkan_physical_device(mut self, device: PhysicalDevice<'app>) -> Self {
-        self.vulkan_physical_device = Some(device);
+    pub fn vk_physical_device(mut self, device: vk::PhysicalDevice<'app>) -> Self {
+        self.vk_physical_device = Some(device);
         self
     }
 
@@ -643,8 +638,8 @@ impl<'app> Builder<'app> {
     /// The device associated with the window's swapchain *must* always have the `khr_swapchain`
     /// feature enabled, so it will be implicitly enabled whether or not it is specified in this
     /// given set of extensions.
-    pub fn vulkan_device_extensions(mut self, extensions: DeviceExtensions) -> Self {
-        self.vulkan_device_extensions = Some(extensions);
+    pub fn vk_device_extensions(mut self, extensions: vk::DeviceExtensions) -> Self {
+        self.vk_device_extensions = Some(extensions);
         self
     }
 
@@ -656,11 +651,11 @@ impl<'app> Builder<'app> {
     /// Once the window is built, this queue can be accessed via the `window.swapchain_queue()`
     /// method.
     ///
-    /// Note: If this builder method is called, previous calls to `vulkan_physical_device` and
-    /// `vulkan_device_extensions` will be ignored as specifying the queue for the sharing mode
+    /// Note: If this builder method is called, previous calls to `vk_physical_device` and
+    /// `vk_device_extensions` will be ignored as specifying the queue for the sharing mode
     /// implies which logical device is desired.
-    pub fn vulkan_device_queue(mut self, queue: Arc<device::Queue>) -> Self {
-        self.vulkan_device_queue = Some(queue);
+    pub fn vk_device_queue(mut self, queue: Arc<vk::Queue>) -> Self {
+        self.vk_device_queue = Some(queue);
         self
     }
 
@@ -939,9 +934,9 @@ impl<'app> Builder<'app> {
     pub fn build(self) -> Result<Id, BuildError> {
         let Builder {
             app,
-            vulkan_physical_device,
-            vulkan_device_extensions,
-            vulkan_device_queue,
+            vk_physical_device,
+            vk_device_extensions,
+            vk_device_queue,
             mut window,
             title_was_set,
             swapchain_builder,
@@ -990,16 +985,16 @@ impl<'app> Builder<'app> {
         }
 
         // Build the vulkan surface.
-        let surface = window.build_vk_surface(&app.events_loop, app.vulkan_instance.clone())?;
+        let surface = window.build_vk_surface(&app.events_loop, app.vk_instance.clone())?;
 
         // The logical device queue to use as the swapchain sharing mode.
         // This queue will also be used for constructing the `Frame`'s intermediary image.
-        let queue = match vulkan_device_queue {
+        let queue = match vk_device_queue {
             Some(queue) => queue,
             None => {
                 // Retrieve the physical, vulkan-supported device to use.
-                let physical_device = vulkan_physical_device
-                    .or_else(|| app.default_vulkan_physical_device())
+                let physical_device = vk_physical_device
+                    .or_else(|| app.default_vk_physical_device())
                     .unwrap_or_else(|| unimplemented!());
 
                 // Select the queue family to use. Default to the first graphics-supporting queue.
@@ -1011,15 +1006,15 @@ impl<'app> Builder<'app> {
                 let queue_priority = 0.5;
 
                 // The required device extensions.
-                let mut device_ext = vulkan_device_extensions
-                    .unwrap_or_else(DeviceExtensions::none);
+                let mut device_ext = vk_device_extensions
+                    .unwrap_or_else(vk::DeviceExtensions::none);
                 device_ext.khr_swapchain = true;
 
                 // Enable all supported device features.
                 let features = physical_device.supported_features();
 
                 // Construct the logical device and queues.
-                let (_device, mut queues) = Device::new(
+                let (_device, mut queues) = vk::Device::new(
                     physical_device,
                     features,
                     &device_ext,
@@ -1059,7 +1054,7 @@ impl<'app> Builder<'app> {
             Some(View::WithModel(_)) | Some(View::Sketch(_)) | None => {
                 let target_msaa_samples = msaa_samples.unwrap_or(Frame::DEFAULT_MSAA_SAMPLES);
                 let physical_device = queue.device().physical_device();
-                let msaa_samples = gpu::msaa_samples_limited(&physical_device, target_msaa_samples);
+                let msaa_samples = vk::msaa_samples_limited(&physical_device, target_msaa_samples);
                 let render_data = frame::RenderData::new(
                     queue.device().clone(),
                     swapchain.dimensions(),
@@ -1109,9 +1104,9 @@ impl<'app> Builder<'app> {
     {
         let Builder {
             app,
-            vulkan_physical_device,
-            vulkan_device_extensions,
-            vulkan_device_queue,
+            vk_physical_device,
+            vk_device_extensions,
+            vk_device_queue,
             window,
             title_was_set,
             swapchain_builder,
@@ -1121,9 +1116,9 @@ impl<'app> Builder<'app> {
         let window = map(window);
         Builder {
             app,
-            vulkan_physical_device,
-            vulkan_device_extensions,
-            vulkan_device_queue,
+            vk_physical_device,
+            vk_device_extensions,
+            vk_device_queue,
             window,
             title_was_set,
             swapchain_builder,
@@ -1416,12 +1411,12 @@ impl Window {
     /// The vulkan logical device on which the window's swapchain is running.
     ///
     /// This is shorthand for `DeviceOwned::device(window.swapchain())`.
-    pub fn swapchain_device(&self) -> &Arc<device::Device> {
-        device::DeviceOwned::device(self.swapchain())
+    pub fn swapchain_device(&self) -> &Arc<vk::Device> {
+        vk::DeviceOwned::device(self.swapchain())
     }
 
     /// The vulkan graphics queue on which the window swapchain work is run.
-    pub fn swapchain_queue(&self) -> &Arc<device::Queue> {
+    pub fn swapchain_queue(&self) -> &Arc<vk::Queue> {
         &self.queue
     }
 
@@ -1542,26 +1537,26 @@ impl fmt::Display for BuildError {
     }
 }
 
-impl From<vulkano_win::CreationError> for BuildError {
-    fn from(e: vulkano_win::CreationError) -> Self {
+impl From<vk::win::CreationError> for BuildError {
+    fn from(e: vk::win::CreationError) -> Self {
         BuildError::SurfaceCreation(e)
     }
 }
 
-impl From<vulkano::device::DeviceCreationError> for BuildError {
-    fn from(e: vulkano::device::DeviceCreationError) -> Self {
+impl From<vk::DeviceCreationError> for BuildError {
+    fn from(e: vk::DeviceCreationError) -> Self {
         BuildError::DeviceCreation(e)
     }
 }
 
-impl From<vulkano::swapchain::SwapchainCreationError> for BuildError {
-    fn from(e: vulkano::swapchain::SwapchainCreationError) -> Self {
+impl From<vk::swapchain::SwapchainCreationError> for BuildError {
+    fn from(e: vk::swapchain::SwapchainCreationError) -> Self {
         BuildError::SwapchainCreation(e)
     }
 }
 
-impl From<vulkano::swapchain::CapabilitiesError> for BuildError {
-    fn from(e: vulkano::swapchain::CapabilitiesError) -> Self {
+impl From<vk::swapchain::CapabilitiesError> for BuildError {
+    fn from(e: vk::swapchain::CapabilitiesError) -> Self {
         BuildError::SwapchainCapabilities(e)
     }
 }


### PR DESCRIPTION
Also removes the `gpu` module in favour of the new `vk` module.

Many vulkano items have been re-exported into the `vk` module as well to
avoid name repetition and ease access to common types. Items that would
have an ambiguous meaning if they were to be re-exported have been left
out of the re-export list.

Methods and fields on the `App` and `Window` types starting with `vulkan_`
have been renamed to start with `vk_`.

See the examples for how to update and rid of your boilerplate today!