### PR TITLE
Remove explicitly specified initial and final layouts from all renderpass instances

### DIFF
--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -65,8 +65,6 @@ fn model(app: &App) -> Model {
                     store: Store,
                     format: app.main_window().swapchain().format(),
                     samples: app.main_window().msaa_samples(),
-                    initial_layout: ImageLayout::PresentSrc,
-                    final_layout: ImageLayout::PresentSrc,
                 }
             },
             pass: {

--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -49,8 +49,6 @@ fn model(app: &App) -> Model {
                     store: Store,
                     format: app.main_window().swapchain().format(),
                     samples: app.main_window().msaa_samples(),
-                    initial_layout: ImageLayout::PresentSrc,
-                    final_layout: ImageLayout::PresentSrc,
                 }
             },
             pass: {

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -66,8 +66,6 @@ fn model(app: &App) -> Model {
                     store: Store,
                     format: app.main_window().swapchain().format(),
                     samples: app.main_window().msaa_samples(),
-                    initial_layout: ImageLayout::PresentSrc,
-                    final_layout: ImageLayout::PresentSrc,
                 }
             },
             pass: {

--- a/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
+++ b/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
@@ -106,8 +106,6 @@ fn model(app: &App) -> Model {
                     store: Store,
                     format: app.main_window().swapchain().format(),
                     samples: 1,
-                    initial_layout: ImageLayout::Undefined,
-                    final_layout: ImageLayout::ShaderReadOnlyOptimal,
                 },
                 depth: {
                     load: Clear,

--- a/examples/vulkan/vk_quad_warp/warp.rs
+++ b/examples/vulkan/vk_quad_warp/warp.rs
@@ -37,8 +37,6 @@ pub(crate) fn warp(app: &App) -> Warp {
                     store: Store,
                     format: app.main_window().swapchain().format(),
                     samples: app.main_window().msaa_samples(),
-                    initial_layout: ImageLayout::PresentSrc,
-                    final_layout: ImageLayout::PresentSrc,
                 }
             },
             pass: {

--- a/examples/vulkan/vk_shader_include/mod.rs
+++ b/examples/vulkan/vk_shader_include/mod.rs
@@ -66,8 +66,6 @@ fn model(app: &App) -> Model {
                     store: Store,
                     format: app.main_window().swapchain().format(),
                     samples: app.main_window().msaa_samples(),
-                    initial_layout: ImageLayout::PresentSrc,
-                    final_layout: ImageLayout::PresentSrc,
                 }
             },
             pass: {

--- a/examples/vulkan/vk_teapot.rs
+++ b/examples/vulkan/vk_teapot.rs
@@ -79,8 +79,6 @@ fn model(app: &App) -> Model {
                     store: Store,
                     format: app.main_window().swapchain().format(),
                     samples: app.main_window().msaa_samples(),
-                    initial_layout: ImageLayout::PresentSrc,
-                    final_layout: ImageLayout::PresentSrc,
                 },
                 depth: {
                     load: Clear,

--- a/examples/vulkan/vk_teapot_camera.rs
+++ b/examples/vulkan/vk_teapot_camera.rs
@@ -118,8 +118,6 @@ fn model(app: &App) -> Model {
                     store: Store,
                     format: app.main_window().swapchain().format(),
                     samples: app.main_window().msaa_samples(),
-                    initial_layout: ImageLayout::PresentSrc,
-                    final_layout: ImageLayout::PresentSrc,
                 },
                 depth: {
                     load: Clear,

--- a/examples/vulkan/vk_triangle_raw_frame.rs
+++ b/examples/vulkan/vk_triangle_raw_frame.rs
@@ -65,8 +65,6 @@ fn model(app: &App) -> Model {
                     format: app.main_window().swapchain().format(),
                     // TODO:
                     samples: 1,
-                    initial_layout: ImageLayout::PresentSrc,
-                    final_layout: ImageLayout::PresentSrc,
                 }
             },
             pass: {

--- a/src/draw/backend/vulkano.rs
+++ b/src/draw/backend/vulkano.rs
@@ -402,8 +402,6 @@ pub fn create_render_pass_clear(
                 store: Store,
                 format: depth_format,
                 samples: msaa_samples,
-                initial_layout: ImageLayout::Undefined,
-                final_layout: ImageLayout::DepthStencilAttachmentOptimal,
             }
         },
         pass: {
@@ -436,8 +434,6 @@ pub fn create_render_pass_load(
                 store: Store,
                 format: depth_format,
                 samples: msaa_samples,
-                initial_layout: ImageLayout::Undefined,
-                final_layout: ImageLayout::DepthStencilAttachmentOptimal,
             }
         },
         pass: {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -398,8 +398,6 @@ fn create_render_pass(
                         store: Store,
                         format: color_format,
                         samples: 1,
-                        initial_layout: ImageLayout::PresentSrc,
-                        final_layout: ImageLayout::PresentSrc,
                     }
                 },
                 pass: {
@@ -426,8 +424,6 @@ fn create_render_pass(
                         store: Store,
                         format: color_format,
                         samples: 1,
-                        initial_layout: ImageLayout::PresentSrc,
-                        final_layout: ImageLayout::PresentSrc,
                     }
                 },
                 pass: {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -404,8 +404,6 @@ pub fn create_render_pass(
                 store: Store,
                 format: depth_format,
                 samples: msaa_samples,
-                initial_layout: ImageLayout::Undefined,
-                final_layout: ImageLayout::DepthStencilAttachmentOptimal,
             }
         },
         pass: {


### PR DESCRIPTION
The `nannou_patches` vulkano branch was recently updated to use @freesig's patch (rebased onto master under one of my branches) that seems to remove the need for specifying initial/final layout hacks within renderpasses. This PR accounts for this by removing all explicit mentions of layouts within renderpass declarations.

Tested successfully with the `run_all_examples` test locally.