### PR TITLE
Change `view` function signature to take `Frame` by reference rather than value

### DIFF
--- a/examples/all_functions.rs
+++ b/examples/all_functions.rs
@@ -54,9 +54,8 @@ fn event(_app: &App, _model: &mut Model, event: Event) {
 
 fn update(_app: &App, _model: &mut Model, _update: Update) {}
 
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     frame.clear(DARK_BLUE);
-    frame
 }
 
 fn window_event(_app: &App, _model: &mut Model, event: WindowEvent) {

--- a/examples/basics/1_nannou_events.rs
+++ b/examples/basics/1_nannou_events.rs
@@ -56,10 +56,8 @@ fn event(_app: &App, _model: &mut Model, event: WindowEvent) {
     }
 }
 
-// put your main code here, to run repeatedly:
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+// Put your drawing code, called once per frame, per window.
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     // Clear the window to a dark charcoal color.
     frame.clear(DARK_CHARCOAL);
-    // Return the drawn frame.
-    frame
 }

--- a/examples/basics/2_variables_window_console.rs
+++ b/examples/basics/2_variables_window_console.rs
@@ -27,9 +27,7 @@ fn model(app: &App) -> Model {
     Model
 }
 
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     // Clear the window with dark charcoal.
     frame.clear(DARK_CHARCOAL);
-    // Return the drawn frame.
-    frame
 }

--- a/examples/basics/3_variable_scope.rs
+++ b/examples/basics/3_variable_scope.rs
@@ -40,9 +40,7 @@ fn event(_app: &App, model: &mut Model, event: WindowEvent) {
     }
 }
 
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     // Color the window gray.
     frame.clear(DARK_CHARCOAL);
-    // Return the drawn frame.
-    frame
 }

--- a/examples/basics/4_conditionals.rs
+++ b/examples/basics/4_conditionals.rs
@@ -4,7 +4,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     // Prepare to draw.
     let draw = app.draw();
 
@@ -31,7 +31,4 @@ fn view(app: &App, frame: Frame) -> Frame {
 
     // Draw to the window frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/basics/5_loops.rs
+++ b/examples/basics/5_loops.rs
@@ -42,7 +42,6 @@ fn model(_app: &App) -> Model {
     Model
 }
 
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     frame.clear(DARK_CHARCOAL);
-    frame
 }

--- a/examples/basics/6_functions.rs
+++ b/examples/basics/6_functions.rs
@@ -52,7 +52,6 @@ fn event(_app: &App, _model: &mut Model, event: WindowEvent) {
     }
 }
 
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     frame.clear(DARK_CHARCOAL);
-    frame
 }

--- a/examples/basics/7_modules/7_modules.rs
+++ b/examples/basics/7_modules/7_modules.rs
@@ -23,7 +23,7 @@ fn update(app: &App, model: &mut Model, _update: Update) {
     model.ball.position = pt2(app.mouse.x, app.mouse.y);
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing.
     let draw = app.draw();
     // Draw dark gray for the background
@@ -32,6 +32,4 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     model.ball.display(&draw);
     // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-    // Return the drawn frame.
-    frame
 }

--- a/examples/generative_design/color/p_1_0_01.rs
+++ b/examples/generative_design/color/p_1_0_01.rs
@@ -34,7 +34,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     app.main_window().set_inner_size_points(720.0, 720.0);
 
     // Prepare to draw.
@@ -49,7 +49,4 @@ fn view(app: &App, frame: Frame) -> Frame {
 
     // Write to the window frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/generative_design/color/p_1_1_01.rs
+++ b/examples/generative_design/color/p_1_1_01.rs
@@ -4,7 +4,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     app.main_window().set_inner_size_pixels(800, 400);
 
     // Begin drawing
@@ -35,7 +35,4 @@ fn view(app: &App, frame: Frame) -> Frame {
 
     // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/generative_design/color/p_1_2_3_01.rs
+++ b/examples/generative_design/color/p_1_2_3_01.rs
@@ -135,7 +135,7 @@ fn key_pressed(_app: &App, model: &mut Model, key: Key) {
     }
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
 
@@ -183,7 +183,4 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
 
     // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/generative_design/color/p_1_2_3_02.rs
+++ b/examples/generative_design/color/p_1_2_3_02.rs
@@ -52,7 +52,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
 
@@ -126,7 +126,4 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
 
     // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/laser/laser_frame_stream.rs
+++ b/examples/laser/laser_frame_stream.rs
@@ -155,7 +155,6 @@ fn key_pressed(_app: &App, model: &mut Model, key: Key) {
         .unwrap();
 }
 
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     frame.clear(DARK_CHARCOAL);
-    frame
 }

--- a/examples/laser/laser_frame_stream_gui.rs
+++ b/examples/laser/laser_frame_stream_gui.rs
@@ -568,7 +568,6 @@ fn key_pressed(_app: &App, model: &mut Model, key: Key) {
     }
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     model.ui.draw_to_frame_if_changed(app, &frame).unwrap();
-    frame
 }

--- a/examples/laser/laser_raw_stream.rs
+++ b/examples/laser/laser_raw_stream.rs
@@ -76,11 +76,10 @@ fn mouse_moved(app: &App, model: &mut Model, pos: Point2) {
         .unwrap();
 }
 
-fn view(app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, _model: &Model, frame: &Frame) {
     // Visualise the point in the window.
     let draw = app.draw();
     draw.background().color(DARK_CHARCOAL);
     draw.ellipse().w_h(5.0, 5.0).xy(app.mouse.position());
     draw.to_frame(app, &frame).unwrap();
-    frame
 }

--- a/examples/loop_mode.rs
+++ b/examples/loop_mode.rs
@@ -48,7 +48,6 @@ fn key_pressed(app: &App, _model: &mut Model, _key: Key) {
     app.main_window().set_title(&title);
 }
 
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     frame.clear(DARK_CHARCOAL);
-    frame
 }

--- a/examples/multi_window.rs
+++ b/examples/multi_window.rs
@@ -46,12 +46,11 @@ fn event_c(_app: &App, _model: &mut Model, event: WindowEvent) {
     println!("window c: {:?}", event);
 }
 
-fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, model: &Model, frame: &Frame) {
     match frame.window_id() {
         id if id == model.a => frame.clear(RED),
         id if id == model.b => frame.clear(GREEN),
         id if id == model.c => frame.clear(BLUE),
         _ => (),
     }
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_10_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_10_motion101_acceleration.rs
@@ -72,16 +72,13 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     m.mover.update(pt2(app.mouse.x, app.mouse.y));
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
 
     m.mover.display(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_11_motion101_acceleration_array.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_11_motion101_acceleration_array.rs
@@ -82,7 +82,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -91,9 +91,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_1_bouncingball_novectors.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_1_bouncingball_novectors.rs
@@ -51,7 +51,7 @@ fn update(app: &App, model: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -61,9 +61,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .w_h(50.0, 50.0)
         .rgba(0.5, 0.5, 0.5, 1.0);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors.rs
@@ -40,7 +40,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
 
@@ -55,7 +55,4 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .rgb(0.5, 0.5, 0.5);
     // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors_object.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors_object.rs
@@ -56,7 +56,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     m.ball.update(app.window_rect());
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.rect()
@@ -65,9 +65,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
 
     m.ball.display(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_3_vector_subtraction.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_3_vector_subtraction.rs
@@ -9,7 +9,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     app.main_window().set_inner_size_points(640.0, 360.0);
 
     // Begin drawing
@@ -26,9 +26,6 @@ fn view(app: &App, frame: Frame) -> Frame {
         .thickness(2.0)
         .color(BLACK);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_4_vector_multiplication.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_4_vector_multiplication.rs
@@ -9,7 +9,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     app.main_window().set_inner_size_points(640.0, 360.0);
 
     // Begin drawing
@@ -28,9 +28,6 @@ fn view(app: &App, frame: Frame) -> Frame {
         .thickness(2.0)
         .color(BLACK);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_5_vector_magnitude.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_5_vector_magnitude.rs
@@ -9,7 +9,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     app.main_window().set_inner_size_points(640.0, 360.0);
 
     // Begin drawing
@@ -33,9 +33,6 @@ fn view(app: &App, frame: Frame) -> Frame {
         .thickness(2.0)
         .color(BLACK);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_6_vector_normalize.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_6_vector_normalize.rs
@@ -9,7 +9,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     app.main_window().set_inner_size_points(640.0, 360.0);
 
     // Begin drawing
@@ -35,9 +35,6 @@ fn view(app: &App, frame: Frame) -> Frame {
         .thickness(2.0)
         .color(BLACK);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_7_motion101.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_7_motion101.rs
@@ -70,7 +70,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     m.mover.check_edges(app.window_rect());
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.rect()
@@ -79,9 +79,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
 
     m.mover.display(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_8_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_8_motion101_acceleration.rs
@@ -80,7 +80,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     m.mover.check_edges(app.window_rect());
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.rect()
@@ -89,9 +89,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
 
     m.mover.display(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_01_vectors/1_9_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_9_motion101_acceleration.rs
@@ -81,16 +81,13 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     m.mover.update();
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
 
     m.mover.display(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_10_exercise_attract_repel.rs
+++ b/examples/nature_of_code/chp_02_forces/2_10_exercise_attract_repel.rs
@@ -218,7 +218,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     let draw = app.draw();
     draw.background().color(WHITE);
 
@@ -229,9 +229,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_1_forces.rs
+++ b/examples/nature_of_code/chp_02_forces/2_1_forces.rs
@@ -88,16 +88,13 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     m.mover.check_edges(app.window_rect());
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
 
     m.mover.display(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_2_forces_many.rs
+++ b/examples/nature_of_code/chp_02_forces/2_2_forces_many.rs
@@ -93,7 +93,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -102,9 +102,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_3_forces_many_real_gravity.rs
+++ b/examples/nature_of_code/chp_02_forces/2_3_forces_many_real_gravity.rs
@@ -93,7 +93,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -102,9 +102,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_4_forces_friction.rs
+++ b/examples/nature_of_code/chp_02_forces/2_4_forces_friction.rs
@@ -109,7 +109,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -118,9 +118,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_4_forces_no_friction.rs
+++ b/examples/nature_of_code/chp_02_forces/2_4_forces_no_friction.rs
@@ -100,7 +100,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -109,9 +109,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_5_fluid_resistance.rs
+++ b/examples/nature_of_code/chp_02_forces/2_5_fluid_resistance.rs
@@ -180,7 +180,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -193,9 +193,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_6_attraction.rs
+++ b/examples/nature_of_code/chp_02_forces/2_6_attraction.rs
@@ -182,7 +182,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     m.attractor.hover(app.mouse.x, app.mouse.y);
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -190,9 +190,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
     m.attractor.display(&draw);
     m.mover.display(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_7_attraction_many.rs
+++ b/examples/nature_of_code/chp_02_forces/2_7_attraction_many.rs
@@ -182,7 +182,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -194,9 +194,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_8_mutual_attraction.rs
+++ b/examples/nature_of_code/chp_02_forces/2_8_mutual_attraction.rs
@@ -96,7 +96,7 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -106,9 +106,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_02_forces/2_forces_many_mutual_boundaries.rs
+++ b/examples/nature_of_code/chp_02_forces/2_forces_many_mutual_boundaries.rs
@@ -118,7 +118,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -128,9 +128,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_01_angular_motion.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_01_angular_motion.rs
@@ -36,7 +36,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.a_velocity += model.a_acceleration;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -59,9 +59,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .color(BLACK)
         .rotate(model.angle);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_02_forces_angular_motion.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_02_forces_angular_motion.rs
@@ -134,7 +134,7 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -146,9 +146,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         mover.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_04_exercise_spiral.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_04_exercise_spiral.rs
@@ -33,7 +33,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.r += 0.05;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     //draw.background().color(WHITE);
@@ -47,9 +47,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .w_h(16.0, 16.0)
         .rgba(0.0, 0.0, 0.0, 1.0);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian.rs
@@ -33,7 +33,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.theta += 0.02;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -49,9 +49,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     // Draw an ellipse at cartesian coordinate
     draw.ellipse().x_y(x, y).w_h(48.0, 48.0).rgb(0.5, 0.5, 0.5);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian_trail.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian_trail.rs
@@ -33,7 +33,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.theta += 0.02;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
 
@@ -52,9 +52,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     // Draw an ellipse at cartesian coordinate
     draw.ellipse().x_y(x, y).w_h(48.0, 48.0).rgb(0.5, 0.5, 0.5);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_05_simple_harmonic_motion.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_05_simple_harmonic_motion.rs
@@ -9,7 +9,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     app.main_window().set_inner_size_points(640.0, 360.0);
     // Begin drawing
     let draw = app.draw();
@@ -25,9 +25,6 @@ fn view(app: &App, frame: Frame) -> Frame {
         .w_h(50.0, 50.0)
         .rgba(0.5, 0.5, 0.5, 1.0);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_06_simple_harmonic_motion.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_06_simple_harmonic_motion.rs
@@ -30,7 +30,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.angle += model.a_velocity;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -43,9 +43,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .w_h(50.0, 50.0)
         .rgba(0.5, 0.5, 0.5, 1.0);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_07_oscillating_objects.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_07_oscillating_objects.rs
@@ -65,7 +65,7 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().rgba(1.0, 1.0, 1.0, 1.0);
@@ -74,9 +74,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         osc.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_09_wave.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_09_wave.rs
@@ -32,7 +32,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.start_angle += 0.015;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -51,9 +51,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         x += 24.0;
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_09_wave_a.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_09_wave_a.rs
@@ -32,7 +32,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.start_angle += 0.015;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -51,9 +51,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         x += 24.0;
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_09_wave_b.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_09_wave_b.rs
@@ -32,7 +32,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.start_angle += 0.015;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -51,9 +51,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         x += 24.0;
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_09_wave_c.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_09_wave_c.rs
@@ -32,7 +32,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.start_angle += 0.015;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -51,9 +51,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         x += 24.0;
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_10_exercise_oop_wave.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_10_exercise_oop_wave.rs
@@ -90,7 +90,7 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     m.wave1.calculate();
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -99,9 +99,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
     m.wave0.display(&draw);
     m.wave1.display(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_extra_oscillating_up_and_down.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_extra_oscillating_up_and_down.rs
@@ -27,7 +27,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.angle += 0.02;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -43,9 +43,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .w_h(16.0, 16.0)
         .rgb(0.4, 0.4, 0.4);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_multiple_oscillations.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_multiple_oscillations.rs
@@ -47,7 +47,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
     model.angle2 += model.a_velocity2;
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -61,9 +61,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .w_h(20.0, 20.0)
         .rgba(0.7, 0.7, 0.7, 1.0);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_03_oscillation/3_oop_wave_particles.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_oop_wave_particles.rs
@@ -111,7 +111,7 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     m.wave1.calculate();
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -120,9 +120,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
     m.wave0.display(&draw);
     m.wave1.display(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_04_systems/4_01_single_particle.rs
+++ b/examples/nature_of_code/chp_04_systems/4_01_single_particle.rs
@@ -79,16 +79,13 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
 
     m.p.display(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_04_systems/4_02_vector_particle.rs
+++ b/examples/nature_of_code/chp_04_systems/4_02_vector_particle.rs
@@ -84,7 +84,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(BLACK);
@@ -93,9 +93,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         p.display(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_04_systems/4_03_particle_system_type.rs
+++ b/examples/nature_of_code/chp_04_systems/4_03_particle_system_type.rs
@@ -111,16 +111,13 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     m.ps.update();
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(BLACK);
 
     m.ps.draw(&draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_04_systems/4_04_system_of_systems.rs
+++ b/examples/nature_of_code/chp_04_systems/4_04_system_of_systems.rs
@@ -130,7 +130,7 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(BLACK);
@@ -139,9 +139,6 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         m.systems[i].draw(&draw);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_06_agents/6_01_seek.rs
+++ b/examples/nature_of_code/chp_06_agents/6_01_seek.rs
@@ -81,7 +81,7 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     m.vehicle.update();
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -95,11 +95,8 @@ fn view(app: &App, m: &Model, frame: Frame) -> Frame {
         .rgb(0.78, 0.78, 0.78);
     display(&m.vehicle, &draw);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }
 
 // A method that calculates a steering force towards a target

--- a/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_figures.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_figures.rs
@@ -164,15 +164,12 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
 
     m.ca.display(&draw, &app.window_rect());
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_simple.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_simple.rs
@@ -129,15 +129,12 @@ fn update(app: &App, m: &mut Model, _update: Update) {
     }
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
 
     m.ca.display(&draw, &app.window_rect());
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_07_cellular_automata/7_02_game_of_life_simple.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_02_game_of_life_simple.rs
@@ -149,16 +149,13 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     m.gol.generate();
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
 
     m.gol.display(&draw, &app.window_rect());
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_07_cellular_automata/7_03_game_of_life_oop.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_03_game_of_life_oop.rs
@@ -172,16 +172,13 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     m.gol.generate();
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
 
     m.gol.display(&draw, &app.window_rect());
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_07_cellular_automata/7_04_exercise_wolfram_ca_scrolling.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_04_exercise_wolfram_ca_scrolling.rs
@@ -175,15 +175,12 @@ fn update(_app: &App, m: &mut Model, _update: Update) {
     m.ca.generate();
 }
 
-fn view(app: &App, m: &Model, frame: Frame) -> Frame {
+fn view(app: &App, m: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
 
     m.ca.display(&draw, &app.window_rect());
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/nature_of_code/chp_08_fractals/8_1_recursion.rs
+++ b/examples/nature_of_code/chp_08_fractals/8_1_recursion.rs
@@ -22,18 +22,15 @@ fn model(app: &App) -> Model {
     Model
 }
 
-fn view(app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, _model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
 
     draw_circle(&draw, 0.0, 0.0, app.window_rect().w());
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }
 
 fn draw_circle(draw: &app::Draw, x: f32, y: f32, mut r: f32) {

--- a/examples/nature_of_code/chp_08_fractals/8_2_recursion.rs
+++ b/examples/nature_of_code/chp_08_fractals/8_2_recursion.rs
@@ -22,18 +22,15 @@ fn model(app: &App) -> Model {
     Model
 }
 
-fn view(app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, _model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
 
     draw_circle(&draw, 0.0, 0.0, 400.0);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }
 
 // Recursive function

--- a/examples/nature_of_code/chp_08_fractals/8_3_recursion.rs
+++ b/examples/nature_of_code/chp_08_fractals/8_3_recursion.rs
@@ -22,18 +22,15 @@ fn model(app: &App) -> Model {
     Model
 }
 
-fn view(app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, _model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
 
     draw_circle(&draw, 0.0, 0.0, 400.0);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }
 
 // Recursive function

--- a/examples/nature_of_code/chp_08_fractals/8_4_cantor_set.rs
+++ b/examples/nature_of_code/chp_08_fractals/8_4_cantor_set.rs
@@ -23,7 +23,7 @@ fn model(app: &App) -> Model {
     Model
 }
 
-fn view(app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, _model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     draw.background().color(WHITE);
@@ -31,11 +31,8 @@ fn view(app: &App, _model: &Model, frame: Frame) -> Frame {
     let win = app.window_rect();
     cantor(&draw, 0.0, win.top(), 730.0);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }
 
 // Recursive function

--- a/examples/osc_receiver.rs
+++ b/examples/osc_receiver.rs
@@ -71,7 +71,6 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
 }
 
 // Draw the state of your `Model` into the given `Frame` here.
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     model.ui.draw_to_frame(app, &frame).unwrap();
-    frame
 }

--- a/examples/osc_sender.rs
+++ b/examples/osc_sender.rs
@@ -85,7 +85,6 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
         .set(model.text, &mut ui);
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     model.ui.draw_to_frame(app, &frame).unwrap();
-    frame
 }

--- a/examples/simple_audio.rs
+++ b/examples/simple_audio.rs
@@ -85,7 +85,6 @@ fn key_pressed(_app: &App, model: &mut Model, key: Key) {
     }
 }
 
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     frame.clear(DARK_CHARCOAL);
-    frame
 }

--- a/examples/simple_audio_file.rs
+++ b/examples/simple_audio_file.rs
@@ -83,7 +83,6 @@ fn key_pressed(app: &App, model: &mut Model, key: Key) {
     }
 }
 
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     frame.clear(DARK_CHARCOAL);
-    frame
 }

--- a/examples/simple_draw.rs
+++ b/examples/simple_draw.rs
@@ -4,7 +4,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
 
@@ -44,9 +44,6 @@ fn view(app: &App, frame: Frame) -> Frame {
         .w(app.mouse.x * 0.25)
         .hsv(t, 1.0, 1.0);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/simple_mesh.rs
+++ b/examples/simple_mesh.rs
@@ -4,7 +4,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     // Begin drawing
     let win = app.window_rect();
     let t = app.time;
@@ -48,9 +48,6 @@ fn view(app: &App, frame: Frame) -> Frame {
     // Draw the mesh!
     draw.mesh().tris(tris);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/simple_polygon.rs
+++ b/examples/simple_polygon.rs
@@ -4,7 +4,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     // Begin drawing
     let win = app.window_rect();
     let t = app.time;
@@ -48,9 +48,6 @@ fn view(app: &App, frame: Frame) -> Frame {
         .x(win.w() * 0.25)
         .rotate(t * 0.2);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/simple_polyline.rs
+++ b/examples/simple_polyline.rs
@@ -4,7 +4,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
 
@@ -41,9 +41,6 @@ fn view(app: &App, frame: Frame) -> Frame {
     // Draw the polyline.
     draw.polyline().vertices(half_thickness, vertices);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -129,7 +129,7 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
 }
 
 // Draw the state of your `Model` into the given `Frame` here.
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
 
@@ -142,12 +142,9 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .rotate(model.rotation)
         .color(model.color);
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
 
     // Draw the state of the `Ui` to the frame.
     model.ui.draw_to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -28,9 +28,7 @@ fn event(_app: &App, _model: &mut Model, event: WindowEvent) {
 }
 
 // Draw the state of your `Model` into the given `Frame` here.
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     // Clear the window with a "dark charcoal" shade.
     frame.clear(BLUE);
-    // Return the cleared frame.
-    frame
 }

--- a/examples/template_app.rs
+++ b/examples/template_app.rs
@@ -44,7 +44,7 @@ fn window_event(_app: &App, _model: &mut Model, event: WindowEvent) {
     }
 }
 
-fn view(app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, _model: &Model, frame: &Frame) {
     // Prepare to draw.
     let draw = app.draw();
     // Clear the background to pink.
@@ -53,6 +53,4 @@ fn view(app: &App, _model: &Model, frame: Frame) -> Frame {
     draw.ellipse().color(DARK_BLUE);
     // Write to the window frame.
     draw.to_frame(app, &frame).unwrap();
-    // Return the drawn frame.
-    frame
 }

--- a/examples/template_sketch.rs
+++ b/examples/template_sketch.rs
@@ -4,7 +4,7 @@ fn main() {
     nannou::sketch(view);
 }
 
-fn view(app: &App, frame: Frame) -> Frame {
+fn view(app: &App, frame: &Frame) {
     // Prepare to draw.
     let draw = app.draw();
 
@@ -16,7 +16,4 @@ fn view(app: &App, frame: Frame) -> Frame {
 
     // Write to the window frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the drawn frame.
-    frame
 }

--- a/examples/vulkan/vk_compute_shader.rs
+++ b/examples/vulkan/vk_compute_shader.rs
@@ -148,7 +148,7 @@ fn update(app: &App, model: &mut Model, _update: Update) {
     future.wait(None).unwrap();
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     // Begin drawing
     let draw = app.draw();
     let win = app.window_rect();
@@ -169,11 +169,8 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         draw.rect().x_y(x, y).w_h(1.0, h).hsv(hue, 1.0, 1.0);
     }
 
-    // Write the result of our drawing to the window's OpenGL frame.
+    // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();
-
-    // Return the cleared frame.
-    frame
 }
 
 mod cs {

--- a/examples/vulkan/vk_debug.rs
+++ b/examples/vulkan/vk_debug.rs
@@ -24,7 +24,6 @@ fn model(_app: &App) -> Model {
     Model
 }
 
-fn view(_app: &App, _model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, _model: &Model, frame: &Frame) {
     frame.clear(DARK_BLUE);
-    frame
 }

--- a/examples/vulkan/vk_hotload.rs
+++ b/examples/vulkan/vk_hotload.rs
@@ -175,7 +175,7 @@ fn update(_app: &App, model: &mut Model, _: Update) {
 }
 
 // Draw the state of your `Model` into the given `Frame` here.
-fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, model: &Model, frame: &Frame) {
     // Dynamic viewports allow us to recreate just the viewport when the window is resized
     // Otherwise we would have to recreate the whole pipeline.
     let [w, h] = frame.swapchain_image().dimensions();
@@ -186,7 +186,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     model
         .view_fbo
         .borrow_mut()
-        .update(&frame, model.render_pass.clone(), |builder, image| {
+        .update(frame, model.render_pass.clone(), |builder, image| {
             builder.add(image)
         })
         .unwrap();
@@ -209,8 +209,6 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
         .unwrap()
         .end_render_pass()
         .expect("failed to add `end_render_pass` command");
-
-    frame
 }
 
 fn update_pipeline(model: &mut Model) {

--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -123,7 +123,7 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
@@ -132,7 +132,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     model
         .view_fbo
         .borrow_mut()
-        .update(&frame, model.render_pass.clone(), |builder, image| {
+        .update(frame, model.render_pass.clone(), |builder, image| {
             builder.add(image)
         })
         .unwrap();
@@ -157,8 +157,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .unwrap()
         .end_render_pass()
         .expect("failed to add `end_render_pass` command");
-
-    frame
 }
 
 mod vs {

--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -131,7 +131,7 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
@@ -140,7 +140,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     model
         .view_fbo
         .borrow_mut()
-        .update(&frame, model.render_pass.clone(), |builder, image| {
+        .update(frame, model.render_pass.clone(), |builder, image| {
             builder.add(image)
         })
         .unwrap();
@@ -174,8 +174,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .x_y(app.mouse.x * t.cos(), app.mouse.y)
         .radius(win.w() * 0.125 * t.sin())
         .rgba(1.0, 0.0, 0.0, 0.4);
-
-    frame
 }
 
 mod vs {

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -140,7 +140,7 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, model: &Model, frame: &Frame) {
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
@@ -149,7 +149,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     model
         .view_fbo
         .borrow_mut()
-        .update(&frame, model.render_pass.clone(), |builder, image| {
+        .update(frame, model.render_pass.clone(), |builder, image| {
             builder.add(image)
         })
         .unwrap();
@@ -170,8 +170,6 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
         .unwrap()
         .end_render_pass()
         .expect("failed to add `end_render_pass` command");
-
-    frame
 }
 
 mod vs {

--- a/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
+++ b/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
@@ -217,7 +217,7 @@ fn update(_: &App, model: &mut Model, _update: Update) {
 }
 
 // Draw the state of your `Model` into the given `Frame` here.
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     let mut graphics = model.graphics.borrow_mut();
     let inter_image = graphics.inter_image.clone();
 
@@ -300,7 +300,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .end_render_pass()
         .expect("failed to add `end_render_pass` command");
 
-    warp::view(&app, model, inter_image, frame)
+    warp::view(&app, model, inter_image, frame);
 }
 
 // Create the graphics pipeline.
@@ -325,10 +325,9 @@ fn create_graphics_pipeline(
     Ok(Arc::new(pipeline) as Arc<_>)
 }
 
-fn ui_view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn ui_view(app: &App, model: &Model, frame: &Frame) {
     // Draw the state of the `Ui` to the frame.
-    model.ui.draw_to_frame(app, &frame).unwrap();
-    frame
+    model.ui.draw_to_frame(app, frame).unwrap();
 }
 
 // GLSL Shaders

--- a/examples/vulkan/vk_quad_warp/warp.rs
+++ b/examples/vulkan/vk_quad_warp/warp.rs
@@ -76,12 +76,7 @@ pub(crate) fn warp(app: &App) -> Warp {
     }
 }
 
-pub(crate) fn view(
-    app: &App,
-    model: &Model,
-    inter_image: Arc<vk::AttachmentImage>,
-    frame: Frame,
-) -> Frame {
+pub(crate) fn view(app: &App, model: &Model, inter_image: Arc<vk::AttachmentImage>, frame: &Frame) {
     let Model { warp, controls, .. } = model;
 
     let [w, h] = frame.swapchain_image().dimensions();
@@ -175,8 +170,6 @@ pub(crate) fn view(
         .expect("Failed to draw")
         .end_render_pass()
         .expect("failed to add `end_render_pass` command");
-
-    frame
 }
 
 mod vs {

--- a/examples/vulkan/vk_shader_include/mod.rs
+++ b/examples/vulkan/vk_shader_include/mod.rs
@@ -97,7 +97,7 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);
@@ -106,7 +106,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     model
         .view_fbo
         .borrow_mut()
-        .update(&frame, model.render_pass.clone(), |builder, image| {
+        .update(frame, model.render_pass.clone(), |builder, image| {
             builder.add(image)
         })
         .unwrap();
@@ -133,8 +133,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .unwrap()
         .end_render_pass()
         .expect("failed to add `end_render_pass` command");
-
-    frame
 }
 
 mod vs {

--- a/examples/vulkan/vk_teapot.rs
+++ b/examples/vulkan/vk_teapot.rs
@@ -135,7 +135,7 @@ fn model(app: &App) -> Model {
 }
 
 // Draw the state of your `Model` into the given `Frame` here.
-fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(app: &App, model: &Model, frame: &Frame) {
     let mut graphics = model.graphics.borrow_mut();
 
     let [w, h] = frame.swapchain_image().dimensions();
@@ -166,7 +166,7 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
     let depth_image = graphics.depth_image.clone();
     graphics
         .view_fbo
-        .update(&frame, render_pass, |builder, image| {
+        .update(frame, render_pass, |builder, image| {
             builder.add(image)?.add(depth_image.clone())
         })
         .unwrap();
@@ -226,8 +226,6 @@ fn view(app: &App, model: &Model, frame: Frame) -> Frame {
         .unwrap()
         .end_render_pass()
         .expect("failed to add `end_render_pass` command");
-
-    frame
 }
 
 // Create the graphics pipeline.

--- a/examples/vulkan/vk_teapot_camera.rs
+++ b/examples/vulkan/vk_teapot_camera.rs
@@ -269,7 +269,7 @@ fn key_pressed(app: &App, model: &mut Model, key: Key) {
 }
 
 // Draw the state of your `Model` into the given `Frame` here.
-fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, model: &Model, frame: &Frame) {
     let mut graphics = model.graphics.borrow_mut();
 
     let [w, h] = frame.swapchain_image().dimensions();
@@ -300,7 +300,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     let depth_image = graphics.depth_image.clone();
     graphics
         .view_fbo
-        .update(&frame, render_pass, |builder, image| {
+        .update(frame, render_pass, |builder, image| {
             builder.add(image)?.add(depth_image.clone())
         })
         .unwrap();
@@ -356,8 +356,6 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
         .unwrap()
         .end_render_pass()
         .expect("failed to add `end_render_pass` command");
-
-    frame
 }
 
 // Create the graphics pipeline.

--- a/examples/vulkan/vk_triangle.rs
+++ b/examples/vulkan/vk_triangle.rs
@@ -114,7 +114,7 @@ fn model(app: &App) -> Model {
 }
 
 // Draw the state of your `Model` into the given `Frame` here.
-fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
+fn view(_app: &App, model: &Model, frame: &Frame) {
     // Dynamic viewports allow us to recreate just the viewport when the window is resized
     // Otherwise we would have to recreate the whole pipeline.
     let [w, h] = frame.swapchain_image().dimensions();
@@ -125,7 +125,7 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
     model
         .view_fbo
         .borrow_mut()
-        .update(&frame, model.render_pass.clone(), |builder, image| {
+        .update(frame, model.render_pass.clone(), |builder, image| {
             builder.add(image)
         })
         .unwrap();
@@ -148,8 +148,6 @@ fn view(_app: &App, model: &Model, frame: Frame) -> Frame {
         .unwrap()
         .end_render_pass()
         .expect("failed to add `end_render_pass` command");
-
-    frame
 }
 
 mod vs {

--- a/examples/vulkan/vk_triangle_raw_frame.rs
+++ b/examples/vulkan/vk_triangle_raw_frame.rs
@@ -117,7 +117,7 @@ fn model(app: &App) -> Model {
 }
 
 // Draw the state of your `Model` into the given `RawFrame` here.
-fn view(_app: &App, model: &Model, frame: RawFrame) -> RawFrame {
+fn view(_app: &App, model: &Model, frame: &RawFrame) {
     // Dynamic viewports allow us to recreate just the viewport when the window is resized
     // Otherwise we would have to recreate the whole pipeline.
     let [w, h] = frame.swapchain_image().dimensions();
@@ -128,7 +128,7 @@ fn view(_app: &App, model: &Model, frame: RawFrame) -> RawFrame {
     model
         .framebuffers
         .borrow_mut()
-        .update(&frame, model.render_pass.clone(), |builder, image| {
+        .update(frame, model.render_pass.clone(), |builder, image| {
             builder.add(image)
         })
         .unwrap();
@@ -155,8 +155,6 @@ fn view(_app: &App, model: &Model, frame: RawFrame) -> RawFrame {
         .unwrap()
         .end_render_pass()
         .expect("failed to add `end_render_pass` command");
-
-    frame
 }
 
 mod vs {

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,10 +49,10 @@ pub type EventFn<Model, Event> = fn(&App, &mut Model, Event);
 pub type UpdateFn<Model> = fn(&App, &mut Model, Update);
 
 /// The user function type for drawing their model to the surface of a single window.
-pub type ViewFn<Model> = fn(&App, &Model, Frame) -> Frame;
+pub type ViewFn<Model> = fn(&App, &Model, &Frame);
 
 /// A shorthand version of `ViewFn` for sketches where the user does not need a model.
-pub type SketchViewFn = fn(&App, Frame) -> Frame;
+pub type SketchViewFn = fn(&App, &Frame);
 
 /// The user function type allowing them to consume the `model` when the application exits.
 pub type ExitFn<Model> = fn(&App, Model);
@@ -853,7 +853,7 @@ impl App {
             .for_folder(Self::ASSETS_DIRECTORY_NAME)
     }
 
-    /// Begin building a new OpenGL window.
+    /// Begin building a new window.
     pub fn new_window(&self) -> window::Builder {
         window::Builder::new(self)
     }
@@ -2085,7 +2085,7 @@ fn view_frame<M>(
             let render_data = take_window_frame_render_data(app, window_id)
                 .expect("failed to take window's `frame_render_data`");
             let frame = Frame::new_empty(raw_frame, render_data).expect("failed to create `Frame`");
-            let frame = view(app, frame);
+            view(app, &frame);
             let (render_data, raw_frame) = frame
                 .finish()
                 .expect("failed to resolve frame's intermediary_image to the swapchain_image");
@@ -2102,7 +2102,7 @@ fn view_frame<M>(
             let view = view
                 .to_fn_ptr::<M>()
                 .expect("unexpected model argument given to window view function");
-            let frame = (*view)(app, model, frame);
+            (*view)(app, model, &frame);
             let (render_data, raw_frame) = frame
                 .finish()
                 .expect("failed to resolve frame's intermediary_image to the swapchain_image");
@@ -2116,7 +2116,7 @@ fn view_frame<M>(
             let raw_view = raw_view
                 .to_fn_ptr::<M>()
                 .expect("unexpected model argument given to window raw_view function");
-            let raw_frame = (*raw_view)(app, model, raw_frame);
+            (*raw_view)(app, model, &raw_frame);
             raw_frame
                 .finish()
                 .build()
@@ -2128,7 +2128,7 @@ fn view_frame<M>(
                     .expect("failed to take window's `frame_render_data`");
                 let frame =
                     Frame::new_empty(raw_frame, render_data).expect("failed to create `Frame`");
-                let frame = view(app, frame);
+                view(app, &frame);
                 let (render_data, raw_frame) = frame
                     .finish()
                     .expect("failed to resolve frame's intermediary_image to the swapchain_image");
@@ -2143,7 +2143,7 @@ fn view_frame<M>(
                     .expect("failed to take window's `frame_render_data`");
                 let frame =
                     Frame::new_empty(raw_frame, render_data).expect("failed to create `Frame`");
-                let frame = view(app, &model, frame);
+                view(app, &model, &frame);
                 let (render_data, raw_frame) = frame
                     .finish()
                     .expect("failed to resolve frame's intermediary_image to the swapchain_image");

--- a/src/window.rs
+++ b/src/window.rs
@@ -27,11 +27,7 @@ pub const DEFAULT_DIMENSIONS: LogicalSize = LogicalSize {
     height: 768.0,
 };
 
-/// For building an OpenGL window.
-///
-/// Window parameters can be specified via the `window` method.
-///
-/// OpenGL context parameters can be specified via the `context` method.
+/// A context for building a window.
 pub struct Builder<'app> {
     app: &'app App,
     vk_physical_device: Option<vk::PhysicalDevice<'app>>,
@@ -71,18 +67,18 @@ pub(crate) struct UserFunctions {
 }
 
 /// The user function type for drawing their model to the surface of a single window.
-pub type ViewFn<Model> = fn(&App, &Model, Frame) -> Frame;
+pub type ViewFn<Model> = fn(&App, &Model, &Frame);
 
 /// The user function type for drawing their model to the surface of a single window.
 ///
 /// Unlike the `ViewFn`, the `RawViewFn` is designed for drawing directly to a window's swapchain
 /// images rather than to a convenient intermediary image.
-pub type RawViewFn<Model> = fn(&App, &Model, RawFrame) -> RawFrame;
+pub type RawViewFn<Model> = fn(&App, &Model, &RawFrame);
 
 /// The same as `ViewFn`, but provides no user model to draw from.
 ///
 /// Useful for simple, stateless sketching.
-pub type SketchFn = fn(&App, Frame) -> Frame;
+pub type SketchFn = fn(&App, &Frame);
 
 /// The user's view function, whether with a model or without one.
 #[derive(Clone)]
@@ -212,10 +208,10 @@ fn_any!(FocusedFn<M>, FocusedFnAny);
 fn_any!(UnfocusedFn<M>, UnfocusedFnAny);
 fn_any!(ClosedFn<M>, ClosedFnAny);
 
-/// An OpenGL window.
+/// A nannou window.
 ///
-/// The `Window` acts as a wrapper around the `glium::Display` type, providing a more
-/// nannou-friendly API.
+/// The `Window` acts as a wrapper around the `winit::Window` and `vulkano::Surface` types and
+/// manages the associated swapchain, providing a more nannou-friendly API.
 #[derive(Debug)]
 pub struct Window {
     pub(crate) queue: Arc<vk::Queue>,


### PR DESCRIPTION
This was suggested by @lewislepton in #366 and I think it makes a lot of
sense in terms of API consistency and keeping things simple for new users.
See #366 for the lead-up discussion, history and reasoning behind the change.

Also closes #328.

cc @freesig and @JoshuaBatty what are your thoughts on this?