### PR TITLE
Adding in DynamicLibraryLoader to vk.rs

### DIFF
--- a/src/vk.rs
+++ b/src/vk.rs
@@ -136,7 +136,7 @@ pub use vulkano_win as win;
 
 use crate::vk;
 use crate::vk::instance::debug::{DebugCallback, DebugCallbackCreationError, Message, MessageTypes};
-use crate::vk::instance::loader::{FunctionPointers, Loader};
+use crate::vk::instance::loader::{DynamicLibraryLoader, FunctionPointers, Loader};
 use std::borrow::Cow;
 use std::ops;
 use std::panic::RefUnwindSafe;


### PR DESCRIPTION
use vulkano::instance::loader::DynamicLibraryLoader was missing from the vk.rs file which meant it would throw an error when compiling on mac. 