### PR TITLE
Update simple_audio example for nannou_audio v0.2.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-
 before_script:
 - rustup component add rustfmt
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ winit = "0.19"
 
 [dev-dependencies]
 audrey = "0.2"
-nannou_audio = "0.1"
+nannou_audio = "0.2"
 nannou_laser = "0.3"
 nannou_osc = "0.1"
 shade_runner = "0.1"

--- a/examples/simple_audio.rs
+++ b/examples/simple_audio.rs
@@ -24,13 +24,17 @@ fn model(app: &App) -> Model {
         .build()
         .unwrap();
     // Initialise the audio API so we can spawn an audio stream.
-    let audio_api = audio::Api::new();
+    let audio_host = audio::Host::new();
     // Initialise the state that we want to live on the audio thread.
     let model = Audio {
         phase: 0.0,
         hz: 440.0,
     };
-    let stream = audio_api.new_output_stream(model, audio).build().unwrap();
+    let stream = audio_host
+        .new_output_stream(model)
+        .render(audio)
+        .build()
+        .unwrap();
     Model { stream }
 }
 
@@ -54,9 +58,9 @@ fn key_pressed(_app: &App, model: &mut Model, key: Key) {
         // Pause or unpause the audio when Space is pressed.
         Key::Space => {
             if model.stream.is_playing() {
-                model.stream.pause();
+                model.stream.pause().unwrap();
             } else {
-                model.stream.play();
+                model.stream.play().unwrap();
             }
         }
         // Raise the frequency when the up key is pressed.

--- a/examples/simple_audio_file.rs
+++ b/examples/simple_audio_file.rs
@@ -22,13 +22,17 @@ fn model(app: &App) -> Model {
         .build()
         .unwrap();
 
-    // Initialise the audio API so we can spawn an audio stream.
-    let audio_api = audio::Api::new();
+    // Initialise the audio host so we can spawn an audio stream.
+    let audio_host = audio::Host::new();
 
     // Initialise the state that we want to live on the audio thread.
     let sounds = vec![];
     let model = Audio { sounds };
-    let stream = audio_api.new_output_stream(model, audio).build().unwrap();
+    let stream = audio_host
+        .new_output_stream(model)
+        .render(audio)
+        .build()
+        .unwrap();
     Model { stream }
 }
 


### PR DESCRIPTION
For the most part not a lot has changed, however nannou_audio 0.2 now
supports alternative audio host APIs including ASIO on windows via the
`asio` feature.