### PR TITLE
Add an `examples/laser` directory demonstrating laser streams from the new `lasy` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ winit = "0.19"
 moltenvk_deps = "0.1"
 
 [dev-dependencies]
-lasy = { git = "https://github.com/nannou-org/lasy", branch = "master" }
+lasy = "0.2"
 
 # --------------- Nannou Examples
 [[example]]
@@ -159,6 +159,9 @@ path = "examples/generative_design/color/p_1_2_3_02.rs"
 [[example]]
 name = "laser_frame_stream"
 path = "examples/laser/laser_frame_stream.rs"
+[[example]]
+name = "laser_frame_stream_gui"
+path = "examples/laser/laser_frame_stream_gui.rs"
 [[example]]
 name = "laser_raw_stream"
 path = "examples/laser/laser_raw_stream.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ winit = "0.19"
 [target.'cfg(target_os = "macos")'.dependencies]
 moltenvk_deps = "0.1"
 
+[dev-dependencies]
+lasy = { git = "https://github.com/nannou-org/lasy", branch = "master" }
+
 # --------------- Nannou Examples
 [[example]]
 name = "all_functions"
@@ -152,6 +155,13 @@ path = "examples/generative_design/color/p_1_2_3_01.rs"
 [[example]]
 name = "p_1_2_3_02"
 path = "examples/generative_design/color/p_1_2_3_02.rs"
+# --------------- Laser
+[[example]]
+name = "laser_frame_stream"
+path = "examples/laser/laser_frame_stream.rs"
+[[example]]
+name = "laser_raw_stream"
+path = "examples/laser/laser_raw_stream.rs"
 # --------------- Nature of Code
 # --------------- Chapter 1 Vectors
 [[example]]

--- a/examples/laser/laser_frame_stream.rs
+++ b/examples/laser/laser_frame_stream.rs
@@ -1,0 +1,122 @@
+//! A simple example demonstrating how to use the position of the mouse to control a single-point
+//! beam via a raw laser stream.
+
+extern crate nannou;
+
+use nannou::prelude::*;
+
+fn main() {
+    nannou::app(model).run();
+}
+
+struct Model {
+    laser_api: lasy::Lasy,
+    laser_stream: lasy::FrameStream<Laser>,
+}
+
+struct Laser {
+    test_pattern: TestPattern,
+}
+
+// A collection of laser test patterns. We'll toggle between these with the numeric keys.
+pub enum TestPattern {
+    // A rectangle that outlines the laser's entire field of projection.
+    Rectangle,
+    // A triangle in the centre of the projection field.
+    Triangle,
+    // A crosshair in the centre of the projection field that reaches the edges.
+    Crosshair,
+    // Three vertical lines. One to the far left, one in the centre and one on the right.
+    ThreeVerticalLines,
+}
+
+fn model(app: &App) -> Model {
+    // Create a window to receive keyboard events.
+    app.new_window()
+        .key_pressed(key_pressed)
+        .view(view)
+        .build()
+        .unwrap();
+
+    // Initialise the state that we want to live on the laser thread and spawn the stream.
+    let laser_model = Laser { test_pattern: TestPattern::Rectangle };
+    let laser_api = lasy::Lasy::new();
+    let laser_stream = laser_api
+        .new_frame_stream(laser_model, laser)
+        .build()
+        .unwrap();
+
+    Model { laser_api, laser_stream }
+}
+
+fn laser(laser: &mut Laser, frame: &mut lasy::Frame) {
+    // Simple constructors for white or blank points.
+    let white_p = |position| lasy::Point { position, color: [1.0; 3] };
+
+    // Draw the frame with the selected pattern.
+    match laser.test_pattern {
+        TestPattern::Rectangle => {
+            let tl = [-1.0, 1.0];
+            let tr = [1.0, 1.0];
+            let br = [1.0, -1.0];
+            let bl = [-1.0, -1.0];
+            let positions = [tl, tr, br, bl, tl];
+            let points = positions.iter().cloned().map(white_p);
+            frame.add_points(points);
+        }
+
+        TestPattern::Triangle => {
+            let a = [-0.75, -0.75];
+            let b = [0.0, 0.75];
+            let c = [0.75, -0.75];
+            let positions = [a, b, c, a];
+            let points = positions.iter().cloned().map(white_p);
+            frame.add_points(points);
+        }
+
+        TestPattern::Crosshair => {
+            let xa = [-1.0, 0.0];
+            let xb = [1.0, 0.0];
+            let ya = [0.0, -1.0];
+            let yb = [0.0, 1.0];
+            let x = [white_p(xa), white_p(xb)];
+            let y = [white_p(ya), white_p(yb)];
+            frame.add_points(&x);
+            frame.add_points(&y);
+        }
+
+        TestPattern::ThreeVerticalLines => {
+            let la = [-1.0, -0.5];
+            let lb = [-1.0, 0.5];
+            let ma = [0.0, 0.5];
+            let mb = [0.0, -0.5];
+            let ra = [1.0, -0.5];
+            let rb = [1.0, 0.5];
+            let l = [white_p(la), white_p(lb)];
+            let m = [white_p(ma), white_p(mb)];
+            let r = [white_p(ra), white_p(rb)];
+            frame.add_points(&l);
+            frame.add_points(&m);
+            frame.add_points(&r);
+        }
+    }
+}
+
+fn key_pressed(_app: &App, model: &mut Model, key: Key) {
+    // Send a new pattern to the laser on keys 1, 2, 3 and 4.
+    let new_pattern = match key {
+        Key::Key1 => TestPattern::Rectangle,
+        Key::Key2 => TestPattern::Triangle,
+        Key::Key3 => TestPattern::Crosshair,
+        Key::Key4 => TestPattern::ThreeVerticalLines,
+        _ => return,
+    };
+    model.laser_stream.send(|laser| {
+        laser.test_pattern = new_pattern;
+    }).unwrap();
+}
+
+fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+    frame.clear(DARK_CHARCOAL);
+    frame
+}

--- a/examples/laser/laser_frame_stream_gui.rs
+++ b/examples/laser/laser_frame_stream_gui.rs
@@ -1,0 +1,452 @@
+//! A clone of the `laser_frame_stream.rs` example that allows for configuring laser settings via a
+//! UI.
+
+extern crate lasy;
+extern crate nannou;
+
+use nannou::geom::Rect;
+use nannou::prelude::*;
+use nannou::ui::prelude::*;
+
+fn main() {
+    nannou::app(model).update(update).run();
+}
+
+struct Model {
+    laser_api: lasy::Lasy,
+    laser_stream: lasy::FrameStream<Laser>,
+    laser_settings: LaserSettings,
+    ui: Ui,
+    ids: Ids,
+}
+
+struct Laser {
+    draw_mode: DrawMode,
+    color_profile: RgbProfile,
+    point_weight: u32,
+    test_pattern: TestPattern,
+}
+
+struct LaserSettings {
+    draw_mode: DrawMode,
+    point_weight: u32,
+    point_hz: u32,
+    latency_points: u32,
+    frame_hz: u32,
+    distance_per_point: f32,
+    blank_delay_points: u32,
+    radians_per_point: f32,
+    color_profile: RgbProfile,
+}
+
+#[derive(Clone, Copy)]
+struct RgbProfile {
+    red: f32,
+    green: f32,
+    blue: f32,
+}
+
+#[derive(Clone, Copy)]
+enum DrawMode { Lines, Points }
+
+// A collection of laser test patterns. We'll toggle between these with the numeric keys.
+pub enum TestPattern {
+    // A rectangle that outlines the laser's entire field of projection.
+    Rectangle,
+    // A triangle in the centre of the projection field.
+    Triangle,
+    // A crosshair in the centre of the projection field that reaches the edges.
+    Crosshair,
+    // Three vertical lines. One to the far left, one in the centre and one on the right.
+    ThreeVerticalLines,
+    // A circle whose diameter reaches the edges of the projection field.
+    Circle,
+    // A spiral that starts from the centre and revolves out towards the edge of the field.
+    Spiral,
+}
+
+struct Ids {
+    background_canvas: widget::Id,
+    laser_points_text: widget::Id,
+    draw_mode_lines_button: widget::Id,
+    draw_mode_points_button: widget::Id,
+    point_weight_slider: widget::Id,
+    laser_settings_text: widget::Id,
+    point_hz_slider: widget::Id,
+    latency_points_slider: widget::Id,
+    frame_hz_slider: widget::Id,
+    laser_path_interpolation_text: widget::Id,
+    distance_per_point_slider: widget::Id,
+    blank_delay_points_slider: widget::Id,
+    radians_per_point_slider: widget::Id,
+    color_profile_text: widget::Id,
+    red_slider: widget::Id,
+    green_slider: widget::Id,
+    blue_slider: widget::Id,
+}
+
+impl Default for LaserSettings {
+    fn default() -> Self {
+        use lasy::stream;
+        use lasy::stream::frame::opt::InterpolationConfig;
+        LaserSettings {
+            draw_mode: DrawMode::Lines,
+            point_weight: lasy::Point::DEFAULT_LINE_POINT_WEIGHT,
+            point_hz: stream::DEFAULT_POINT_HZ,
+            latency_points: stream::points_per_frame(stream::DEFAULT_POINT_HZ, stream::DEFAULT_FRAME_HZ),
+            frame_hz: stream::DEFAULT_FRAME_HZ,
+            distance_per_point: InterpolationConfig::DEFAULT_DISTANCE_PER_POINT,
+            blank_delay_points: InterpolationConfig::DEFAULT_BLANK_DELAY_POINTS,
+            radians_per_point: InterpolationConfig::DEFAULT_RADIANS_PER_POINT,
+            color_profile: Default::default(),
+        }
+    }
+}
+
+impl Default for RgbProfile {
+    fn default() -> Self {
+        RgbProfile {
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+        }
+    }
+}
+
+fn model(app: &App) -> Model {
+    // Create a window to receive keyboard events.
+    app.new_window()
+        .with_dimensions(240, 620)
+        .key_pressed(key_pressed)
+        .view(view)
+        .build()
+        .unwrap();
+
+    // Initialise the state that we want to live on the laser thread and spawn the stream.
+    let laser_settings = LaserSettings::default();
+    let laser_model = Laser {
+        draw_mode: laser_settings.draw_mode,
+        point_weight: laser_settings.point_weight,
+        color_profile: laser_settings.color_profile,
+        test_pattern: TestPattern::Rectangle,
+    };
+    let laser_api = lasy::Lasy::new();
+    let laser_stream = laser_api.new_frame_stream(laser_model, laser).build().unwrap();
+
+    // A user-interface to tweak the settings.
+    let mut ui = app.new_ui().build().unwrap();
+    let ids = Ids {
+        background_canvas: ui.generate_widget_id(),
+        laser_points_text: ui.generate_widget_id(),
+        draw_mode_lines_button: ui.generate_widget_id(),
+        draw_mode_points_button: ui.generate_widget_id(),
+        point_weight_slider: ui.generate_widget_id(),
+        laser_settings_text: ui.generate_widget_id(),
+        point_hz_slider: ui.generate_widget_id(),
+        latency_points_slider: ui.generate_widget_id(),
+        frame_hz_slider: ui.generate_widget_id(),
+        laser_path_interpolation_text: ui.generate_widget_id(),
+        distance_per_point_slider: ui.generate_widget_id(),
+        blank_delay_points_slider: ui.generate_widget_id(),
+        radians_per_point_slider: ui.generate_widget_id(),
+        color_profile_text: ui.generate_widget_id(),
+        red_slider: ui.generate_widget_id(),
+        green_slider: ui.generate_widget_id(),
+        blue_slider: ui.generate_widget_id(),
+    };
+
+    Model {
+        laser_api,
+        laser_stream,
+        laser_settings,
+        ui,
+        ids,
+    }
+}
+
+// Draw lines or points based on the `DrawMode`.
+fn add_points<I>(points: I, mode: DrawMode, frame: &mut lasy::Frame)
+where
+    I: IntoIterator,
+    I::Item: AsRef<lasy::Point>,
+{
+    match mode {
+        DrawMode::Lines => frame.add_lines(points),
+        DrawMode::Points => frame.add_points(points),
+    }
+}
+
+fn laser(laser: &mut Laser, frame: &mut lasy::Frame) {
+    // Simple constructor for a lit point.
+    let color = [
+        laser.color_profile.red,
+        laser.color_profile.green,
+        laser.color_profile.blue,
+    ];
+    let weight = laser.point_weight;
+    let lit_p = |position| lasy::Point { position, color, weight };
+
+    // Retrieve some points to draw based on the pattern.
+    match laser.test_pattern {
+        TestPattern::Rectangle => {
+            let tl = [-1.0, 1.0];
+            let tr = [1.0, 1.0];
+            let br = [1.0, -1.0];
+            let bl = [-1.0, -1.0];
+            let positions = [tl, tr, br, bl, tl];
+            let points = positions.iter().cloned().map(lit_p);
+            add_points(points, laser.draw_mode, frame);
+        }
+
+        TestPattern::Triangle => {
+            let a = [-0.75, -0.75];
+            let b = [0.0, 0.75];
+            let c = [0.75, -0.75];
+            let positions = [a, b, c, a];
+            let points = positions.iter().cloned().map(lit_p);
+            add_points(points, laser.draw_mode, frame);
+        }
+
+        TestPattern::Crosshair => {
+            let xa = [-1.0, 0.0];
+            let xb = [1.0, 0.0];
+            let ya = [0.0, -1.0];
+            let yb = [0.0, 1.0];
+            let x = [lit_p(xa), lit_p(xb)];
+            let y = [lit_p(ya), lit_p(yb)];
+            add_points(&x, laser.draw_mode, frame);
+            add_points(&y, laser.draw_mode, frame);
+        }
+
+        TestPattern::ThreeVerticalLines => {
+            let la = [-1.0, -0.5];
+            let lb = [-1.0, 0.5];
+            let ma = [0.0, 0.5];
+            let mb = [0.0, -0.5];
+            let ra = [1.0, -0.5];
+            let rb = [1.0, 0.5];
+            let l = [lit_p(la), lit_p(lb)];
+            let m = [lit_p(ma), lit_p(mb)];
+            let r = [lit_p(ra), lit_p(rb)];
+            add_points(&l, laser.draw_mode, frame);
+            add_points(&m, laser.draw_mode, frame);
+            add_points(&r, laser.draw_mode, frame);
+        }
+
+        TestPattern::Circle => {
+            let n_points = frame.points_per_frame() as usize / 4;
+            let rect = Rect::from_w_h(1.0, 1.0);
+            let ellipse: Vec<_> = geom::ellipse::Circumference::new(rect, n_points)
+                .map(|p| lit_p([p.x, p.y]))
+                .collect();
+            add_points(&ellipse, laser.draw_mode, frame);
+        }
+
+        TestPattern::Spiral => {
+            let n_points = frame.points_per_frame() as usize / 2;
+            let radius = 1.0;
+            let rings = 5.0;
+            let points = (0..n_points)
+                .map(|i| {
+                    let fract = i as f32 / n_points as f32;
+                    let mag = fract * radius;
+                    let phase = rings * fract * 2.0 * std::f32::consts::PI;
+                    let y = mag * -phase.sin();
+                    let x = mag * phase.cos();
+                    [x, y]
+                })
+                .map(lit_p)
+                .collect::<Vec<_>>();
+            add_points(&points, laser.draw_mode, frame);
+        }
+    }
+}
+
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    // Calling `set_widgets` allows us to instantiate some widgets.
+    let ui = &mut model.ui.set_widgets();
+
+    fn slider(val: f32, min: f32, max: f32) -> widget::Slider<'static, f32> {
+        widget::Slider::new(val, min, max)
+            .down(5.0)
+            .w_h(200.0, 30.0)
+            .label_font_size(12)
+            .rgb(0.3, 0.3, 0.3)
+            .label_rgb(1.0, 1.0, 1.0)
+            .border(0.0)
+    }
+
+    fn button() -> widget::Button<'static, widget::button::Flat> {
+        widget::Button::new()
+            .w_h(95.0, 30.0)
+            .label_font_size(12)
+            .label_rgb(1.0, 1.0, 1.0)
+            .border(0.0)
+    }
+
+    widget::Canvas::new()
+        .rgb(0.011, 0.013, 0.017)
+        .set(model.ids.background_canvas, ui);
+
+    widget::Text::new("Laser Points")
+        .color(color::WHITE)
+        .top_left_with_margin(20.0)
+        .set(model.ids.laser_points_text, ui);
+
+    // Button colours.
+    let (lines_color, points_color) = match model.laser_settings.draw_mode {
+        DrawMode::Lines => (color::BLUE, color::BLACK),
+        DrawMode::Points => (color::BLACK, color::BLUE),
+    };
+
+    for _click in button()
+        .label("LINES")
+        .down(20.0)
+        .color(lines_color)
+        .set(model.ids.draw_mode_lines_button, ui)
+    {
+        let mode = DrawMode::Lines;
+        model.laser_settings.draw_mode = mode;
+        model.laser_stream.send(move |laser| laser.draw_mode = mode).unwrap();
+    }
+
+    for _click in button()
+        .label("POINTS")
+        .right(10.0)
+        .color(points_color)
+        .set(model.ids.draw_mode_points_button, ui)
+    {
+        let mode = DrawMode::Points;
+        model.laser_settings.draw_mode = mode;
+        model.laser_stream.send(move |laser| laser.draw_mode = mode).unwrap();
+    }
+
+    let label = format!("Point Weight: {}", model.laser_settings.point_weight);
+    for value in slider(model.laser_settings.point_weight as _, 0.0, 128.0)
+        .down_from(model.ids.draw_mode_lines_button, 10.0)
+        .label(&label)
+        .set(model.ids.point_weight_slider, ui)
+    {
+        model.laser_settings.point_weight = value as _;
+        model.laser_stream.send(move |laser| laser.point_weight = value as _).unwrap();
+    }
+
+    widget::Text::new("Laser Settings")
+        .color(color::WHITE)
+        .down(20.0)
+        .set(model.ids.laser_settings_text, ui);
+
+    let label = format!("DAC PPS: {}", model.laser_settings.point_hz);
+    for value in slider(model.laser_settings.point_hz as _, 1_000.0, 10_000.0)
+        .down(20.0)
+        .label(&label)
+        .set(model.ids.point_hz_slider, ui)
+    {
+        model.laser_settings.point_hz = value as _;
+        model.laser_stream.set_point_hz(value as _).unwrap();
+    }
+
+    let label = format!("Latency: {} points", model.laser_settings.latency_points);
+    for value in slider(model.laser_settings.latency_points as _, 10.0, 1_500.0)
+        .label(&label)
+        .set(model.ids.latency_points_slider, ui)
+    {
+        model.laser_settings.latency_points = value as _;
+        model.laser_stream.set_latency_points(value as _).unwrap();
+    }
+
+    let label = format!("Target FPS: {}", model.laser_settings.frame_hz);
+    for value in slider(model.laser_settings.frame_hz as _, 1.0, 120.0)
+        .label(&label)
+        .set(model.ids.frame_hz_slider, ui)
+    {
+        model.laser_settings.frame_hz = value as _;
+        model.laser_stream.set_frame_hz(value as _).unwrap();
+    }
+
+    widget::Text::new("Laser Path Interpolation")
+        .down(20.0)
+        .color(color::WHITE)
+        .font_size(16)
+        .set(model.ids.laser_path_interpolation_text, ui);
+
+    let label = format!("Distance per point: {:.2}", model.laser_settings.distance_per_point);
+    for value in slider(model.laser_settings.distance_per_point, 0.01, 1.0)
+        .down(20.0)
+        .label(&label)
+        .set(model.ids.distance_per_point_slider, ui)
+    {
+        model.laser_settings.distance_per_point = value;
+        model.laser_stream.set_distance_per_point(value).unwrap();
+    }
+
+    let label = format!("Blank delay: {} points", model.laser_settings.blank_delay_points);
+    for value in slider(model.laser_settings.blank_delay_points as _, 0.0, 32.0)
+        .label(&label)
+        .set(model.ids.blank_delay_points_slider, ui)
+    {
+        model.laser_settings.blank_delay_points = value as _;
+        model.laser_stream.set_blank_delay_points(value as _).unwrap();
+    }
+
+    let degrees_per_point = rad_to_deg(model.laser_settings.radians_per_point);
+    let label = format!("Degrees per point (inertia): {:.2}", degrees_per_point);
+    for value in slider(degrees_per_point, 1.0, 180.0)
+        .label(&label)
+        .set(model.ids.radians_per_point_slider, ui)
+    {
+        let radians = deg_to_rad(value);
+        model.laser_settings.radians_per_point = radians;
+        model.laser_stream.set_radians_per_point(radians).unwrap();
+    }
+
+    widget::Text::new("Color Profile")
+        .down(20.0)
+        .color(color::WHITE)
+        .font_size(16)
+        .set(model.ids.color_profile_text, ui);
+
+    for value in slider(model.laser_settings.color_profile.red, 0.0, 1.0)
+        .down(20.0)
+        .color(color::RED)
+        .set(model.ids.red_slider, ui)
+    {
+        model.laser_settings.color_profile.red = value;
+        model.laser_stream.send(move |model| model.color_profile.red = value).unwrap();
+    }
+
+    for value in slider(model.laser_settings.color_profile.green, 0.0, 1.0)
+        .color(color::GREEN)
+        .set(model.ids.green_slider, ui)
+    {
+        model.laser_settings.color_profile.green = value;
+        model.laser_stream.send(move |model| model.color_profile.green = value).unwrap();
+    }
+
+    for value in slider(model.laser_settings.color_profile.blue, 0.0, 1.0)
+        .color(color::BLUE)
+        .set(model.ids.blue_slider, ui)
+    {
+        model.laser_settings.color_profile.blue = value;
+        model.laser_stream.send(move |model| model.color_profile.blue = value).unwrap();
+    }
+}
+
+fn key_pressed(_app: &App, model: &mut Model, key: Key) {
+    // Send a new pattern to the laser on keys 1, 2, 3 and 4.
+    let new_pattern = match key {
+        Key::Key1 => TestPattern::Rectangle,
+        Key::Key2 => TestPattern::Triangle,
+        Key::Key3 => TestPattern::Crosshair,
+        Key::Key4 => TestPattern::ThreeVerticalLines,
+        Key::Key5 => TestPattern::Circle,
+        Key::Key6 => TestPattern::Spiral,
+        _ => return,
+    };
+    model.laser_stream.send(|laser| laser.test_pattern = new_pattern).unwrap();
+}
+
+fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+    model.ui.draw_to_frame_if_changed(app, &frame).unwrap();
+    frame
+}

--- a/examples/laser/laser_raw_stream.rs
+++ b/examples/laser/laser_raw_stream.rs
@@ -1,0 +1,79 @@
+//! A simple example demonstrating how to use the position of the mouse to control a single-point
+//! beam via a raw laser stream.
+
+extern crate lasy;
+extern crate nannou;
+
+use nannou::prelude::*;
+
+fn main() {
+    nannou::app(model).run();
+}
+
+struct Model {
+    laser_api: lasy::Lasy,
+    laser_stream: lasy::RawStream<Laser>,
+}
+
+struct Laser {
+    point_idx: usize,
+    position: Point2,
+}
+
+fn model(app: &App) -> Model {
+    // Create a window to receive mouse events.
+    app.new_window()
+        .mouse_moved(mouse_moved)
+        .view(view)
+        .build()
+        .unwrap();
+
+    // Initialise the state that we want to live on the laser thread and spawn the stream.
+    let laser_model = Laser { point_idx: 0, position: pt2(0.0, 0.0) };
+    let laser_api = lasy::Lasy::new();
+    let laser_stream = laser_api
+        .new_raw_stream(laser_model, laser)
+        .build()
+        .unwrap();
+
+    Model { laser_api, laser_stream }
+}
+
+fn laser(laser: &mut Laser, buffer: &mut lasy::Buffer) {
+    // Write white points to the laser stream at the current position.
+    for point in buffer.iter_mut() {
+        point.color = [1.0, 1.0, 1.0];
+        point.position = laser.position.into();
+        // Many lasers have a feature called "scan fail safety" (SFS) where the beam will
+        // automatically cut out if the scanner is not moving for safety.
+        // To avoid cutting out, we'll offset the point slightly to make a diamond shape.
+        let offset = 0.125;
+        match laser.point_idx % 4 {
+            0 => point.position[0] += offset * 0.5,
+            1 => point.position[1] += offset * 0.5,
+            2 => point.position[0] -= offset * 0.5,
+            _ => point.position[1] -= offset * 0.5,
+        }
+        laser.point_idx = laser.point_idx.wrapping_add(1);
+    }
+}
+
+fn mouse_moved(app: &App, model: &mut Model, pos: Point2) {
+    // Lets use the mouse position to control the laser position.
+    let win_rect = app.window_rect();
+    let laser_rect = geom::Rect::from_w_h(2.0, 2.0);
+    let x = win_rect.x.map_value(pos.x, &laser_rect.x);
+    let y = win_rect.y.map_value(pos.y, &laser_rect.y);
+    model.laser_stream.send(move |laser| {
+        laser.position = pt2(x, y);
+    }).unwrap();
+}
+
+fn view(app: &App, _model: &Model, frame: Frame) -> Frame {
+    // Visualise the point in the window.
+    let draw = app.draw();
+    draw.background().color(DARK_CHARCOAL);
+    draw.ellipse().w_h(5.0, 5.0).xy(app.mouse.position());
+    draw.to_frame(app, &frame).unwrap();
+    frame
+}


### PR DESCRIPTION
Recently I started a new crate for discovering and streaming to laser
DACs called [**lasy**][1]. This commit adds two examples demonstrating
how to work with both the RawStream and FrameStream APIs from the new
crate.

The **laser_raw_stream.rs** example demonstrates how to feed points to a
raw stream by drawing a single point at a position controlled by the
position of the mouse within the window.

The **laser_frame_stream.rs** example demonstrates how to feed points
to a frame stream by switching between different test patterns with the 1, 2,
3 and 4 keys.

Both examples could be improved in the future by targeting all lasers
detected (rather than just the first) and using the
`ether-dream-dac-emulator` crate to assist with creating a visualisation
of what the DAC is outputting. Currently there's a demo of how to
visualise an emulated DAC in the ether-dream repo, but it might be best
to move that example into its own configurable visualiser type in a separate
crate so that it is super easy to drop into laser examples or other
downstream laser code. 

Originally I started integrating `lasy` directly into nannou itself, but
was weary of adding the extra compile-time work when the vast majority
of users probably don't have access to lasers. We can reconsider if we
can find a good motivation to do so, but otherwise I think the new
examples already demonstrate a decent level of simplicity!

[1]: https://github.com/nannou-org/lasy