### PR TITLE
Address new trait dynamic dispatch syntax warning from latest nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: rust
 
-cache: cargo
-
 before_script:
 - rustup component add rustfmt
 

--- a/examples/vulkan/vk_compute_shader.rs
+++ b/examples/vulkan/vk_compute_shader.rs
@@ -8,8 +8,8 @@ fn main() {
 struct Model {
     device: Arc<vk::Device>,
     queue: Arc<vk::Queue>,
-    pipeline: Arc<vk::ComputePipelineAbstract + Send + Sync>,
-    desciptor_set: Arc<vk::DescriptorSet + Send + Sync>,
+    pipeline: Arc<dyn vk::ComputePipelineAbstract + Send + Sync>,
+    desciptor_set: Arc<dyn vk::DescriptorSet + Send + Sync>,
     data_buffer: Arc<vk::CpuAccessibleBuffer<[f32]>>,
 }
 

--- a/examples/vulkan/vk_hotload.rs
+++ b/examples/vulkan/vk_hotload.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 struct Model {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    pipeline: Option<Arc<vk::GraphicsPipelineAbstract + Send + Sync>>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Option<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>>,
     vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
     view_fbo: RefCell<ViewFbo>,
     shade_watcher: shade_runner::Watch,

--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -7,11 +7,11 @@ fn main() {
 }
 
 struct Model {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
     view_fbo: RefCell<ViewFbo>,
-    desciptor_set: Arc<vk::DescriptorSet + Send + Sync>,
+    desciptor_set: Arc<dyn vk::DescriptorSet + Send + Sync>,
 }
 
 #[derive(Debug, Clone)]

--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -7,11 +7,11 @@ fn main() {
 }
 
 struct Model {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
     view_fbo: RefCell<ViewFbo>,
-    desciptor_set: Arc<vk::DescriptorSet + Send + Sync>,
+    desciptor_set: Arc<dyn vk::DescriptorSet + Send + Sync>,
 }
 
 #[derive(Debug, Clone)]

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -7,11 +7,11 @@ fn main() {
 }
 
 struct Model {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
     view_fbo: RefCell<ViewFbo>,
-    desciptor_set: Arc<vk::DescriptorSet + Send + Sync>,
+    desciptor_set: Arc<dyn vk::DescriptorSet + Send + Sync>,
 }
 
 #[derive(Debug, Clone)]

--- a/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
+++ b/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
@@ -310,7 +310,8 @@ fn create_graphics_pipeline(
     fragment_shader: &fs::Shader,
     render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
     dimensions: [f32; 2],
-) -> Result<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError> {
+) -> Result<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError>
+{
     let pipeline = vk::GraphicsPipeline::start()
         .vertex_input(vk::TwoBuffersDefinition::<Vertex, Normal>::new())
         .vertex_shader(vertex_shader.main_entry_point(), ())

--- a/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
+++ b/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
@@ -32,11 +32,11 @@ struct Graphics {
     uniform_buffer: vk::CpuBufferPool<vs::ty::Data>,
     vertex_shader: vs::Shader,
     fragment_shader: fs::Shader,
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    graphics_pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    graphics_pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     depth_image: Arc<vk::AttachmentImage>,
     inter_image: Arc<vk::AttachmentImage>,
-    framebuffer: Arc<vk::FramebufferAbstract + Send + Sync>,
+    framebuffer: Arc<dyn vk::FramebufferAbstract + Send + Sync>,
 }
 
 vk::impl_vertex!(Vertex, position);
@@ -308,9 +308,9 @@ fn create_graphics_pipeline(
     device: Arc<vk::Device>,
     vertex_shader: &vs::Shader,
     fragment_shader: &fs::Shader,
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
     dimensions: [f32; 2],
-) -> Result<Arc<vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError> {
+) -> Result<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError> {
     let pipeline = vk::GraphicsPipeline::start()
         .vertex_input(vk::TwoBuffersDefinition::<Vertex, Normal>::new())
         .vertex_shader(vertex_shader.main_entry_point(), ())

--- a/examples/vulkan/vk_quad_warp/warp.rs
+++ b/examples/vulkan/vk_quad_warp/warp.rs
@@ -6,8 +6,8 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 pub struct Warp {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     view_fbo: RefCell<ViewFbo>,
     uniform_buffer: vk::CpuBufferPool<vs::ty::Data>,
     sampler: Arc<vk::Sampler>,

--- a/examples/vulkan/vk_shader_include/mod.rs
+++ b/examples/vulkan/vk_shader_include/mod.rs
@@ -7,8 +7,8 @@ fn main() {
 }
 
 struct Model {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
     view_fbo: RefCell<ViewFbo>,
 }

--- a/examples/vulkan/vk_teapot.rs
+++ b/examples/vulkan/vk_teapot.rs
@@ -237,7 +237,8 @@ fn create_graphics_pipeline(
     fragment_shader: &fs::Shader,
     render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
     dimensions: [f32; 2],
-) -> Result<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError> {
+) -> Result<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError>
+{
     let pipeline = vk::GraphicsPipeline::start()
         .vertex_input(vk::TwoBuffersDefinition::<Vertex, Normal>::new())
         .vertex_shader(vertex_shader.main_entry_point(), ())

--- a/examples/vulkan/vk_teapot.rs
+++ b/examples/vulkan/vk_teapot.rs
@@ -18,8 +18,8 @@ struct Graphics {
     uniform_buffer: vk::CpuBufferPool<vs::ty::Data>,
     vertex_shader: vs::Shader,
     fragment_shader: fs::Shader,
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    graphics_pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    graphics_pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     depth_image: Arc<vk::AttachmentImage>,
     view_fbo: ViewFbo,
 }
@@ -235,9 +235,9 @@ fn create_graphics_pipeline(
     device: Arc<vk::Device>,
     vertex_shader: &vs::Shader,
     fragment_shader: &fs::Shader,
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
     dimensions: [f32; 2],
-) -> Result<Arc<vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError> {
+) -> Result<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError> {
     let pipeline = vk::GraphicsPipeline::start()
         .vertex_input(vk::TwoBuffersDefinition::<Vertex, Normal>::new())
         .vertex_shader(vertex_shader.main_entry_point(), ())

--- a/examples/vulkan/vk_teapot_camera.rs
+++ b/examples/vulkan/vk_teapot_camera.rs
@@ -16,8 +16,8 @@ struct Graphics {
     uniform_buffer: vk::CpuBufferPool<vs::ty::Data>,
     vertex_shader: vs::Shader,
     fragment_shader: fs::Shader,
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    graphics_pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    graphics_pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     depth_image: Arc<vk::AttachmentImage>,
     view_fbo: ViewFbo,
 }
@@ -365,9 +365,9 @@ fn create_graphics_pipeline(
     device: Arc<vk::Device>,
     vertex_shader: &vs::Shader,
     fragment_shader: &fs::Shader,
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
     dimensions: [f32; 2],
-) -> Result<Arc<vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError> {
+) -> Result<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError> {
     let pipeline = vk::GraphicsPipeline::start()
         .vertex_input(vk::TwoBuffersDefinition::<Vertex, Normal>::new())
         .vertex_shader(vertex_shader.main_entry_point(), ())

--- a/examples/vulkan/vk_teapot_camera.rs
+++ b/examples/vulkan/vk_teapot_camera.rs
@@ -367,7 +367,8 @@ fn create_graphics_pipeline(
     fragment_shader: &fs::Shader,
     render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
     dimensions: [f32; 2],
-) -> Result<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError> {
+) -> Result<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>, vk::GraphicsPipelineCreationError>
+{
     let pipeline = vk::GraphicsPipeline::start()
         .vertex_input(vk::TwoBuffersDefinition::<Vertex, Normal>::new())
         .vertex_shader(vertex_shader.main_entry_point(), ())

--- a/examples/vulkan/vk_triangle.rs
+++ b/examples/vulkan/vk_triangle.rs
@@ -7,8 +7,8 @@ fn main() {
 }
 
 struct Model {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
     view_fbo: RefCell<ViewFbo>,
 }

--- a/examples/vulkan/vk_triangle_raw_frame.rs
+++ b/examples/vulkan/vk_triangle_raw_frame.rs
@@ -7,8 +7,8 @@ fn main() {
 }
 
 struct Model {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     vertex_buffer: Arc<vk::CpuAccessibleBuffer<[Vertex]>>,
     framebuffers: RefCell<window::SwapchainFramebuffers>,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2172,7 +2172,7 @@ fn view_frame<M>(
                 swapchain.swapchain.clone(),
                 swapchain_image_index,
             );
-        (Box::new(present_future) as Box<GpuFuture>).then_signal_fence_and_flush()
+        (Box::new(present_future) as Box<dyn GpuFuture>).then_signal_fence_and_flush()
     };
 
     // Handle the result of the future.

--- a/src/draw/backend/vulkano.rs
+++ b/src/draw/backend/vulkano.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 
 /// A type used for rendering a **nannou::draw::Mesh** with a vulkan graphics pipeline.
 pub struct Renderer {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
-    graphics_pipeline: Arc<vk::GraphicsPipelineAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
+    graphics_pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     vertices: Vec<Vertex>,
     render_pass_images: Option<RenderPassImages>,
     view_fbo: ViewFbo,
@@ -215,9 +215,9 @@ impl Renderer {
             depth_format,
             load_op,
             msaa_samples,
-        )?) as Arc<vk::RenderPassAbstract + Send + Sync>;
+        )?) as Arc<dyn vk::RenderPassAbstract + Send + Sync>;
         let graphics_pipeline = create_graphics_pipeline(render_pass.clone())?
-            as Arc<vk::GraphicsPipelineAbstract + Send + Sync>;
+            as Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>;
         let vertices = vec![];
         let render_pass_images = None;
         let view_fbo = ViewFbo::default();
@@ -368,7 +368,7 @@ pub fn create_render_pass(
     depth_format: vk::Format,
     load_op: vk::LoadOp,
     msaa_samples: u32,
-) -> Result<Arc<vk::RenderPassAbstract + Send + Sync>, vk::RenderPassCreationError> {
+) -> Result<Arc<dyn vk::RenderPassAbstract + Send + Sync>, vk::RenderPassCreationError> {
     // TODO: Remove this in favour of a nannou-specific, dynamic `RenderPassDesc` implementation.
     match load_op {
         vk::LoadOp::Clear => {
@@ -388,7 +388,7 @@ pub fn create_render_pass_clear(
     color_format: vk::Format,
     depth_format: vk::Format,
     msaa_samples: u32,
-) -> Result<Arc<vk::RenderPassAbstract + Send + Sync>, vk::RenderPassCreationError> {
+) -> Result<Arc<dyn vk::RenderPassAbstract + Send + Sync>, vk::RenderPassCreationError> {
     let rp = vk::single_pass_renderpass!(
         device,
         attachments: {
@@ -420,7 +420,7 @@ pub fn create_render_pass_load(
     color_format: vk::Format,
     depth_format: vk::Format,
     msaa_samples: u32,
-) -> Result<Arc<vk::RenderPassAbstract + Send + Sync>, vk::RenderPassCreationError> {
+) -> Result<Arc<dyn vk::RenderPassAbstract + Send + Sync>, vk::RenderPassCreationError> {
     let rp = vk::single_pass_renderpass!(
         device,
         attachments: {
@@ -454,7 +454,7 @@ pub fn dynamic_state(viewport_dimensions: [f32; 2]) -> vk::DynamicState {
 /// The graphics pipeline used by the renderer.
 pub fn create_graphics_pipeline<R>(
     render_pass: R,
-) -> Result<Arc<vk::GraphicsPipelineAbstract + Send + Sync>, GraphicsPipelineError>
+) -> Result<Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>, GraphicsPipelineError>
 where
     R: vk::RenderPassAbstract + Send + Sync + 'static,
 {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -45,7 +45,7 @@ pub type ViewFbo = ViewFramebufferObject;
 /// Data necessary for rendering the **Frame**'s `image` to the the `swapchain_image` of the inner
 /// raw frame.
 pub(crate) struct RenderData {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
     // The intermediary image to which the user will draw.
     //
     // The number of multisampling samples may be specified by the user when constructing the
@@ -289,7 +289,7 @@ impl StdError for RenderDataCreationError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             RenderDataCreationError::RenderPassCreation(ref err) => Some(err),
             RenderDataCreationError::ImageCreation(ref err) => Some(err),
@@ -305,7 +305,7 @@ impl StdError for FrameCreationError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             FrameCreationError::ImageCreation(ref err) => Some(err),
             FrameCreationError::FramebufferCreation(ref err) => Some(err),
@@ -320,7 +320,7 @@ impl StdError for FrameFinishError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             FrameFinishError::BeginRenderPass(ref err) => Some(err),
         }
@@ -385,7 +385,7 @@ fn create_render_pass(
     device: Arc<vk::Device>,
     color_format: vk::Format,
     msaa_samples: u32,
-) -> Result<Arc<vk::RenderPassAbstract + Send + Sync>, vk::RenderPassCreationError> {
+) -> Result<Arc<dyn vk::RenderPassAbstract + Send + Sync>, vk::RenderPassCreationError> {
     match msaa_samples {
         // Render pass without multisampling.
         0 | 1 => {
@@ -410,7 +410,7 @@ fn create_render_pass(
                     depth_stencil: {}
                 }
             )?;
-            Ok(Arc::new(rp) as Arc<vk::RenderPassAbstract + Send + Sync>)
+            Ok(Arc::new(rp) as Arc<dyn vk::RenderPassAbstract + Send + Sync>)
         }
 
         // Renderpass with multisampling.
@@ -437,7 +437,7 @@ fn create_render_pass(
                     resolve: [swapchain_color],
                 }
             )?;
-            Ok(Arc::new(rp) as Arc<vk::RenderPassAbstract + Send + Sync>)
+            Ok(Arc::new(rp) as Arc<dyn vk::RenderPassAbstract + Send + Sync>)
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -262,7 +262,7 @@ pub mod mouse {
 
     fn idx_to_button(i: usize) -> Button {
         match i {
-            n @ 0...5 => Button::Other(n as u8),
+            n @ 0..=5 => Button::Other(n as u8),
             6 => Button::Left,
             7 => Button::Right,
             8 => Button::Middle,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -76,7 +76,7 @@ enum RenderMode {
 
 // The render pass in which the `Ui` will be rendered along with the owned buffers.
 struct RenderTarget {
-    render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
+    render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
     images: RenderPassImages,
     view_fbo: ViewFbo,
 }
@@ -133,7 +133,7 @@ pub enum DrawToFrameError {
 }
 
 /// The subpass type to which the `Ui` may be rendered.
-pub type Subpass = vk::framebuffer::Subpass<Arc<vk::RenderPassAbstract + Send + Sync>>;
+pub type Subpass = vk::framebuffer::Subpass<Arc<dyn vk::RenderPassAbstract + Send + Sync>>;
 
 /// A map from `image::Id`s to their associated `Texture2d`.
 pub type ImageMap = conrod_core::image::Map<conrod_vulkano::Image>;
@@ -394,7 +394,7 @@ pub fn create_render_pass(
     color_format: vk::Format,
     depth_format: vk::Format,
     msaa_samples: u32,
-) -> Result<Arc<vk::RenderPassAbstract + Send + Sync>, vk::RenderPassCreationError> {
+) -> Result<Arc<dyn vk::RenderPassAbstract + Send + Sync>, vk::RenderPassCreationError> {
     let render_pass = vk::single_pass_renderpass!(
         device,
         attachments: {
@@ -769,7 +769,7 @@ impl StdError for BuildError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             BuildError::InvalidWindow => None,
             BuildError::RendererCreation(ref err) => Some(err),
@@ -786,7 +786,7 @@ impl StdError for RenderTargetCreationError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             RenderTargetCreationError::RenderPassCreation(ref err) => Some(err),
             RenderTargetCreationError::ImageCreation(ref err) => Some(err),
@@ -815,7 +815,7 @@ impl StdError for DrawToFrameError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             DrawToFrameError::InvalidWindow => None,
             DrawToFrameError::RendererPoisoned => None,

--- a/src/vk.rs
+++ b/src/vk.rs
@@ -155,7 +155,7 @@ pub const DEFAULT_APPLICATION_INFO: ApplicationInfo<'static> = ApplicationInfo {
 /// - The dimensions of the framebuffer don't match the dimensions of the images.
 #[derive(Default)]
 pub struct FramebufferObject {
-    framebuffer: Option<Arc<FramebufferAbstract + Send + Sync>>,
+    framebuffer: Option<Arc<dyn FramebufferAbstract + Send + Sync>>,
 }
 
 /// Shorthand for the **FramebufferObject** type.
@@ -232,11 +232,11 @@ impl DynamicStateBuilder for DynamicState {
 }
 
 // The user vulkan debug callback allocated on the heap to avoid complicated type params.
-type BoxedUserCallback = Box<Fn(&Message) + 'static + Send + RefUnwindSafe>;
+type BoxedUserCallback = Box<dyn Fn(&Message) + 'static + Send + RefUnwindSafe>;
 
 impl FramebufferObject {
     /// Access the inner framebuffer trait object.
-    pub fn inner(&self) -> &Option<Arc<FramebufferAbstract + Send + Sync>> {
+    pub fn inner(&self) -> &Option<Arc<dyn FramebufferAbstract + Send + Sync>> {
         &self.framebuffer
     }
 
@@ -268,7 +268,7 @@ impl FramebufferObject {
     /// **panic!**s if the `update` method has not yet been called.
     ///
     /// This method is shorthand for `fbo.as_ref().expect("inner framebuffer was None").clone()`.
-    pub fn expect_inner(&self) -> Arc<FramebufferAbstract + Send + Sync> {
+    pub fn expect_inner(&self) -> Arc<dyn FramebufferAbstract + Send + Sync> {
         self.framebuffer
             .as_ref()
             .expect("inner framebuffer was `None` - you must call the `update` method first")
@@ -617,7 +617,7 @@ impl ViewportBuilder {
 }
 
 impl ops::Deref for FramebufferObject {
-    type Target = Option<Arc<FramebufferAbstract + Send + Sync>>;
+    type Target = Option<Arc<dyn FramebufferAbstract + Send + Sync>>;
     fn deref(&self) -> &Self::Target {
         &self.framebuffer
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -159,7 +159,7 @@ macro_rules! fn_any {
         // A handle to a function that can be stored without requiring a type param.
         #[derive(Clone)]
         pub(crate) struct $TFnAny {
-            fn_ptr: Arc<Any>,
+            fn_ptr: Arc<dyn Any>,
         }
 
         impl $TFnAny {
@@ -168,7 +168,7 @@ macro_rules! fn_any {
             where
                 M: 'static,
             {
-                let fn_ptr = Arc::new(fn_ptr) as Arc<Any>;
+                let fn_ptr = Arc::new(fn_ptr) as Arc<dyn Any>;
                 $TFnAny { fn_ptr }
             }
 
@@ -261,7 +261,7 @@ pub(crate) struct WindowSwapchain {
     //
     // Destroying the `GpuFuture` blocks until the GPU is finished executing it. In order to avoid
     // that, we store the submission of the previous frame here.
-    pub(crate) previous_frame_end: Mutex<Option<vk::FenceSignalFuture<Box<vk::GpuFuture>>>>,
+    pub(crate) previous_frame_end: Mutex<Option<vk::FenceSignalFuture<Box<dyn vk::GpuFuture>>>>,
 }
 
 /// Swapchain building parameters for which Nannou will provide a default if unspecified.
@@ -296,11 +296,11 @@ pub struct SwapchainBuilder {
 ///   recently been recreated and the framebuffers should be recreated accordingly.
 #[derive(Default)]
 pub struct SwapchainFramebuffers {
-    framebuffers: Vec<Arc<vk::FramebufferAbstract + Send + Sync>>,
+    framebuffers: Vec<Arc<dyn vk::FramebufferAbstract + Send + Sync>>,
 }
 
 pub type SwapchainFramebufferBuilder<A> =
-    vk::FramebufferBuilder<Arc<vk::RenderPassAbstract + Send + Sync>, A>;
+    vk::FramebufferBuilder<Arc<dyn vk::RenderPassAbstract + Send + Sync>, A>;
 pub type FramebufferBuildResult<A> =
     Result<SwapchainFramebufferBuilder<A>, vk::FramebufferCreationError>;
 
@@ -309,7 +309,7 @@ impl SwapchainFramebuffers {
     pub fn update<F, A>(
         &mut self,
         frame: &RawFrame,
-        render_pass: Arc<vk::RenderPassAbstract + Send + Sync>,
+        render_pass: Arc<dyn vk::RenderPassAbstract + Send + Sync>,
         builder: F,
     ) -> Result<(), vk::FramebufferCreationError>
     where
@@ -346,7 +346,7 @@ impl SwapchainFramebuffers {
 }
 
 impl ops::Deref for SwapchainFramebuffers {
-    type Target = [Arc<vk::FramebufferAbstract + Send + Sync>];
+    type Target = [Arc<dyn vk::FramebufferAbstract + Send + Sync>];
     fn deref(&self) -> &Self::Target {
         &self.framebuffers
     }


### PR DESCRIPTION
This does not address the audio or osc modules as they will be moved
into independent crates as of #331 and #334.