### PR TITLE
Use the `notosans` crate to guarantee default font availability.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/nannou-org/nannou.git"
 homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
+[features]
+default = ["notosans"]
+
 [dependencies]
 approx = "0.1"
 cgmath = { version = "0.16", features = ["serde"] }
@@ -21,6 +24,7 @@ find_folder = "0.3"
 image = "0.21"
 lyon = "0.14"
 noise = "0.5"
+notosans = { version = "0.1", optional = true }
 palette = "0.4"
 pennereq = "0.3"
 rand = "0.7"
@@ -31,6 +35,7 @@ toml = "0.4"
 vulkano = "0.13"
 vulkano-win = "0.13"
 vulkano-shaders = "0.13"
+walkdir = "2"
 winit = "0.19"
 
 [dev-dependencies]

--- a/src/io.rs
+++ b/src/io.rs
@@ -150,3 +150,13 @@ where
     let t = toml::from_str(&string)?;
     Ok(t)
 }
+
+/// Attempt to recursively walk the given directory and all its sub-directories.
+///
+/// This function is shorthand for the `walkdir` crate's `WalkDir::new` constructor.
+pub fn walk_dir<P>(path: P) -> walkdir::WalkDir
+where
+    P: AsRef<Path>,
+{
+    walkdir::WalkDir::new(path)
+}


### PR DESCRIPTION
This addresses the #380.

The `notosans` crate is behind a `notosans` feature which is enabled by
default. To disable this dependency (which may help to remove roughly
~800kb of total binary size), use the `--no-default-features` flag. In
the case that the `notosans` feature is disabled, the `Ui` will attempt
to load the first font discovered in `assets/fonts`. If no fonts exist,
an error will be returned.

Closes #380.