### PR TITLE
Add a `ViewportBuilder` type.

### DIFF
--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -129,11 +129,7 @@ fn model(app: &App) -> Model {
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
-    let viewport = vk::Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [w as _, h as _],
-        depth_range: 0.0..1.0,
-    };
+    let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState {
         line_width: None,
         viewports: Some(vec![viewport]),

--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -137,11 +137,7 @@ fn model(app: &App) -> Model {
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
-    let viewport = vk::Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [w as _, h as _],
-        depth_range: 0.0..1.0,
-    };
+    let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState {
         line_width: None,
         viewports: Some(vec![viewport]),

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -146,11 +146,7 @@ fn model(app: &App) -> Model {
 
 fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
-    let viewport = vk::Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [w as _, h as _],
-        depth_range: 0.0..1.0,
-    };
+    let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState {
         line_width: None,
         viewports: Some(vec![viewport]),

--- a/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
+++ b/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
@@ -311,11 +311,7 @@ fn create_graphics_pipeline(
         .vertex_shader(vertex_shader.main_entry_point(), ())
         .triangle_list()
         .viewports_dynamic_scissors_irrelevant(1)
-        .viewports(Some(vk::Viewport {
-            origin: [0.0, 0.0],
-            dimensions,
-            depth_range: 0.0..1.0,
-        }))
+        .viewports(Some(vk::ViewportBuilder::new().build(dimensions)))
         .fragment_shader(fragment_shader.main_entry_point(), ())
         .depth_stencil_simple_depth()
         .render_pass(vk::Subpass::from(render_pass.clone(), 0).unwrap())

--- a/examples/vulkan/vk_quad_warp/warp.rs
+++ b/examples/vulkan/vk_quad_warp/warp.rs
@@ -129,11 +129,7 @@ pub(crate) fn view(app: &App, model: &Model, inter_image: Arc<vk::AttachmentImag
         .expect("failed to wait for buffer and image creation future");
 
     let [w, h] = frame.swapchain_image().dimensions();
-    let viewport = vk::Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [w as _, h as _],
-        depth_range: 0.0..1.0,
-    };
+    let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState {
         line_width: None,
         viewports: Some(vec![viewport]),

--- a/examples/vulkan/vk_shader_include/mod.rs
+++ b/examples/vulkan/vk_shader_include/mod.rs
@@ -103,11 +103,7 @@ fn model(app: &App) -> Model {
 
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
-    let viewport = vk::Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [w as _, h as _],
-        depth_range: 0.0..1.0,
-    };
+    let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState {
         line_width: None,
         viewports: Some(vec![viewport]),

--- a/examples/vulkan/vk_teapot.rs
+++ b/examples/vulkan/vk_teapot.rs
@@ -237,11 +237,7 @@ fn create_graphics_pipeline(
         .vertex_shader(vertex_shader.main_entry_point(), ())
         .triangle_list()
         .viewports_dynamic_scissors_irrelevant(1)
-        .viewports(Some(vk::Viewport {
-            origin: [0.0, 0.0],
-            dimensions,
-            depth_range: 0.0..1.0,
-        }))
+        .viewports(Some(vk::ViewportBuilder::new().build(dimensions)))
         .fragment_shader(fragment_shader.main_entry_point(), ())
         .depth_stencil_simple_depth()
         .render_pass(vk::Subpass::from(render_pass.clone(), 0).unwrap())

--- a/examples/vulkan/vk_teapot_camera.rs
+++ b/examples/vulkan/vk_teapot_camera.rs
@@ -367,11 +367,7 @@ fn create_graphics_pipeline(
         .vertex_shader(vertex_shader.main_entry_point(), ())
         .triangle_list()
         .viewports_dynamic_scissors_irrelevant(1)
-        .viewports(Some(vk::Viewport {
-            origin: [0.0, 0.0],
-            dimensions,
-            depth_range: 0.0..1.0,
-        }))
+        .viewports(Some(vk::ViewportBuilder::new().build(dimensions)))
         .fragment_shader(fragment_shader.main_entry_point(), ())
         .depth_stencil_simple_depth()
         .render_pass(vk::Subpass::from(render_pass.clone(), 0).unwrap())

--- a/examples/vulkan/vk_triangle.rs
+++ b/examples/vulkan/vk_triangle.rs
@@ -120,12 +120,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     // Dynamic viewports allow us to recreate just the viewport when the window is resized
     // Otherwise we would have to recreate the whole pipeline.
     let [w, h] = frame.swapchain_image().dimensions();
-    let viewport = vk::Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [w as _, h as _],
-        depth_range: 0.0..1.0,
-    };
-
+    let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState {
         line_width: None,
         viewports: Some(vec![viewport]),

--- a/examples/vulkan/vk_triangle_raw_frame.rs
+++ b/examples/vulkan/vk_triangle_raw_frame.rs
@@ -125,11 +125,7 @@ fn view(_app: &App, model: &Model, frame: RawFrame) -> RawFrame {
     // Dynamic viewports allow us to recreate just the viewport when the window is resized
     // Otherwise we would have to recreate the whole pipeline.
     let [w, h] = frame.swapchain_image().dimensions();
-    let viewport = vk::Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [w as _, h as _],
-        depth_range: 0.0..1.0,
-    };
+    let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState {
         line_width: None,
         viewports: Some(vec![viewport]),

--- a/src/draw/backend/vulkano.rs
+++ b/src/draw/backend/vulkano.rs
@@ -450,11 +450,7 @@ pub fn create_render_pass_load(
 
 /// The dynamic state for the renderer.
 pub fn dynamic_state(viewport_dimensions: [f32; 2]) -> vk::DynamicState {
-    let viewport = vk::Viewport {
-        origin: [0.0, 0.0],
-        dimensions: viewport_dimensions,
-        depth_range: 0.0 .. 1.0,
-    };
+    let viewport = vk::ViewportBuilder::new().build(viewport_dimensions);
     let viewports = Some(vec![viewport]);
     let line_width = None;
     let scissors = None;


### PR DESCRIPTION
This simplifies the viewport creation process by removing the need to
specify the origin and depth_range, which can use reasonable defaults in
the vast majority of cases.

The defaults can be retrieved via `ViewportBuilder::DEFAULT_ORIGIN` and
`ViewportBuilder::DEFAULT_DEPTH_RANGE`.