### PR TITLE
Use a unique `draw::backend::vulkano::Renderer` per window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add an example that demonstrates using the Draw API with multiple windows.
 - Fix a bug where `Draw::to_frame` would `panic!` when used between multiple
   windows.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Fix a bug where `Draw::to_frame` would `panic!` when used between multiple
+  windows.
+
 # Version 0.10.0 (2019-07-21)
 
 - Change the `view` function signature to take `Frame` by reference rather than

--- a/examples/multi_window_draw.rs
+++ b/examples/multi_window_draw.rs
@@ -1,0 +1,67 @@
+use nannou::prelude::*;
+
+fn main() {
+    nannou::app(model).update(update).view(view).run();
+}
+
+struct Model {
+    a: WindowId,
+    b: WindowId,
+    c: WindowId,
+}
+
+fn model(app: &App) -> Model {
+    let a = app
+        .new_window()
+        .with_title("window a")
+        .event(event_a)
+        .build()
+        .unwrap();
+    let b = app
+        .new_window()
+        .with_title("window b")
+        .event(event_b)
+        .build()
+        .unwrap();
+    let c = app
+        .new_window()
+        .with_title("window c")
+        .event(event_c)
+        .build()
+        .unwrap();
+    Model { a, b, c }
+}
+
+fn update(_app: &App, _model: &mut Model, _update: Update) {}
+
+fn event_a(_app: &App, _model: &mut Model, event: WindowEvent) {
+    println!("window a: {:?}", event);
+}
+
+fn event_b(_app: &App, _model: &mut Model, event: WindowEvent) {
+    println!("window b: {:?}", event);
+}
+
+fn event_c(_app: &App, _model: &mut Model, event: WindowEvent) {
+    println!("window c: {:?}", event);
+}
+
+fn view(app: &App, model: &Model, frame: &Frame) {
+    let draw = app.draw_for_window(frame.window_id()).unwrap();
+    match frame.window_id() {
+        id if id == model.a => {
+            draw.background().color(INDIANRED);
+            draw.ellipse().color(LIGHTGREEN);
+        }
+        id if id == model.b => {
+            draw.background().color(LIGHTGREEN);
+            draw.tri().color(CORNFLOWERBLUE);
+        }
+        id if id == model.c => {
+            draw.background().color(CORNFLOWERBLUE);
+            draw.rect().color(INDIANRED);
+        }
+        _ => (),
+    }
+    draw.to_frame(app, frame).unwrap();
+}

--- a/examples/nature_of_code/chp_01_vectors/1_7_motion101.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_7_motion101.rs
@@ -42,7 +42,7 @@ impl Mover {
         if self.position.y > rect.top() {
             self.position.y = rect.bottom();
         } else if self.position.y < rect.bottom() {
-            self.position.y = rect.top();;
+            self.position.y = rect.top();
         }
     }
 

--- a/examples/nature_of_code/chp_01_vectors/1_8_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_8_motion101_acceleration.rs
@@ -52,7 +52,7 @@ impl Mover {
         if self.position.y > rect.top() {
             self.position.y = rect.bottom();
         } else if self.position.y < rect.bottom() {
-            self.position.y = rect.top();;
+            self.position.y = rect.top();
         }
     }
 

--- a/examples/nature_of_code/chp_01_vectors/1_9_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_9_motion101_acceleration.rs
@@ -54,7 +54,7 @@ impl Mover {
         if self.position.y > rect.top() {
             self.position.y = rect.bottom();
         } else if self.position.y < rect.bottom() {
-            self.position.y = rect.top();;
+            self.position.y = rect.top();
         }
     }
 

--- a/examples/nature_of_code/chp_08_fractals/8_2_recursion.rs
+++ b/examples/nature_of_code/chp_08_fractals/8_2_recursion.rs
@@ -6,7 +6,7 @@
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).run();;
+    nannou::app(model).run();
 }
 
 struct Model;


### PR DESCRIPTION
This solves a `panic!` that would occur when the app's draw renderer
would be re-used between multiple windows.

Closes #376.