### PR TITLE
Add fps convenience method to app

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1023,6 +1023,11 @@ impl App {
     pub fn elapsed_frames(&self) -> u64 {
         self.main_window().frame_count
     }
+
+    /// The number of frames that can currently be displayed a second
+    pub fn fps(&self) -> f32 {
+        self.duration.updates_per_second()
+    }
 }
 
 impl Audio {

--- a/src/state.rs
+++ b/src/state.rs
@@ -290,4 +290,21 @@ pub mod time {
         /// The duration since the previous update.
         pub since_prev_update: std::time::Duration,
     }
+
+    impl Time {
+        /// The number of updates per second if `since_prev_update` were to remain constant
+        pub fn updates_per_second(&self) -> f32 {
+            if self.since_prev_update.as_secs() > 0 {
+                return 0.0
+            }
+
+            let millis = self.since_prev_update.subsec_millis() as f32;
+
+            if millis == 0.0 {
+                return std::f32::MAX;
+            }
+
+            1000.0 / millis
+        }
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -295,7 +295,7 @@ pub mod time {
         /// The number of updates per second if `since_prev_update` were to remain constant
         pub fn updates_per_second(&self) -> f32 {
             if self.since_prev_update.as_secs() > 0 {
-                return 0.0
+                return 0.0;
             }
 
             let millis = self.since_prev_update.subsec_millis() as f32;


### PR DESCRIPTION
Helpful for tracking if you're hitting a good fps. When nannou supports text, we can also have a convenience method for rendering the fps to the frame. 