### PR TITLE
Add `DynamicStateBuilder` trait to ease `DynamicState` creation

### DIFF
--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -130,11 +130,7 @@ fn model(app: &App) -> Model {
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
-    let dynamic_state = vk::DynamicState {
-        line_width: None,
-        viewports: Some(vec![viewport]),
-        scissors: None,
-    };
+    let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
 
     // Update view_fbo in case of resize.
     model.view_fbo.borrow_mut()

--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -138,11 +138,7 @@ fn model(app: &App) -> Model {
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
-    let dynamic_state = vk::DynamicState {
-        line_width: None,
-        viewports: Some(vec![viewport]),
-        scissors: None,
-    };
+    let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
 
     // Update view_fbo in case of window resize.
     model.view_fbo.borrow_mut()

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -147,11 +147,7 @@ fn model(app: &App) -> Model {
 fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
-    let dynamic_state = vk::DynamicState {
-        line_width: None,
-        viewports: Some(vec![viewport]),
-        scissors: None,
-    };
+    let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
 
     // Update view_fbo in case of window resize.
     model.view_fbo.borrow_mut()

--- a/examples/vulkan/vk_quad_warp/warp.rs
+++ b/examples/vulkan/vk_quad_warp/warp.rs
@@ -130,11 +130,7 @@ pub(crate) fn view(app: &App, model: &Model, inter_image: Arc<vk::AttachmentImag
 
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
-    let dynamic_state = vk::DynamicState {
-        line_width: None,
-        viewports: Some(vec![viewport]),
-        scissors: None,
-    };
+    let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
 
     // Update view_fbo in case of window resize.
     warp.view_fbo.borrow_mut()

--- a/examples/vulkan/vk_shader_include/mod.rs
+++ b/examples/vulkan/vk_shader_include/mod.rs
@@ -104,11 +104,7 @@ fn model(app: &App) -> Model {
 fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
-    let dynamic_state = vk::DynamicState {
-        line_width: None,
-        viewports: Some(vec![viewport]),
-        scissors: None,
-    };
+    let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
 
     // Update the view_fbo in case of window resize.
     model.view_fbo.borrow_mut()

--- a/examples/vulkan/vk_triangle.rs
+++ b/examples/vulkan/vk_triangle.rs
@@ -121,11 +121,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     // Otherwise we would have to recreate the whole pipeline.
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
-    let dynamic_state = vk::DynamicState {
-        line_width: None,
-        viewports: Some(vec![viewport]),
-        scissors: None,
-    };
+    let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
 
     // Update the view_fbo.
     model.view_fbo.borrow_mut()

--- a/examples/vulkan/vk_triangle_raw_frame.rs
+++ b/examples/vulkan/vk_triangle_raw_frame.rs
@@ -126,11 +126,7 @@ fn view(_app: &App, model: &Model, frame: RawFrame) -> RawFrame {
     // Otherwise we would have to recreate the whole pipeline.
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
-    let dynamic_state = vk::DynamicState {
-        line_width: None,
-        viewports: Some(vec![viewport]),
-        scissors: None,
-    };
+    let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
 
     // Update framebuffers so that count matches swapchain image count and dimensions match.
     model.framebuffers.borrow_mut()

--- a/src/draw/backend/vulkano.rs
+++ b/src/draw/backend/vulkano.rs
@@ -6,7 +6,7 @@ use math::{BaseFloat, NumCast};
 use std::error::Error as StdError;
 use std::fmt;
 use std::sync::Arc;
-use vk::{self, DeviceOwned, GpuFuture, RenderPassDesc};
+use vk::{self, DeviceOwned, DynamicStateBuilder, GpuFuture, RenderPassDesc};
 
 /// A type used for rendering a **nannou::draw::Mesh** with a vulkan graphics pipeline.
 pub struct Renderer {
@@ -451,10 +451,7 @@ pub fn create_render_pass_load(
 /// The dynamic state for the renderer.
 pub fn dynamic_state(viewport_dimensions: [f32; 2]) -> vk::DynamicState {
     let viewport = vk::ViewportBuilder::new().build(viewport_dimensions);
-    let viewports = Some(vec![viewport]);
-    let line_width = None;
-    let scissors = None;
-    vk::DynamicState { line_width, viewports, scissors }
+    vk::DynamicState::default().viewports(vec![viewport])
 }
 
 /// The graphics pipeline used by the renderer.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -22,7 +22,7 @@ pub use osc;
 pub use rand::{random, random_f32, random_f64, random_range};
 pub use time::DurationF64;
 pub use ui;
-pub use vk::{self, DeviceOwned as VulkanDeviceOwned, GpuFuture};
+pub use vk::{self, DeviceOwned as VulkanDeviceOwned, DynamicStateBuilder, GpuFuture};
 pub use window::{self, Id as WindowId};
 
 // The following constants have "regular" names for the `DefaultScalar` type and type suffixes for

--- a/src/vk.rs
+++ b/src/vk.rs
@@ -212,6 +212,34 @@ pub struct ViewportBuilder {
     pub depth_range: Option<Range<f32>>,
 }
 
+/// A simple trait that extends the `DynamicState` type with builder methods.
+///
+/// This fills a similar role to the `SamplerBuilder` and `ViewportBuilder` structs, but seeing as
+/// `DynamicState` already uses `Option`s for all its fields, a trait allows for a simpler
+/// approach.
+///
+/// This trait is included within the `nannou::prelude` for ease of access.
+pub trait DynamicStateBuilder {
+    fn line_width(self, line_width: f32) -> Self;
+    fn viewports(self, viewports: Vec<Viewport>) -> Self;
+    fn scissors(self, scissors: Vec<Scissor>) -> Self;
+}
+
+impl DynamicStateBuilder for DynamicState {
+    fn line_width(mut self, line_width: f32) -> Self {
+        self.line_width = Some(line_width);
+        self
+    }
+    fn viewports(mut self, viewports: Vec<Viewport>) -> Self {
+        self.viewports = Some(viewports);
+        self
+    }
+    fn scissors(mut self, scissors: Vec<Scissor>) -> Self {
+        self.scissors = Some(scissors);
+        self
+    }
+}
+
 // The user vulkan debug callback allocated on the heap to avoid complicated type params.
 type BoxedUserCallback = Box<Fn(&Message) + 'static + Send + RefUnwindSafe>;
 


### PR DESCRIPTION
This adds a trait that allows for specifying `DynamicState` params via
builder methods, allowing the user to not have to think about `scissors`
or `line_width` until they have to.