### PR TITLE
Publish nannou 0.10.0. Update the CHANGELOG. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+# Version 0.10.0 (2019-07-21)
+
+- Change the `view` function signature to take `Frame` by reference rather than
+  by value.
+- Remove depth format constants in favour of querying supported formats.
 - Update from palette 0.2 to 0.4.
 - Add shorthand color constructors to the `color` module.
 - Remove nannou named colors in favour of using palette's.
@@ -8,6 +13,15 @@
 - Change the `Frame` image type from the swapchain color format (non-linear
   sRGB) to a linear sRGB format for better consistency across platforms.
 - Add Window::rect method.
+- Add `simple_audio_file.rs` playback example.
+- Add a new `NTimes` loop mode.
+- Separate the OSC API out into a `nannou_osc` crate.
+- Separate the audio API out into a `nannou_audio` crate.
+- Update laser examples for switch from `lasy` to `nannou_laser`.
+- Update deps:
+  - rand 0.7
+  - conrod 0.66
+  - vulkano 0.13
 
 # Version 0.9.0 (2019-05-28)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"

--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -123,7 +123,7 @@ fn model(app: &App) -> Model {
     }
 }
 
-fn view(app: &App, model: &Model, frame: &Frame) {
+fn view(_app: &App, model: &Model, frame: &Frame) {
     let [w, h] = frame.swapchain_image().dimensions();
     let viewport = vk::ViewportBuilder::new().build([w as _, h as _]);
     let dynamic_state = vk::DynamicState::default().viewports(vec![viewport]);


### PR DESCRIPTION
Time for v0.10! Here are some of the main changes to look out for:

**Colour Overhaul** #355

The **palette** crate dependency has been updated from v0.2 to v0.4.
Nannou's old named colours (e.g. DARK_BLUE, PURPLE, etc based on the
Tango desktop color selection) have been removed in favour of using the
named colours provided by palette which are much more extensive and
based on the the CSS spec. This means there's a high chance some of your
code or colors might break! In some cases certain colours will be
missing, in other cases the colour may now look different. We've added a
new `named_color_reference.rs` example that should hopefully make it a
little easier to find equivalent colours from the new selection.

Friendlier colour constructors have been added to the prelude, so e.g.
now we can do `rgb(r, g, b)` rather than `Rgb::new(r, g, b)`. The same
goes for `hsl`, `hsv`, etc.

The color constructors that take a continuous hue value as an argument
(e.g. `hsl`, `hsv`) have been simplified so that they now expect the hue
as a normalised value between 0.0 and 1.0.

**View API Tweak** #368

The `view` function used for presenting graphics to the frame for a
window has been changed slightly so that the `Frame` argument is taken
by reference, rather than by value. See #366 for the motivation behind
this change. This should hopefully be an easy fix - check out any of the
updated examples to see how to update your view function signature.

**Audio and OSC Refactor** #331 #334

The `osc` and `audio` modules have been moved into their own
`nannou_osc` and `nannou_audio` crates respectively. This should
hopefully speed up compile times a little for users who are using nannou
purely for graphics/sketches and don't require either. There is very
little difference in terms of usage and if you are using either the
`osc` or `audio` modules breakage should be minimal - you can check out
the osc or audio examples and the linked PRs for a demonstration of how
to update your code.

**NTimes Loop Mode** #353

A new loop mode has been added that allows for looping *n* number of
times before stopping and presenting only the last frame. This should be
useful for users who only wish to render a single frame, or perhaps a
specific number of frames for a fixed length animation.

---

For more information on the other changes included within this release
checkout the CHANGELOG! You can also checkout the commit messages
accompanying each PR for more details on the changes themselves.