### PR TITLE
Switch to stable dependencies for vulkano and conrod!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2018"
 [dependencies]
 approx = "0.1"
 cgmath = { version = "0.16", features = ["serde"] }
-conrod_core = { git = "https://github.com/mitchmindtree/conrod", branch = "update_vulkano_nannou_patches" }
-conrod_winit = { git = "https://github.com/mitchmindtree/conrod", branch = "update_vulkano_nannou_patches" }
-conrod_vulkano = { git = "https://github.com/mitchmindtree/conrod", branch = "update_vulkano_nannou_patches" }
+conrod_core = "0.65"
+conrod_winit = "0.65"
+conrod_vulkano = "0.65"
 cpal = "0.8"
 daggy = "0.6"
 find_folder = "0.3"
@@ -30,13 +30,13 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 toml = "0.4"
-vulkano = { git = "https://github.com/mitchmindtree/vulkano", branch = "nannou_patches" }
-vulkano-win = { git = "https://github.com/mitchmindtree/vulkano", branch = "nannou_patches" }
-vulkano-shaders = { git = "https://github.com/mitchmindtree/vulkano", branch = "nannou_patches" }
+vulkano = "0.12"
+vulkano-win = "0.12"
+vulkano-shaders = "0.12"
 winit = "0.19"
 
 [dev-dependencies]
-shade_runner = { git = "https://github.com/freesig/shade_runner.git" }
+shade_runner = { git = "https://github.com/mitchmindtree/shade_runner.git", branch = "vulkano_update" }
 lasy = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/examples/laser/laser_frame_stream.rs
+++ b/examples/laser/laser_frame_stream.rs
@@ -7,7 +7,7 @@ fn main() {
 }
 
 struct Model {
-    laser_api: lasy::Lasy,
+    _laser_api: lasy::Lasy,
     laser_stream: lasy::FrameStream<Laser>,
 }
 
@@ -43,14 +43,14 @@ fn model(app: &App) -> Model {
     let laser_model = Laser {
         test_pattern: TestPattern::Rectangle,
     };
-    let laser_api = lasy::Lasy::new();
-    let laser_stream = laser_api
+    let _laser_api = lasy::Lasy::new();
+    let laser_stream = _laser_api
         .new_frame_stream(laser_model, laser)
         .build()
         .unwrap();
 
     Model {
-        laser_api,
+        _laser_api,
         laser_stream,
     }
 }

--- a/examples/laser/laser_raw_stream.rs
+++ b/examples/laser/laser_raw_stream.rs
@@ -8,7 +8,7 @@ fn main() {
 }
 
 struct Model {
-    laser_api: lasy::Lasy,
+    _laser_api: lasy::Lasy,
     laser_stream: lasy::RawStream<Laser>,
 }
 
@@ -30,14 +30,14 @@ fn model(app: &App) -> Model {
         point_idx: 0,
         position: pt2(0.0, 0.0),
     };
-    let laser_api = lasy::Lasy::new();
-    let laser_stream = laser_api
+    let _laser_api = lasy::Lasy::new();
+    let laser_stream = _laser_api
         .new_raw_stream(laser_model, laser)
         .build()
         .unwrap();
 
     Model {
-        laser_api,
+        _laser_api,
         laser_stream,
     }
 }


### PR DESCRIPTION

Switch to stable dependencies for vulkano and conrod!

Now that vulkano 0.12.0 is out we're able to start stabilising
dependencies!

All that's left is to stabilise the `shade_runner` dev-dependency (used
within the `vk_hotload.rs` example) and we'll be able to publish v0.9!

This PR also fixes a couple of warnings appearing in the laser stream examples.