### PR TITLE
[v0.9] Rebase vulkano nannou_patches branch onto master. Update winit.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ homepage = "https://github.com/MindBuffer/nannou"
 [dependencies]
 approx = "0.1"
 cgmath = { version = "0.16", features = ["serde"] }
-conrod_core = "0.63"
-conrod_winit = "0.63"
-conrod_vulkano = "0.63"
+conrod_core = { git = "https://github.com/mitchmindtree/conrod", branch = "update_vulkano_nannou_patches" }
+conrod_winit = { git = "https://github.com/mitchmindtree/conrod", branch = "update_vulkano_nannou_patches" }
+conrod_vulkano = { git = "https://github.com/mitchmindtree/conrod", branch = "update_vulkano_nannou_patches" }
 cpal = "0.8"
 daggy = "0.6"
 find_folder = "0.3"
@@ -32,13 +32,10 @@ toml = "0.4"
 vulkano = { git = "https://github.com/mitchmindtree/vulkano", branch = "nannou_patches" }
 vulkano-win = { git = "https://github.com/mitchmindtree/vulkano", branch = "nannou_patches" }
 vulkano-shaders = { git = "https://github.com/mitchmindtree/vulkano", branch = "nannou_patches" }
-winit = "0.18"
+winit = "0.19"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 moltenvk_deps = "0.1"
-
-[replace]
-"vulkano:0.11.1" = { git = "https://github.com/mitchmindtree/vulkano", branch = "nannou_patches" }
 
 # --------------- Nannou Examples
 [[example]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,10 @@
 //! examples](https://github.com/nannou-org/nannou/tree/master/examples) to get an idea of how
 //! nannou applications are structured and how the API works.
 
+pub extern crate conrod_core;
+pub extern crate conrod_vulkano;
+#[macro_use]
+pub extern crate conrod_winit;
 pub extern crate daggy;
 pub extern crate find_folder;
 extern crate serde;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,8 @@
 //! The User Interface API. Instantiate a [**Ui**](struct.Ui.html) via `app.new_ui()`.
 
-pub extern crate conrod_core;
-pub extern crate conrod_winit;
-pub extern crate conrod_vulkano;
-
+pub use crate::conrod_core;
+pub use crate::conrod_vulkano;
+pub use crate::conrod_winit;
 pub use self::conrod_core::event::Input;
 pub use self::conrod_core::{color, cursor, event, graph, image, input, position, scroll, text,
                             theme, utils, widget};
@@ -701,11 +700,15 @@ pub fn draw_primitives(
     Ok(())
 }
 
+mod conrod_winit_conv {
+    conrod_winit::conversion_fns!();
+}
+
 /// Convert the given window event to a UI Input.
 ///
 /// Returns `None` if there's no associated UI Input for the given event.
 pub fn winit_window_event_to_input(event: winit::WindowEvent, window: &Window) -> Option<Input> {
-    conrod_winit::convert_window_event(event, window)
+    conrod_winit_conv::convert_window_event(event, window)
 }
 
 impl From<RenderTargetCreationError> for BuildError {


### PR DESCRIPTION
In order to update winit and rebase nannou_patches to the latest master
of vulkano, conrod's vulkano dependency also had to be updated.

I'll hold off publishing a new version of conrod_vulkano until we can
land whatever the necessary image layout fix is in vulkano and get a new
vulkano version published. Until then, v0.9 will use a branch of the
conrod crates called `update_vulkano_nannou_patches`.