### PR TITLE
 Add a `text` module providing various items useful for text layout. Begin work on `draw.text("some text")` API (WIP).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ notosans = { version = "0.1", optional = true }
 palette = "0.4"
 pennereq = "0.3"
 rand = "0.7"
+rusttype = "0.7"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,9 @@ path = "examples/simple_polygon.rs"
 name = "simple_polyline"
 path = "examples/simple_polyline.rs"
 [[example]]
+name = "simple_text_path"
+path = "examples/simple_text_path.rs"
+[[example]]
 name = "simple_ui"
 path = "examples/simple_ui.rs"
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,9 @@ path = "examples/simple_polygon.rs"
 name = "simple_polyline"
 path = "examples/simple_polyline.rs"
 [[example]]
+name = "simple_text"
+path = "examples/simple_text.rs"
+[[example]]
 name = "simple_text_path"
 path = "examples/simple_text_path.rs"
 [[example]]

--- a/examples/simple_text.rs
+++ b/examples/simple_text.rs
@@ -18,11 +18,7 @@ fn view(app: &App, frame: &Frame) {
 
     let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nResize the window to test dynamic layout.";
 
-    draw.text(text)
-        .color(BLACK)
-        .font_size(24)
-        .center_justify()
-        .wh(win_rect.wh());
+    draw.text(text).color(BLACK).font_size(24).wh(win_rect.wh());
 
     draw.to_frame(app, &frame).unwrap();
 }

--- a/examples/simple_text.rs
+++ b/examples/simple_text.rs
@@ -1,0 +1,28 @@
+//! A simple example demonstrating the `draw.text("foo")` API.
+//!
+//! If you're looking for more control over the text path, checkout `simple_text_path.rs`.
+
+use nannou::prelude::*;
+
+fn main() {
+    nannou::sketch(view);
+}
+
+fn view(app: &App, frame: &Frame) {
+    // Begin drawing.
+    let draw = app.draw();
+    draw.background().color(WHITE);
+
+    // We'll align to the window dimensions, but padded slightly.
+    let win_rect = app.main_window().rect().pad(20.0);
+
+    let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nResize the window to test dynamic layout.";
+
+    draw.text(text)
+        .color(BLACK)
+        .font_size(24)
+        .center_justify()
+        .wh(win_rect.wh());
+
+    draw.to_frame(app, &frame).unwrap();
+}

--- a/examples/simple_text_path.rs
+++ b/examples/simple_text_path.rs
@@ -21,10 +21,7 @@ fn view(app: &App, frame: &Frame) {
         .w_h(win_rect.w(), win_rect.top());
 
     // Draw the text.
-    let text = text("create\nwith\nnannou")
-        .font_size(128)
-        .center_justify()
-        .build(win_rect);
+    let text = text("create\nwith\nnannou").font_size(128).build(win_rect);
 
     // Draw rects behind the lines.
     for line_rect in text.line_rects() {

--- a/examples/simple_text_path.rs
+++ b/examples/simple_text_path.rs
@@ -14,7 +14,6 @@ fn view(app: &App, frame: &Frame) {
     let draw = app.draw();
     draw.background().color(WHITE);
 
-
     let win_rect = app.main_window().rect();
     draw.rect()
         .hsla(0.0, 0.0, 0.5, 0.5)
@@ -30,25 +29,26 @@ fn view(app: &App, frame: &Frame) {
     // Draw rects behind the lines.
     for line_rect in text.line_rects() {
         let a = map_range(app.mouse.x, win_rect.left(), win_rect.right(), 0.0, 1.0);
-        draw.rect()
-            .xy(line_rect.xy())
-            .wh(line_rect.wh())
-            .hsla(-line_rect.y() / win_rect.top(), 1.0, 0.5, a);
+        draw.rect().xy(line_rect.xy()).wh(line_rect.wh()).hsla(
+            -line_rect.y() / win_rect.top(),
+            1.0,
+            0.5,
+            a,
+        );
     }
 
     // Draw rects behind the glyphs.
     for (_glyph, rect) in text.glyphs() {
         let a = map_range(app.mouse.y, win_rect.bottom(), win_rect.top(), 0.0, 1.0);
-        draw.rect()
-            .xy(rect.xy())
-            .wh(rect.wh())
-            .hsla((rect.x() + rect.y()) / win_rect.w(), 1.0, 0.5, a);
+        draw.rect().xy(rect.xy()).wh(rect.wh()).hsla(
+            (rect.x() + rect.y()) / win_rect.w(),
+            1.0,
+            0.5,
+            a,
+        );
     }
 
-    draw.path()
-        .fill()
-        .color(BLACK)
-        .events(text.path_events());
+    draw.path().fill().color(BLACK).events(text.path_events());
 
     // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();

--- a/examples/simple_text_path.rs
+++ b/examples/simple_text_path.rs
@@ -25,15 +25,13 @@ fn view(app: &App, frame: &Frame) {
     let text = text("create\nwith\nnannou")
         .font_size(128)
         .center_justify()
-        .build(win_rect.w(), &app.assets_path().unwrap());
-    //let offset = vec2(0.0, 0.0);
-    let offset = text.offset_into_rect(win_rect.left(), win_rect.y, text::Align::Middle);
+        .build(win_rect);
 
     // Draw rects behind the lines.
     for line_rect in text.line_rects() {
         let a = map_range(app.mouse.x, win_rect.left(), win_rect.right(), 0.0, 1.0);
         draw.rect()
-            .xy(line_rect.xy() + offset)
+            .xy(line_rect.xy())
             .wh(line_rect.wh())
             .hsla(-line_rect.y() / win_rect.top(), 1.0, 0.5, a);
     }
@@ -42,7 +40,7 @@ fn view(app: &App, frame: &Frame) {
     for (_glyph, rect) in text.glyphs() {
         let a = map_range(app.mouse.y, win_rect.bottom(), win_rect.top(), 0.0, 1.0);
         draw.rect()
-            .xy(rect.xy() + offset)
+            .xy(rect.xy())
             .wh(rect.wh())
             .hsla((rect.x() + rect.y()) / win_rect.w(), 1.0, 0.5, a);
     }
@@ -50,8 +48,7 @@ fn view(app: &App, frame: &Frame) {
     draw.path()
         .fill()
         .color(BLACK)
-        .events(text.path_events())
-        .xy(offset);
+        .events(text.path_events());
 
     // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();

--- a/examples/simple_text_path.rs
+++ b/examples/simple_text_path.rs
@@ -1,0 +1,58 @@
+//! A simple example demonstrating how to produce path events from text.
+//!
+//! While drawing text via the `Path` API may not be the most efficient approach, it allows for
+//! interesting creative applications.
+
+use nannou::prelude::*;
+
+fn main() {
+    nannou::sketch(view);
+}
+
+fn view(app: &App, frame: &Frame) {
+    // Begin drawing.
+    let draw = app.draw();
+    draw.background().color(WHITE);
+
+
+    let win_rect = app.main_window().rect();
+    draw.rect()
+        .hsla(0.0, 0.0, 0.5, 0.5)
+        .y(win_rect.bottom() * 0.5)
+        .w_h(win_rect.w(), win_rect.top());
+
+    // Draw the text.
+    let text = text("create\nwith\nnannou")
+        .font_size(128)
+        .center_justify()
+        .build(win_rect.w(), &app.assets_path().unwrap());
+    //let offset = vec2(0.0, 0.0);
+    let offset = text.offset_into_rect(win_rect.left(), win_rect.y, text::Align::Middle);
+
+    // Draw rects behind the lines.
+    for line_rect in text.line_rects() {
+        let a = map_range(app.mouse.x, win_rect.left(), win_rect.right(), 0.0, 1.0);
+        draw.rect()
+            .xy(line_rect.xy() + offset)
+            .wh(line_rect.wh())
+            .hsla(-line_rect.y() / win_rect.top(), 1.0, 0.5, a);
+    }
+
+    // Draw rects behind the glyphs.
+    for (_glyph, rect) in text.glyphs() {
+        let a = map_range(app.mouse.y, win_rect.bottom(), win_rect.top(), 0.0, 1.0);
+        draw.rect()
+            .xy(rect.xy() + offset)
+            .wh(rect.wh())
+            .hsla((rect.x() + rect.y()) / win_rect.w(), 1.0, 0.5, a);
+    }
+
+    draw.path()
+        .fill()
+        .color(BLACK)
+        .events(text.path_events())
+        .xy(offset);
+
+    // Write the result of our drawing to the window's frame.
+    draw.to_frame(app, &frame).unwrap();
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -849,13 +849,7 @@ impl App {
     /// 2. Recursively checks exe's parent directories (to a max depth of 5).
     /// 3. Recursively checks exe's children directories (to a max depth of 3).
     pub fn assets_path(&self) -> Result<PathBuf, find_folder::Error> {
-        let exe_path = std::env::current_exe()?;
-        find_folder::Search::ParentsThenKids(5, 3)
-            .of(exe_path
-                .parent()
-                .expect("executable has no parent directory to search")
-                .into())
-            .for_folder(Self::ASSETS_DIRECTORY_NAME)
+        find_assets_path()
     }
 
     /// Begin building a new window.
@@ -1119,6 +1113,17 @@ impl<'a> DerefMut for Draw<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.draw
     }
+}
+
+/// Attempt to find the assets directory path relative to the executable location.
+pub fn find_assets_path() -> Result<PathBuf, find_folder::Error> {
+    let exe_path = std::env::current_exe()?;
+    find_folder::Search::ParentsThenKids(5, 3)
+        .of(exe_path
+            .parent()
+            .expect("executable has no parent directory to search")
+            .into())
+        .for_folder(App::ASSETS_DIRECTORY_NAME)
 }
 
 /// Find a compatible depth format for the `App`'s `Draw` API.

--- a/src/draw/backend/vulkano.rs
+++ b/src/draw/backend/vulkano.rs
@@ -3,6 +3,7 @@
 use crate::draw;
 use crate::frame::{Frame, ViewFbo};
 use crate::math::{BaseFloat, NumCast};
+use crate::text;
 use crate::vk::{self, DeviceOwned, DynamicStateBuilder, GpuFuture, RenderPassDesc};
 use std::error::Error as StdError;
 use std::fmt;
@@ -14,7 +15,54 @@ pub struct Renderer {
     graphics_pipeline: Arc<dyn vk::GraphicsPipelineAbstract + Send + Sync>,
     vertices: Vec<Vertex>,
     render_pass_images: Option<RenderPassImages>,
+    glyph_cache: GlyphCache,
     view_fbo: ViewFbo,
+}
+
+/// Cache for all glyphs.
+pub struct GlyphCache {
+    cache: text::GlyphCache<'static>,
+    cpu_buffer_pool: Arc<vk::CpuBufferPool<u8>>,
+    image: Arc<vk::StorageImage<vk::format::R8Unorm>>,
+    pixel_buffer: Vec<u8>,
+}
+
+impl GlyphCache {
+    /// Construct a glyph cache with the given dimensions.
+    pub fn with_dimensions(
+        queue: Arc<vk::Queue>,
+        dims: [u32; 2],
+    ) -> Result<Self, vk::ImageCreationError> {
+        const SCALE_TOLERANCE: f32 = 0.1;
+        const POSITION_TOLERANCE: f32 = 0.1;
+        let [width, height] = dims;
+        let cache = text::GlyphCache::builder()
+            .dimensions(width, height)
+            .scale_tolerance(SCALE_TOLERANCE)
+            .position_tolerance(POSITION_TOLERANCE)
+            .build();
+        let device = queue.device().clone();
+        let image = vk::StorageImage::with_usage(
+            device.clone(),
+            vk::image::Dimensions::Dim2d { width, height },
+            vk::format::R8Unorm,
+            vk::ImageUsage {
+                transfer_destination: true,
+                sampled: true,
+                ..vk::ImageUsage::none()
+            },
+            Some(queue.family()),
+        )?;
+        let cpu_buffer_pool = Arc::new(vk::CpuBufferPool::upload(device));
+        let pixel_buffer = vec![0u8; width as usize * height as usize];
+        let glyph_cache = GlyphCache {
+            cache,
+            cpu_buffer_pool,
+            image,
+            pixel_buffer,
+        };
+        Ok(glyph_cache)
+    }
 }
 
 /// The `Vertex` type passed to the vertex shader.
@@ -63,6 +111,7 @@ struct RenderPassImages {
 pub enum RendererCreationError {
     RenderPass(vk::RenderPassCreationError),
     GraphicsPipeline(GraphicsPipelineError),
+    ImageCreation(vk::ImageCreationError),
 }
 
 /// Errors that might occur while building the **vk::GraphicsPipeline**.
@@ -206,12 +255,14 @@ impl Renderer {
     ///
     /// This creates the `RenderPass` and `vk::GraphicsPipeline` ready for drawing.
     pub fn new(
-        device: Arc<vk::Device>,
+        queue: Arc<vk::Queue>,
         color_format: vk::Format,
         depth_format: vk::Format,
         msaa_samples: u32,
+        glyph_cache_dims: [u32; 2],
     ) -> Result<Self, RendererCreationError> {
         let load_op = vk::LoadOp::Load;
+        let device = queue.device().clone();
         let render_pass = Arc::new(create_render_pass(
             device,
             color_format,
@@ -224,12 +275,14 @@ impl Renderer {
         let vertices = vec![];
         let render_pass_images = None;
         let view_fbo = ViewFbo::default();
+        let glyph_cache = GlyphCache::with_dimensions(queue, glyph_cache_dims)?;
         Ok(Renderer {
             render_pass,
             graphics_pipeline,
             vertices,
             render_pass_images,
             view_fbo,
+            glyph_cache,
         })
     }
 
@@ -252,6 +305,7 @@ impl Renderer {
             ref mut vertices,
             ref mut render_pass_images,
             ref mut view_fbo,
+            ref mut glyph_cache,
         } = *self;
 
         // Retrieve the color/depth image load op and clear values based on the bg color.
@@ -493,6 +547,12 @@ impl From<GraphicsPipelineError> for RendererCreationError {
     }
 }
 
+impl From<vk::ImageCreationError> for RendererCreationError {
+    fn from(err: vk::ImageCreationError) -> Self {
+        RendererCreationError::ImageCreation(err)
+    }
+}
+
 impl From<vk::GraphicsPipelineCreationError> for GraphicsPipelineError {
     fn from(err: vk::GraphicsPipelineCreationError) -> Self {
         GraphicsPipelineError::Creation(err)
@@ -546,6 +606,7 @@ impl StdError for RendererCreationError {
         match *self {
             RendererCreationError::RenderPass(ref err) => err.description(),
             RendererCreationError::GraphicsPipeline(ref err) => err.description(),
+            RendererCreationError::ImageCreation(ref err) => err.description(),
         }
     }
 }

--- a/src/draw/drawing.rs
+++ b/src/draw/drawing.rs
@@ -51,6 +51,8 @@ pub struct DrawingContext<'a, S> {
     pub fill_tessellator: &'a mut FillTessellator,
     /// A re-usable buffer for collecting path events.
     pub path_event_buffer: &'a mut Vec<PathEvent>,
+    /// A re-usable buffer for collecting text.
+    pub text_buffer: &'a mut String,
 }
 
 /// Construct a new **Drawing** instance.
@@ -151,13 +153,18 @@ where
         if let Ok(mut state) = self.draw.state.try_borrow_mut() {
             if let Some(mut primitive) = state.drawing.remove(&self.index) {
                 {
-                    let mut intermediary_mesh = state.intermediary_mesh.borrow_mut();
-                    let mut fill_tessellator = state.fill_tessellator.borrow_mut();
-                    let mut path_event_buffer = state.path_event_buffer.borrow_mut();
+                    let mut intermediary_state = state.intermediary_state.borrow_mut();
+                    let super::IntermediaryState {
+                        ref mut intermediary_mesh,
+                        ref mut fill_tessellator,
+                        ref mut path_event_buffer,
+                        ref mut text_buffer,
+                    } = *intermediary_state;
                     let ctxt = DrawingContext {
-                        mesh: &mut *intermediary_mesh,
+                        mesh: intermediary_mesh,
                         fill_tessellator: &mut fill_tessellator.0,
-                        path_event_buffer: &mut *path_event_buffer,
+                        path_event_buffer: path_event_buffer,
+                        text_buffer: text_buffer,
                     };
                     primitive = map(primitive, ctxt);
                 }

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -384,6 +384,7 @@ where
         Primitive::Polygon(prim) => into_drawn(draw, node_index, prim),
         Primitive::Quad(prim) => into_drawn(draw, node_index, prim),
         Primitive::Rect(prim) => into_drawn(draw, node_index, prim),
+        Primitive::Text(prim) => unimplemented!(),
         Primitive::Tri(prim) => into_drawn(draw, node_index, prim),
 
         Primitive::MeshVertexless(_)

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -4,6 +4,7 @@
 use crate::geom::graph::{edge, node};
 use crate::geom::{self, Vector3};
 use crate::math::BaseFloat;
+use crate::text;
 use lyon::path::PathEvent;
 use lyon::tessellation::FillTessellator;
 use std::cell::{Ref, RefCell};
@@ -95,6 +96,17 @@ where
     /// If `Some`, the **Draw** should first clear the frame's gl context with the given color.
     background_color: Option<properties::LinSrgba>,
 }
+
+// /// The CPU half of the glyph cache used for caching text.
+// #[derive(Clone, Debug)]
+// pub struct GlyphCache {
+//     /// Manages the caching process.
+//     cache: text::GlyphCache<'static>,
+//     /// The buffer used for storing pixel data to be written to the GPU.
+//     pixel_buffer: Vec<u8>,
+//     /// Whether or not the glyph cache has been updated and needs to be written to an image.
+//     has_updated: bool,
+// }
 
 /// State made accessible via the `DrawingContext`.
 #[derive(Clone, Debug)]

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -738,10 +738,7 @@ impl ops::Deref for GlyphCacheWrapper {
 impl Default for GlyphCache {
     fn default() -> Self {
         let (w, h) = GlyphCache::DEFAULT_DIMENSIONS;
-        let cache = text::GlyphCache::builder()
-            .dimensions(w, h)
-            .build()
-            .into();
+        let cache = text::GlyphCache::builder().dimensions(w, h).build().into();
         let pixel_buffer = vec![0u8; w as usize * h as usize];
         let has_updated = false;
         GlyphCache {

--- a/src/draw/primitive/mod.rs
+++ b/src/draw/primitive/mod.rs
@@ -5,6 +5,7 @@ pub mod path;
 pub mod polygon;
 pub mod quad;
 pub mod rect;
+pub mod text;
 pub mod tri;
 
 use crate::geom;
@@ -16,6 +17,7 @@ pub use self::path::{Path, PathFill, PathInit, PathStroke};
 pub use self::polygon::{Polygon, PolygonInit};
 pub use self::quad::Quad;
 pub use self::rect::Rect;
+pub use self::text::Text;
 pub use self::tri::Tri;
 
 /// A wrapper around all primitive sets of properties so that they may be stored within the
@@ -37,5 +39,6 @@ pub enum Primitive<S = geom::scalar::Default> {
     Polygon(Polygon<S>),
     Quad(Quad<S>),
     Rect(Rect<S>),
+    Text(Text<S>),
     Tri(Tri<S>),
 }

--- a/src/draw/primitive/polygon.rs
+++ b/src/draw/primitive/polygon.rs
@@ -106,6 +106,7 @@ impl<S> PolygonInit<S> {
             mesh,
             fill_tessellator,
             path_event_buffer,
+            ..
         } = ctxt;
 
         path_event_buffer.clear();

--- a/src/draw/primitive/text.rs
+++ b/src/draw/primitive/text.rs
@@ -7,7 +7,7 @@ use crate::draw::properties::{
 use crate::draw::{theme, Drawing};
 use crate::geom;
 use crate::math::BaseFloat;
-use crate::text;
+use crate::text::{self, Align, Font, FontSize, Justify, Layout, Scalar, Wrap};
 
 /// Properties related to drawing the **Text** primitive.
 #[derive(Clone, Debug)]
@@ -22,28 +22,11 @@ pub struct Text<S = geom::scalar::Default> {
 #[derive(Clone, Debug, Default)]
 pub struct Style {
     pub color: Option<LinSrgba>,
-    pub line_spacing: Option<text::Scalar>,
-    pub maybe_wrap: Option<Option<Wrap>>,
-    pub font_size: Option<text::FontSize>,
-    pub justify: Option<text::Justify>,
-    pub font_id: Option<Option<text::font::Id>>,
-}
-
-/// The way in which text should wrap around the width.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum Wrap {
-    /// Wrap at the first character that exceeds the width.
-    Character,
-    /// Wrap at the first word that exceeds the width.
-    Whitespace,
+    pub layout: text::layout::Builder,
 }
 
 /// The drawing context for the **Text** primitive.
 pub type DrawingText<'a, S = geom::scalar::Default> = Drawing<'a, Text<S>, S>;
-
-pub const DEFAULT_WRAP: Option<Wrap> = Some(Wrap::Whitespace);
-pub const DEFAULT_FONT_SIZE: u32 = 12;
-pub const DEFAULT_LINE_SPACING: f32 = 1.0;
 
 impl<S> Text<S> {
     /// Begin drawing some text.
@@ -61,66 +44,108 @@ impl<S> Text<S> {
         }
     }
 
-    /// The font size to use for the text.
-    pub fn font_size(mut self, size: text::FontSize) -> Self {
-        self.style.font_size = Some(size);
+    // Apply the given function to the inner text layout.
+    fn map_layout<F>(mut self, map: F) -> Self
+    where
+        F: FnOnce(text::layout::Builder) -> text::layout::Builder,
+    {
+        self.style.layout = map(self.style.layout);
         self
+    }
+
+    /// The font size to use for the text.
+    pub fn font_size(self, size: FontSize) -> Self {
+        self.map_layout(|l| l.font_size(size))
+    }
+
+    /// Specify whether or not text should be wrapped around some width and how to do so.
+    ///
+    /// The default value is `DEFAULT_LINE_WRAP`.
+    pub fn line_wrap(self, line_wrap: Option<Wrap>) -> Self {
+        self.map_layout(|l| l.line_wrap(line_wrap))
     }
 
     /// Specify that the **Text** should not wrap lines around the width.
-    pub fn no_line_wrap(mut self) -> Self {
-        self.style.maybe_wrap = Some(None);
-        self
+    ///
+    /// Shorthand for `builder.line_wrap(None)`.
+    pub fn no_line_wrap(self) -> Self {
+        self.map_layout(|l| l.no_line_wrap())
     }
 
     /// Line wrap the **Text** at the beginning of the first word that exceeds the width.
-    pub fn wrap_by_word(mut self) -> Self {
-        self.style.maybe_wrap = Some(Some(Wrap::Whitespace));
-        self
+    ///
+    /// Shorthand for `builder.line_wrap(Some(Wrap::Whitespace))`.
+    pub fn wrap_by_word(self) -> Self {
+        self.map_layout(|l| l.wrap_by_word())
     }
 
     /// Line wrap the **Text** at the beginning of the first character that exceeds the width.
-    pub fn wrap_by_character(mut self) -> Self {
-        self.style.maybe_wrap = Some(Some(Wrap::Character));
-        self
+    ///
+    /// Shorthand for `builder.line_wrap(Some(Wrap::Character))`.
+    pub fn wrap_by_character(self) -> Self {
+        self.map_layout(|l| l.wrap_by_character())
     }
 
     /// A method for specifying the `Font` used for displaying the `Text`.
-    pub fn font_id(mut self, font_id: text::font::Id) -> Self {
-        self.style.font_id = Some(Some(font_id));
-        self
-    }
-
-    /// Build the **Text** with the given **Style**.
-    pub fn with_style(mut self, style: Style) -> Self {
-        self.style = style;
-        self
+    pub fn font(self, font: Font) -> Self {
+        self.map_layout(|l| l.font(font))
     }
 
     /// Describe the end along the *x* axis to which the text should be aligned.
-    pub fn justify(mut self, justify: text::Justify) -> Self {
-        self.style.justify = Some(justify);
-        self
+    pub fn justify(self, justify: Justify) -> Self {
+        self.map_layout(|l| l.justify(justify))
     }
 
     /// Align the text to the left of its bounding **Rect**'s *x* axis range.
     pub fn left_justify(self) -> Self {
-        self.justify(text::Justify::Left)
+        self.map_layout(|l| l.left_justify())
     }
 
     /// Align the text to the middle of its bounding **Rect**'s *x* axis range.
     pub fn center_justify(self) -> Self {
-        self.justify(text::Justify::Center)
+        self.map_layout(|l| l.center_justify())
     }
 
     /// Align the text to the right of its bounding **Rect**'s *x* axis range.
     pub fn right_justify(self) -> Self {
-        self.justify(text::Justify::Right)
+        self.map_layout(|l| l.right_justify())
     }
 
     /// Specify how much vertical space should separate each line of text.
-    pub fn line_spacing(mut self, spacing: text::Scalar) -> Self {
-        self.style.line_spacing = Some(spacing);
+    pub fn line_spacing(self, spacing: Scalar) -> Self {
+        self.map_layout(|l| l.line_spacing(spacing))
+    }
+
+    /// Specify how the whole text should be aligned along the y axis of its bounding rectangle
+    pub fn y_align(self, align: Align) -> Self {
+        self.map_layout(|l| l.y_align(align))
+    }
+
+    /// Align the top edge of the text with the top edge of its bounding rectangle.
+    pub fn align_top(self) -> Self {
+        self.map_layout(|l| l.align_top())
+    }
+
+    /// Align the middle of the text with the middle of the bounding rect along the y axis..
+    ///
+    /// This is the default behaviour.
+    pub fn align_middle_y(self) -> Self {
+        self.map_layout(|l| l.align_middle_y())
+    }
+
+    /// Align the bottom edge of the text with the bottom edge of its bounding rectangle.
+    pub fn align_bottom(self) -> Self {
+        self.map_layout(|l| l.align_bottom())
+    }
+
+    /// Set all the parameters via an existing `Layout`
+    pub fn layout(self, layout: &Layout) -> Self {
+        self.map_layout(|l| l.layout(layout))
+    }
+
+    /// Specify the entire styling for the **Text**.
+    pub fn with_style(mut self, style: Style) -> Self {
+        self.style = style;
         self
     }
 }
@@ -150,8 +175,8 @@ where
     }
 
     /// A method for specifying the `Font` used for displaying the `Text`.
-    pub fn font_id(self, font_id: text::font::Id) -> Self {
-        self.map_ty(|ty| ty.font_id(font_id))
+    pub fn font(self, font: text::Font) -> Self {
+        self.map_ty(|ty| ty.font(font))
     }
 
     /// Build the **Text** with the given **Style**.
@@ -182,6 +207,33 @@ where
     /// Specify how much vertical space should separate each line of text.
     pub fn line_spacing(self, spacing: text::Scalar) -> Self {
         self.map_ty(|ty| ty.line_spacing(spacing))
+    }
+
+    /// Specify how the whole text should be aligned along the y axis of its bounding rectangle
+    pub fn y_align_text(self, align: Align) -> Self {
+        self.map_ty(|ty| ty.y_align(align))
+    }
+
+    /// Align the top edge of the text with the top edge of its bounding rectangle.
+    pub fn align_text_top(self) -> Self {
+        self.map_ty(|ty| ty.align_top())
+    }
+
+    /// Align the middle of the text with the middle of the bounding rect along the y axis..
+    ///
+    /// This is the default behaviour.
+    pub fn align_text_middle_y(self) -> Self {
+        self.map_ty(|ty| ty.align_middle_y())
+    }
+
+    /// Align the bottom edge of the text with the bottom edge of its bounding rectangle.
+    pub fn align_text_bottom(self) -> Self {
+        self.map_ty(|ty| ty.align_bottom())
+    }
+
+    /// Set all the parameters via an existing `Layout`
+    pub fn layout(self, layout: &Layout) -> Self {
+        self.map_ty(|ty| ty.layout(layout))
     }
 }
 

--- a/src/draw/primitive/text.rs
+++ b/src/draw/primitive/text.rs
@@ -1,3 +1,4 @@
+use crate::draw::drawing::DrawingContext;
 use crate::draw::primitive::Primitive;
 use crate::draw::properties::spatial::{self, dimension, orientation, position};
 use crate::draw::properties::{
@@ -21,7 +22,7 @@ pub struct Text<S = geom::scalar::Default> {
 pub type DrawingText<'a, S = geom::scalar::Default> = Drawing<'a, Text<S>, S>;
 
 /// Styling properties for the **Text** primitive.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Style {
     pub color: Option<LinSrgba>,
     pub line_spacing: Option<text::Scalar>,
@@ -41,6 +42,21 @@ pub enum Wrap {
 }
 
 impl<S> Text<S> {
+    /// Begin drawing some text.
+    pub fn new(ctxt: DrawingContext<S>, text: &str) -> Self {
+        let start = ctxt.text_buffer.len();
+        ctxt.text_buffer.push_str(text);
+        let end = ctxt.text_buffer.len();
+        let text = start..end;
+        let spatial = Default::default();
+        let style = Default::default();
+        Text {
+            spatial,
+            style,
+            text,
+        }
+    }
+
     /// The font size to use for the text.
     pub fn font_size(mut self, size: text::FontSize) -> Self {
         self.style.font_size = Some(size);

--- a/src/draw/primitive/text.rs
+++ b/src/draw/primitive/text.rs
@@ -18,9 +18,6 @@ pub struct Text<S = geom::scalar::Default> {
     text: std::ops::Range<usize>,
 }
 
-/// The drawing context for the **Text** primitive.
-pub type DrawingText<'a, S = geom::scalar::Default> = Drawing<'a, Text<S>, S>;
-
 /// Styling properties for the **Text** primitive.
 #[derive(Clone, Debug, Default)]
 pub struct Style {
@@ -40,6 +37,13 @@ pub enum Wrap {
     /// Wrap at the first word that exceeds the width.
     Whitespace,
 }
+
+/// The drawing context for the **Text** primitive.
+pub type DrawingText<'a, S = geom::scalar::Default> = Drawing<'a, Text<S>, S>;
+
+pub const DEFAULT_WRAP: Option<Wrap> = Some(Wrap::Whitespace);
+pub const DEFAULT_FONT_SIZE: u32 = 12;
+pub const DEFAULT_LINE_SPACING: f32 = 1.0;
 
 impl<S> Text<S> {
     /// Begin drawing some text.
@@ -180,6 +184,90 @@ where
         self.map_ty(|ty| ty.line_spacing(spacing))
     }
 }
+
+// impl<S> IntoDrawn<S> for Text<S>
+// where
+//     S: BaseFloat,
+// {
+//     type Vertices = draw::properties::VerticesFromRanges;
+//     type Indices = draw::properties::IndicesFromRange;
+//     fn into_drawn(self, draw: Draw<S>) -> Drawn<S, Self::Vertices, Self::Indices> {
+//         let Text {
+//             spatial,
+//             style,
+//             text,
+//         } = self;
+//
+//         let maybe_wrap = style.maybe_wrap.unwrap_or(DEFAULT_WRAP);
+//         let font_size = style.font_size(DEFAULT_FONT_SIZE);
+//
+//         let font = match style.font_id(&ui.theme)
+//             .or(ui.fonts.ids().next())
+//             .and_then(|id| ui.fonts.get(id))
+//         {
+//             Some(font) => font,
+//             None => return,
+//         };
+//
+//         // Produces an iterator yielding info for each line within the `text`.
+//         let line_infos = || match maybe_wrap {
+//             None =>
+//                 text::line::infos(text, font, font_size),
+//             Some(Wrap::Character) =>
+//                 text::line::infos(text, font, font_size).wrap_by_character(rect.w()),
+//             Some(Wrap::Whitespace) =>
+//                 text::line::infos(text, font, font_size).wrap_by_whitespace(rect.w()),
+//         };
+//
+//         // If the string is different, we must update both the string and the line breaks.
+//         if &state.string[..] != text {
+//             state.update(|state| {
+//                 state.string = text.to_owned();
+//                 state.line_infos = new_line_infos().collect();
+//             });
+//
+//         // Otherwise, we'll check to see if we have to update the line breaks.
+//         } else {
+//             use utils::write_if_different;
+//             use std::borrow::Cow;
+//
+//             // Compare the line_infos and only collect the new ones if they are different.
+//             let maybe_new_line_infos = {
+//                 let line_infos = &state.line_infos[..];
+//                 match write_if_different(line_infos, new_line_infos()) {
+//                     Cow::Owned(new) => Some(new),
+//                     _ => None,
+//                 }
+//             };
+//
+//             if let Some(new_line_infos) = maybe_new_line_infos {
+//                 state.update(|state| state.line_infos = new_line_infos);
+//             }
+//         }
+//
+//
+//
+//         // 1. Retrieve text slice from intermediary text buffer.
+//         // 2. Insert a rect for every glyph into the mesh while updating glyph cache pixel buffer.
+//         // 3.
+//
+//         let dimensions = spatial::dimension::Properties::default();
+//         let spatial = spatial::Properties {
+//             dimensions,
+//             orientation,
+//             position,
+//         };
+//         let color = color.or_else(|| {
+//             if vertex_data_ranges.colors.len() >= vertex_data_ranges.points.len() {
+//                 return None;
+//             }
+//             Some(draw.theme().fill_lin_srgba(&draw::theme::Primitive::Path))
+//         });
+//         let vertices = draw::properties::VerticesFromRanges::new(vertex_data_ranges, color);
+//         let indices = draw::properties::IndicesFromRange::new(index_range, min_index);
+//         (spatial, vertices, indices)
+//     }
+// }
 
 impl<S> SetOrientation<S> for Text<S> {
     fn properties(&mut self) -> &mut orientation::Properties<S> {

--- a/src/draw/primitive/text.rs
+++ b/src/draw/primitive/text.rs
@@ -244,13 +244,24 @@ where
     type Vertices = draw::properties::VerticesFromRanges;
     type Indices = draw::properties::IndicesFromRange;
     fn into_drawn(self, mut draw: Draw<S>) -> Drawn<S, Self::Vertices, Self::Indices> {
-        let Text { spatial, style, text } = self;
+        let Text {
+            spatial,
+            style,
+            text,
+        } = self;
         let Style { color, layout } = style;
         let layout = layout.build();
         let (maybe_x, maybe_y, maybe_z) = spatial.dimensions.to_scalars(&draw);
-        assert!(maybe_z.is_none(), "z dimension support for text is unimplemented");
-        let w = maybe_x.map(|s| <f32 as crate::math::NumCast>::from(s).unwrap()).unwrap_or(200.0);
-        let h = maybe_y.map(|s| <f32 as crate::math::NumCast>::from(s).unwrap()).unwrap_or(200.0);
+        assert!(
+            maybe_z.is_none(),
+            "z dimension support for text is unimplemented"
+        );
+        let w = maybe_x
+            .map(|s| <f32 as crate::math::NumCast>::from(s).unwrap())
+            .unwrap_or(200.0);
+        let h = maybe_y
+            .map(|s| <f32 as crate::math::NumCast>::from(s).unwrap())
+            .unwrap_or(200.0);
         let rect: geom::Rect = geom::Rect::from_wh(Vector2 { x: w, y: h });
         let color = color.unwrap_or_else(|| draw.theme().fill_lin_srgba(&theme::Primitive::Text));
         let path = draw.drawing_context(|ctxt| {
@@ -282,9 +293,7 @@ where
                 glyph_cache,
                 text_buffer: &mut empty_text,
             };
-            let path = path.fill()
-                .color(color)
-                .events(ctxt, text.path_events());
+            let path = path.fill().color(color).events(ctxt, text.path_events());
             path
         });
         path.into_drawn(draw)

--- a/src/draw/primitive/text.rs
+++ b/src/draw/primitive/text.rs
@@ -1,0 +1,207 @@
+use crate::draw::primitive::Primitive;
+use crate::draw::properties::spatial::{self, dimension, orientation, position};
+use crate::draw::properties::{
+    ColorScalar, LinSrgba, SetColor, SetDimensions, SetOrientation, SetPosition,
+};
+use crate::draw::{theme, Drawing};
+use crate::geom;
+use crate::math::BaseFloat;
+use crate::text;
+
+/// Properties related to drawing the **Text** primitive.
+#[derive(Clone, Debug)]
+pub struct Text<S = geom::scalar::Default> {
+    spatial: spatial::Properties<S>,
+    style: Style,
+    // The byte range into the `Draw` context's text buffer.
+    text: std::ops::Range<usize>,
+}
+
+/// The drawing context for the **Text** primitive.
+pub type DrawingText<'a, S = geom::scalar::Default> = Drawing<'a, Text<S>, S>;
+
+/// Styling properties for the **Text** primitive.
+#[derive(Clone, Debug)]
+pub struct Style {
+    pub color: Option<LinSrgba>,
+    pub line_spacing: Option<text::Scalar>,
+    pub maybe_wrap: Option<Option<Wrap>>,
+    pub font_size: Option<text::FontSize>,
+    pub justify: Option<text::Justify>,
+    pub font_id: Option<Option<text::font::Id>>,
+}
+
+/// The way in which text should wrap around the width.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Wrap {
+    /// Wrap at the first character that exceeds the width.
+    Character,
+    /// Wrap at the first word that exceeds the width.
+    Whitespace,
+}
+
+impl<S> Text<S> {
+    /// The font size to use for the text.
+    pub fn font_size(mut self, size: text::FontSize) -> Self {
+        self.style.font_size = Some(size);
+        self
+    }
+
+    /// Specify that the **Text** should not wrap lines around the width.
+    pub fn no_line_wrap(mut self) -> Self {
+        self.style.maybe_wrap = Some(None);
+        self
+    }
+
+    /// Line wrap the **Text** at the beginning of the first word that exceeds the width.
+    pub fn wrap_by_word(mut self) -> Self {
+        self.style.maybe_wrap = Some(Some(Wrap::Whitespace));
+        self
+    }
+
+    /// Line wrap the **Text** at the beginning of the first character that exceeds the width.
+    pub fn wrap_by_character(mut self) -> Self {
+        self.style.maybe_wrap = Some(Some(Wrap::Character));
+        self
+    }
+
+    /// A method for specifying the `Font` used for displaying the `Text`.
+    pub fn font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.font_id = Some(Some(font_id));
+        self
+    }
+
+    /// Build the **Text** with the given **Style**.
+    pub fn with_style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Describe the end along the *x* axis to which the text should be aligned.
+    pub fn justify(mut self, justify: text::Justify) -> Self {
+        self.style.justify = Some(justify);
+        self
+    }
+
+    /// Align the text to the left of its bounding **Rect**'s *x* axis range.
+    pub fn left_justify(self) -> Self {
+        self.justify(text::Justify::Left)
+    }
+
+    /// Align the text to the middle of its bounding **Rect**'s *x* axis range.
+    pub fn center_justify(self) -> Self {
+        self.justify(text::Justify::Center)
+    }
+
+    /// Align the text to the right of its bounding **Rect**'s *x* axis range.
+    pub fn right_justify(self) -> Self {
+        self.justify(text::Justify::Right)
+    }
+
+    /// Specify how much vertical space should separate each line of text.
+    pub fn line_spacing(mut self, spacing: text::Scalar) -> Self {
+        self.style.line_spacing = Some(spacing);
+        self
+    }
+}
+
+impl<'a, S> DrawingText<'a, S>
+where
+    S: BaseFloat,
+{
+    /// The font size to use for the text.
+    pub fn font_size(self, size: text::FontSize) -> Self {
+        self.map_ty(|ty| ty.font_size(size))
+    }
+
+    /// Specify that the **Text** should not wrap lines around the width.
+    pub fn no_line_wrap(self) -> Self {
+        self.map_ty(|ty| ty.no_line_wrap())
+    }
+
+    /// Line wrap the **Text** at the beginning of the first word that exceeds the width.
+    pub fn wrap_by_word(self) -> Self {
+        self.map_ty(|ty| ty.wrap_by_word())
+    }
+
+    /// Line wrap the **Text** at the beginning of the first character that exceeds the width.
+    pub fn wrap_by_character(self) -> Self {
+        self.map_ty(|ty| ty.wrap_by_character())
+    }
+
+    /// A method for specifying the `Font` used for displaying the `Text`.
+    pub fn font_id(self, font_id: text::font::Id) -> Self {
+        self.map_ty(|ty| ty.font_id(font_id))
+    }
+
+    /// Build the **Text** with the given **Style**.
+    pub fn with_style(self, style: Style) -> Self {
+        self.map_ty(|ty| ty.with_style(style))
+    }
+
+    /// Describe the end along the *x* axis to which the text should be aligned.
+    pub fn justify(self, justify: text::Justify) -> Self {
+        self.map_ty(|ty| ty.justify(justify))
+    }
+
+    /// Align the text to the left of its bounding **Rect**'s *x* axis range.
+    pub fn left_justify(self) -> Self {
+        self.map_ty(|ty| ty.left_justify())
+    }
+
+    /// Align the text to the middle of its bounding **Rect**'s *x* axis range.
+    pub fn center_justify(self) -> Self {
+        self.map_ty(|ty| ty.center_justify())
+    }
+
+    /// Align the text to the right of its bounding **Rect**'s *x* axis range.
+    pub fn right_justify(self) -> Self {
+        self.map_ty(|ty| ty.right_justify())
+    }
+
+    /// Specify how much vertical space should separate each line of text.
+    pub fn line_spacing(self, spacing: text::Scalar) -> Self {
+        self.map_ty(|ty| ty.line_spacing(spacing))
+    }
+}
+
+impl<S> SetOrientation<S> for Text<S> {
+    fn properties(&mut self) -> &mut orientation::Properties<S> {
+        SetOrientation::properties(&mut self.spatial)
+    }
+}
+
+impl<S> SetPosition<S> for Text<S> {
+    fn properties(&mut self) -> &mut position::Properties<S> {
+        SetPosition::properties(&mut self.spatial)
+    }
+}
+
+impl<S> SetDimensions<S> for Text<S> {
+    fn properties(&mut self) -> &mut dimension::Properties<S> {
+        SetDimensions::properties(&mut self.spatial)
+    }
+}
+
+impl<S> SetColor<ColorScalar> for Text<S> {
+    fn rgba_mut(&mut self) -> &mut Option<LinSrgba> {
+        SetColor::rgba_mut(&mut self.style.color)
+    }
+}
+
+// Primitive conversions.
+
+impl<S> From<Text<S>> for Primitive<S> {
+    fn from(prim: Text<S>) -> Self {
+        Primitive::Text(prim)
+    }
+}
+
+impl<S> Into<Option<Text<S>>> for Primitive<S> {
+    fn into(self) -> Option<Text<S>> {
+        match self {
+            Primitive::Text(prim) => Some(prim),
+            _ => None,
+        }
+    }
+}

--- a/src/draw/properties/mod.rs
+++ b/src/draw/properties/mod.rs
@@ -166,12 +166,14 @@ where
             ref mut fill_tessellator,
             ref mut path_event_buffer,
             ref mut text_buffer,
+            ref mut glyph_cache,
         } = *intermediary_state;
         f(DrawingContext {
             mesh: intermediary_mesh,
             fill_tessellator: &mut fill_tessellator.0,
             path_event_buffer: path_event_buffer,
             text_buffer: text_buffer,
+            glyph_cache: glyph_cache,
         })
     }
 }

--- a/src/draw/properties/mod.rs
+++ b/src/draw/properties/mod.rs
@@ -160,13 +160,18 @@ where
         F: FnOnce(DrawingContext<S>) -> T,
     {
         let state = self.state.borrow_mut();
-        let mut mesh = state.intermediary_mesh.borrow_mut();
-        let mut fill = state.fill_tessellator.borrow_mut();
-        let mut path_event_buffer = state.path_event_buffer.borrow_mut();
+        let mut intermediary_state = state.intermediary_state.borrow_mut();
+        let super::IntermediaryState {
+            ref mut intermediary_mesh,
+            ref mut fill_tessellator,
+            ref mut path_event_buffer,
+            ref mut text_buffer,
+        } = *intermediary_state;
         f(DrawingContext {
-            mesh: &mut *mesh,
-            fill_tessellator: &mut fill.0,
-            path_event_buffer: &mut *path_event_buffer,
+            mesh: intermediary_mesh,
+            fill_tessellator: &mut fill_tessellator.0,
+            path_event_buffer: path_event_buffer,
+            text_buffer: text_buffer,
         })
     }
 }

--- a/src/draw/theme.rs
+++ b/src/draw/theme.rs
@@ -30,6 +30,7 @@ pub enum Primitive {
     Polygon,
     Quad,
     Rect,
+    Text,
     Tri,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod noise;
 pub mod prelude;
 pub mod rand;
 pub mod state;
+pub mod text;
 pub mod time;
 pub mod ui;
 pub mod vk;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,6 +21,7 @@ pub use crate::math::{
     turns_to_rad,
 };
 pub use crate::rand::{random, random_f32, random_f64, random_range};
+pub use crate::text::{self, text};
 pub use crate::time::DurationF64;
 pub use crate::ui;
 pub use crate::vk::{self, DeviceOwned as VulkanDeviceOwned, DynamicStateBuilder, GpuFuture};

--- a/src/text/cursor.rs
+++ b/src/text/cursor.rs
@@ -1,0 +1,463 @@
+//! Logic related to the positioning of the cursor within text.
+
+use crate::geom::{Range, Rect};
+use crate::text::{self, Align, FontSize, Point, Scalar};
+
+/// An index representing the position of a cursor within some text.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Index {
+    /// The byte index of the line upon which the cursor is situated.
+    pub line: usize,
+    /// The index within all possible cursor positions for the line.
+    ///
+    /// For example, for the line `foo`, a `char` of `1` would indicate the cursor's position
+    /// as `f|oo` where `|` is the cursor.
+    pub char: usize,
+}
+
+/// Every possible cursor position within each line of text yielded by the given iterator.
+///
+/// Yields `(xs, y_range)`, where `y_range` is the `Range` occupied by the line across the *y*
+/// axis and `xs` is every possible cursor position along the *x* axis
+#[derive(Clone)]
+pub struct XysPerLine<'a, I> {
+    lines_with_rects: I,
+    font: &'a text::Font,
+    text: &'a str,
+    font_size: FontSize,
+}
+
+/// Similarly to `XysPerLine`, yields every possible cursor position within each line of text
+/// yielded by the given iterator.
+///
+/// Rather than taking an iterator type yielding lines and positioning data, this method
+/// constructs its own iterator to do so internally, saving some boilerplate involved in common
+/// `XysPerLine` use cases.
+///
+/// Yields `(xs, y_range)`, where `y_range` is the `Range` occupied by the line across the *y*
+/// axis and `xs` is every possible cursor position along the *x* axis.
+#[derive(Clone)]
+pub struct XysPerLineFromText<'a> {
+    xys_per_line: XysPerLine<
+        'a,
+        std::iter::Zip<
+            std::iter::Cloned<std::slice::Iter<'a, text::line::Info>>,
+            text::line::Rects<std::iter::Cloned<std::slice::Iter<'a, text::line::Info>>>,
+        >,
+    >,
+}
+
+/// Each possible cursor position along the *x* axis within a line of text.
+///
+/// `Xs` iterators are produced by the `XysPerLine` iterator.
+pub struct Xs<'a, 'b> {
+    next_x: Option<Scalar>,
+    layout: text::LayoutIter<'a, 'b>,
+}
+
+impl Index {
+    /// The cursor index of the beginning of the word (block of non-whitespace) before `self`.
+    ///
+    /// If `self` is at the beginning of the line, call previous, which returns the last
+    /// index position of the previous line, or None if it's the first line
+    ///
+    /// If `self` points to whitespace, skip past that whitespace, then return the index of
+    /// the start of the word that precedes the whitespace
+    ///
+    /// If `self` is in the middle or end of a word, return the index of the start of that word
+    pub fn previous_word_start<I>(self, text: &str, mut line_infos: I) -> Option<Self>
+    where
+        I: Iterator<Item = text::line::Info>,
+    {
+        let Index { line, char } = self;
+        if char > 0 {
+            line_infos.nth(line).and_then(|line_info| {
+                let line_count = line_info.char_range().count();
+                let mut chars_rev = (&text[line_info.byte_range()]).chars().rev();
+                if char != line_count {
+                    chars_rev.nth(line_count - char - 1);
+                }
+                let mut new_char = 0;
+                let mut hit_non_whitespace = false;
+                for (i, char_) in chars_rev.enumerate() {
+                    // loop until word starts, then continue until the word ends
+                    if !char_.is_whitespace() {
+                        hit_non_whitespace = true;
+                    }
+                    if char_.is_whitespace() && hit_non_whitespace {
+                        new_char = char - i;
+                        break;
+                    }
+                }
+                Some(Index {
+                    line: line,
+                    char: new_char,
+                })
+            })
+        } else {
+            self.previous(line_infos)
+        }
+    }
+
+    /// The cursor index of the end of the first word (block of non-whitespace) after `self`.
+    ///
+    /// If `self` is at the end of the text, this returns `None`.
+    ///
+    /// If `self` is at the end of a line other than the last, this returns the first index of
+    /// the next line.
+    ///
+    /// If `self` points to whitespace, skip past that whitespace, then return the index of
+    /// the end of the word after the whitespace
+    ///
+    /// If `self` is in the middle or start of a word, return the index of the end of that word
+    pub fn next_word_end<I>(self, text: &str, mut line_infos: I) -> Option<Self>
+    where
+        I: Iterator<Item = text::line::Info>,
+    {
+        let Index { line, char } = self;
+        line_infos.nth(line).and_then(|line_info| {
+            let line_count = line_info.char_range().count();
+            if char < line_count {
+                let mut chars = (&text[line_info.byte_range()]).chars();
+                let mut new_char = line_count;
+                let mut hit_non_whitespace = false;
+                if char != 0 {
+                    chars.nth(char - 1);
+                }
+                for (i, char_) in chars.enumerate() {
+                    // loop until word starts, then continue until the word ends
+                    if !char_.is_whitespace() {
+                        hit_non_whitespace = true;
+                    }
+                    if char_.is_whitespace() && hit_non_whitespace {
+                        new_char = char + i;
+                        break;
+                    }
+                }
+                Some(Index {
+                    line: line,
+                    char: new_char,
+                })
+            } else {
+                line_infos.next().map(|_| Index {
+                    line: line + 1,
+                    char: 0,
+                })
+            }
+        })
+    }
+
+    /// The cursor index that comes before `self`.
+    ///
+    /// If `self` is at the beginning of the text, this returns `None`.
+    ///
+    /// If `self` is at the beginning of a line other than the first, this returns the last
+    /// index position of the previous line.
+    ///
+    /// If `self` is a position other than the start of a line, it will return the position
+    /// that is immediately to the left.
+    pub fn previous<I>(self, mut line_infos: I) -> Option<Self>
+    where
+        I: Iterator<Item = text::line::Info>,
+    {
+        let Index { line, char } = self;
+        if char > 0 {
+            let new_char = char - 1;
+            line_infos.nth(line).and_then(|info| {
+                if new_char <= info.char_range().count() {
+                    Some(Index {
+                        line: line,
+                        char: new_char,
+                    })
+                } else {
+                    None
+                }
+            })
+        } else if line > 0 {
+            let new_line = line - 1;
+            line_infos.nth(new_line).map(|info| {
+                let new_char = info.end_char() - info.start_char;
+                Index {
+                    line: new_line,
+                    char: new_char,
+                }
+            })
+        } else {
+            None
+        }
+    }
+
+    /// The cursor index that follows `self`.
+    ///
+    /// If `self` is at the end of the text, this returns `None`.
+    ///
+    /// If `self` is at the end of a line other than the last, this returns the first index of
+    /// the next line.
+    ///
+    /// If `self` is a position other than the end of a line, it will return the position that
+    /// is immediately to the right.
+    pub fn next<I>(self, mut line_infos: I) -> Option<Self>
+    where
+        I: Iterator<Item = text::line::Info>,
+    {
+        let Index { line, char } = self;
+        line_infos.nth(line).and_then(|info| {
+            if char >= info.char_range().count() {
+                line_infos.next().map(|_| Index {
+                    line: line + 1,
+                    char: 0,
+                })
+            } else {
+                Some(Index {
+                    line: line,
+                    char: char + 1,
+                })
+            }
+        })
+    }
+
+    /// Clamps `self` to the given lines.
+    ///
+    /// If `self` would lie after the end of the last line, return the index at the end of the
+    /// last line.
+    ///
+    /// If `line_infos` is empty, returns cursor at line=0 char=0.
+    pub fn clamp_to_lines<I>(self, line_infos: I) -> Self
+    where
+        I: Iterator<Item = text::line::Info>,
+    {
+        let mut last = None;
+        for (i, info) in line_infos.enumerate() {
+            if i == self.line {
+                let num_chars = info.char_range().len();
+                let char = std::cmp::min(self.char, num_chars);
+                return Index {
+                    line: i,
+                    char: char,
+                };
+            }
+            last = Some((i, info));
+        }
+        match last {
+            Some((i, info)) => Index {
+                line: i,
+                char: info.char_range().len(),
+            },
+            None => Index { line: 0, char: 0 },
+        }
+    }
+}
+
+/// Every possible cursor position within each line of text yielded by the given iterator.
+///
+/// Yields `(xs, y_range)`, where `y_range` is the `Range` occupied by the line across the *y*
+/// axis and `xs` is every possible cursor position along the *x* axis
+pub fn xys_per_line<'a, I>(
+    lines_with_rects: I,
+    font: &'a text::Font,
+    text: &'a str,
+    font_size: FontSize,
+) -> XysPerLine<'a, I> {
+    XysPerLine {
+        lines_with_rects: lines_with_rects,
+        font: font,
+        text: text,
+        font_size: font_size,
+    }
+}
+
+/// Similarly to `xys_per_line`, this produces an iterator yielding every possible cursor
+/// position within each line of text yielded by the given iterator.
+///
+/// Rather than taking an iterator yielding lines and their positioning data, this method
+/// constructs its own iterator to do so internally, saving some boilerplate involved in common
+/// `xys_per_line` use cases.
+///
+/// Yields `(xs, y_range)`, where `y_range` is the `Range` occupied by the line across the *y*
+/// axis and `xs` is every possible cursor position along the *x* axis.
+pub fn xys_per_line_from_text<'a>(
+    text: &'a str,
+    line_infos: &'a [text::line::Info],
+    font: &'a text::Font,
+    font_size: FontSize,
+    x_align: text::Justify,
+    y_align: Align,
+    line_spacing: Scalar,
+    rect: Rect,
+) -> XysPerLineFromText<'a> {
+    let line_infos = line_infos.iter().cloned();
+    let line_rects = text::line::rects(
+        line_infos.clone(),
+        font_size,
+        rect,
+        x_align,
+        y_align,
+        line_spacing,
+    );
+    let lines = line_infos.clone();
+    let lines_with_rects = lines.zip(line_rects.clone());
+    XysPerLineFromText {
+        xys_per_line: text::cursor::xys_per_line(lines_with_rects, font, text, font_size),
+    }
+}
+
+/// Convert the given character index into a cursor `Index`.
+pub fn index_before_char<I>(line_infos: I, char_index: usize) -> Option<Index>
+where
+    I: Iterator<Item = text::line::Info>,
+{
+    for (i, line_info) in line_infos.enumerate() {
+        let start_char = line_info.start_char;
+        let end_char = line_info.end_char();
+        if start_char <= char_index && char_index <= end_char {
+            return Some(Index {
+                line: i,
+                char: char_index - start_char,
+            });
+        }
+    }
+    None
+}
+
+/// Determine the *xy* location of the cursor at the given cursor `Index`.
+pub fn xy_at<'a, I>(xys_per_line: I, idx: Index) -> Option<(Scalar, Range)>
+where
+    I: Iterator<Item = (Xs<'a, 'a>, Range)>,
+{
+    for (i, (xs, y)) in xys_per_line.enumerate() {
+        if i == idx.line {
+            for (j, x) in xs.enumerate() {
+                if j == idx.char {
+                    return Some((x, y));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Find the closest line for the given `y` position, and return the line index, Xs iterator, and y-range of that line
+///
+/// Returns `None` if there are no lines
+pub fn closest_line<'a, I>(y_pos: Scalar, xys_per_line: I) -> Option<(usize, Xs<'a, 'a>, Range)>
+where
+    I: Iterator<Item = (Xs<'a, 'a>, Range)>,
+{
+    let mut xys_per_line_enumerated = xys_per_line.enumerate();
+    xys_per_line_enumerated
+        .next()
+        .and_then(|(first_line_idx, (first_line_xs, first_line_y))| {
+            let mut closest_line = (first_line_idx, first_line_xs, first_line_y);
+            let mut closest_diff = (y_pos - first_line_y.middle()).abs();
+            for (line_idx, (line_xs, line_y)) in xys_per_line_enumerated {
+                if line_y.contains(y_pos) {
+                    closest_line = (line_idx, line_xs, line_y);
+                    break;
+                } else {
+                    let diff = (y_pos - line_y.middle()).abs();
+                    if diff < closest_diff {
+                        closest_line = (line_idx, line_xs, line_y);
+                        closest_diff = diff;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            Some(closest_line)
+        })
+}
+
+/// Find the closest cursor index to the given `xy` position, and the center `Point` of that
+/// cursor.
+///
+/// Returns `None` if the given `text` is empty.
+pub fn closest_cursor_index_and_xy<'a, I>(xy: Point, xys_per_line: I) -> Option<(Index, Point)>
+where
+    I: Iterator<Item = (Xs<'a, 'a>, Range)>,
+{
+    closest_line(xy[1], xys_per_line).and_then(
+        |(closest_line_idx, closest_line_xs, closest_line_y)| {
+            let (closest_char_idx, closest_x) =
+                closest_cursor_index_on_line(xy[0], closest_line_xs);
+            let index = Index {
+                line: closest_line_idx,
+                char: closest_char_idx,
+            };
+            let point = [closest_x, closest_line_y.middle()].into();
+            Some((index, point))
+        },
+    )
+}
+
+/// Find the closest cursor index to the given `x` position on the given line along with the
+/// `x` position of that cursor.
+pub fn closest_cursor_index_on_line<'a>(x_pos: Scalar, line_xs: Xs<'a, 'a>) -> (usize, Scalar) {
+    let mut xs_enumerated = line_xs.enumerate();
+    // `xs` always yields at least one `x` (the start of the line).
+    let (first_idx, first_x) = xs_enumerated.next().unwrap();
+    let first_diff = (x_pos - first_x).abs();
+    let mut closest = (first_idx, first_x);
+    let mut closest_diff = first_diff;
+    for (i, x) in xs_enumerated {
+        let diff = (x_pos - x).abs();
+        if diff < closest_diff {
+            closest = (i, x);
+            closest_diff = diff;
+        } else {
+            break;
+        }
+    }
+    closest
+}
+
+impl<'a, I> Iterator for XysPerLine<'a, I>
+where
+    I: Iterator<Item = (text::line::Info, Rect)>,
+{
+    // The `Range` occupied by the line across the *y* axis, along with an iterator yielding
+    // each possible cursor position along the *x* axis.
+    type Item = (Xs<'a, 'a>, Range);
+    fn next(&mut self) -> Option<Self::Item> {
+        let XysPerLine {
+            ref mut lines_with_rects,
+            font,
+            text,
+            font_size,
+        } = *self;
+        let scale = text::pt_to_scale(font_size);
+        lines_with_rects.next().map(|(line_info, line_rect)| {
+            let line = &text[line_info.byte_range()];
+            let (x, y) = (line_rect.left() as f32, line_rect.top() as f32);
+            let point = text::rt::Point { x: x, y: y };
+            let y = line_rect.y;
+            let layout = font.layout(line, scale, point);
+            let xs = Xs {
+                next_x: Some(line_rect.x.start),
+                layout: layout,
+            };
+            (xs, y)
+        })
+    }
+}
+
+impl<'a> Iterator for XysPerLineFromText<'a> {
+    type Item = (Xs<'a, 'a>, Range);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.xys_per_line.next()
+    }
+}
+
+impl<'a, 'b> Iterator for Xs<'a, 'b> {
+    // Each possible cursor position along the *x* axis.
+    type Item = Scalar;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_x.map(|x| {
+            self.next_x = self.layout.next().map(|g| {
+                g.pixel_bounding_box()
+                    .map(|r| r.max.x as Scalar)
+                    .unwrap_or_else(|| x + g.unpositioned().h_metrics().advance_width as Scalar)
+            });
+            x
+        })
+    }
+}

--- a/src/text/cursor.rs
+++ b/src/text/cursor.rs
@@ -1,7 +1,7 @@
 //! Logic related to the positioning of the cursor within text.
 
 use crate::geom::{Range, Rect};
-use crate::text::{self, Align, FontSize, Point, Scalar};
+use crate::text::{self, FontSize, Point, Scalar};
 
 /// An index representing the position of a cursor within some text.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -280,18 +280,16 @@ pub fn xys_per_line_from_text<'a>(
     line_infos: &'a [text::line::Info],
     font: &'a text::Font,
     font_size: FontSize,
+    max_width: Scalar,
     x_align: text::Justify,
-    y_align: Align,
     line_spacing: Scalar,
-    rect: Rect,
 ) -> XysPerLineFromText<'a> {
     let line_infos = line_infos.iter().cloned();
     let line_rects = text::line::rects(
         line_infos.clone(),
         font_size,
-        rect,
+        max_width,
         x_align,
-        y_align,
         line_spacing,
     );
     let lines = line_infos.clone();

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -1,0 +1,164 @@
+//! The `font::Id` and `font::Map` types.
+
+use std::collections::HashMap;
+
+/// A type-safe wrapper around the `FontId`.
+///
+/// This is used as both:
+///
+/// - The key for the `font::Map`'s inner `HashMap`.
+/// - The `font_id` field for the rusttype::gpu_cache::Cache.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Id(usize);
+
+/// A collection of mappings from `font::Id`s to `rusttype::Font`s.
+#[derive(Debug)]
+pub struct Map {
+    next_index: usize,
+    map: HashMap<Id, super::Font>,
+}
+
+/// An iterator yielding an `Id` for each new `rusttype::Font` inserted into the `Map` via the
+/// `insert_collection` method.
+pub struct NewIds {
+    index_range: std::ops::Range<usize>,
+}
+
+/// Yields the `Id` for each `Font` within the `Map`.
+#[derive(Clone)]
+pub struct Ids<'a> {
+    keys: std::collections::hash_map::Keys<'a, Id, super::Font>,
+}
+
+/// Returned when loading new fonts from file or bytes.
+#[derive(Debug)]
+pub enum Error {
+    /// Some error occurred while loading a `FontCollection` from a file.
+    IO(std::io::Error),
+    /// No `Font`s could be yielded from the `FontCollection`.
+    NoFont,
+}
+
+impl Id {
+    /// Returns the inner `usize` from the `Id`.
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+impl Map {
+    /// Construct the new, empty `Map`.
+    pub fn new() -> Self {
+        Map {
+            next_index: 0,
+            map: HashMap::default(),
+        }
+    }
+
+    /// Borrow the `rusttype::Font` associated with the given `font::Id`.
+    pub fn get(&self, id: Id) -> Option<&super::Font> {
+        self.map.get(&id)
+    }
+
+    /// Adds the given `rusttype::Font` to the `Map` and returns a unique `Id` for it.
+    pub fn insert(&mut self, font: super::Font) -> Id {
+        let index = self.next_index;
+        self.next_index = index.wrapping_add(1);
+        let id = Id(index);
+        self.map.insert(id, font);
+        id
+    }
+
+    /// Insert a single `Font` into the map by loading it from the given file path.
+    pub fn insert_from_file<P>(&mut self, path: P) -> Result<Id, Error>
+    where
+        P: AsRef<std::path::Path>,
+    {
+        let font = from_file(path)?;
+        Ok(self.insert(font))
+    }
+
+    // /// Adds each font in the given `rusttype::FontCollection` to the `Map` and returns an
+    // /// iterator yielding a unique `Id` for each.
+    // pub fn insert_collection(&mut self, collection: super::FontCollection) -> NewIds {
+    //     let start_index = self.next_index;
+    //     let mut end_index = start_index;
+    //     for index in 0.. {
+    //         match collection.font_at(index) {
+    //             Some(font) => {
+    //                 self.insert(font);
+    //                 end_index += 1;
+    //             }
+    //             None => break,
+    //         }
+    //     }
+    //     NewIds { index_range: start_index..end_index }
+    // }
+
+    /// Produces an iterator yielding the `Id` for each `Font` within the `Map`.
+    pub fn ids(&self) -> Ids {
+        Ids {
+            keys: self.map.keys(),
+        }
+    }
+}
+
+/// Load a `super::FontCollection` from a file at a given path.
+pub fn collection_from_file<P>(path: P) -> Result<super::FontCollection, std::io::Error>
+where
+    P: AsRef<std::path::Path>,
+{
+    use std::io::Read;
+    let path = path.as_ref();
+    let mut file = std::fs::File::open(path)?;
+    let mut file_buffer = Vec::new();
+    file.read_to_end(&mut file_buffer)?;
+    Ok(super::FontCollection::from_bytes(file_buffer)?)
+}
+
+/// Load a single `Font` from a file at the given path.
+pub fn from_file<P>(path: P) -> Result<super::Font, Error>
+where
+    P: AsRef<std::path::Path>,
+{
+    let collection = collection_from_file(path)?;
+    collection.into_font().or(Err(Error::NoFont))
+}
+
+impl Iterator for NewIds {
+    type Item = Id;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.index_range.next().map(|i| Id(i))
+    }
+}
+
+impl<'a> Iterator for Ids<'a> {
+    type Item = Id;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.keys.next().map(|&id| id)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::IO(e)
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::IO(ref e) => std::error::Error::description(e),
+            Error::NoFont => "No `Font` found in the loaded `FontCollection`.",
+        }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        match *self {
+            Error::IO(ref e) => std::fmt::Display::fmt(e, f),
+            _ => write!(f, "{}", std::error::Error::description(self)),
+        }
+    }
+}

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -2,6 +2,7 @@
 
 use crate::text::{Font, FontCollection};
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 /// A type-safe wrapper around the `FontId`.
@@ -106,6 +107,15 @@ impl Map {
             keys: self.map.keys(),
         }
     }
+}
+
+/// Produce a unique ID for the given font.
+pub fn id(font: &Font) -> Id {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for name in font.font_name_strings() {
+        name.hash(&mut hasher);
+    }
+    Id((hasher.finish() % std::usize::MAX as u64) as usize)
 }
 
 /// Load a `FontCollection` from a file at a given path.

--- a/src/text/glyph.rs
+++ b/src/text/glyph.rs
@@ -51,13 +51,11 @@ pub struct SelectedRectsPerLine<'a, I> {
 impl<'a, 'b> Iterator for Rects<'a, 'b> {
     type Item = (ScaledGlyph<'a>, Rect);
     fn next(&mut self) -> Option<Self::Item> {
-        let Rects {
-            ref mut layout,
-            y,
-        } = *self;
+        let Rects { ref mut layout, y } = *self;
         layout.next().map(|g| {
             let left = g.position().x;
-            let (right, height) = g.pixel_bounding_box()
+            let (right, height) = g
+                .pixel_bounding_box()
                 .map(|bb| (bb.max.x as Scalar, (bb.max.y - bb.min.y) as Scalar))
                 .unwrap_or_else(|| {
                     let w = g.unpositioned().h_metrics().advance_width as Scalar;
@@ -239,7 +237,6 @@ pub fn contours_to_path<'a, I>(
 where
     I: IntoIterator<Item = rusttype::Contour>,
 {
-
     // Translate the rusttype point to a nannou compatible one.
     let tp = move |p: rusttype::Point<f32>| lyon::math::point(p.x, p.y);
 
@@ -278,14 +275,12 @@ where
         }
     };
 
-    contours
-        .into_iter()
-        .flat_map(move |contour| {
-            let mut segs = contour.segments.into_iter().peekable();
-            let first_event = segs.peek().map(|s| segment_move_event(s));
-            let events = segs.map(segment_to_event);
-            first_event.into_iter().chain(events)
-        })
+    contours.into_iter().flat_map(move |contour| {
+        let mut segs = contour.segments.into_iter().peekable();
+        let first_event = segs.peek().map(|s| segment_move_event(s));
+        let events = segs.map(segment_to_event);
+        first_event.into_iter().chain(events)
+    })
 }
 
 /// Produce the lyon path for the given scaled glyph.
@@ -294,7 +289,8 @@ where
 ///
 /// TODO: This could be optimised by caching path events glyph ID and using normalised glyphs.
 pub fn path_events(glyph: ScaledGlyph) -> Option<impl Iterator<Item = lyon::path::PathEvent>> {
-    glyph.exact_bounding_box()
+    glyph
+        .exact_bounding_box()
         .and_then(|bb| glyph.shape().map(|ctrs| (bb, ctrs)))
         .map(|(bb, ctrs)| contours_to_path(bb, ctrs))
 }

--- a/src/text/glyph.rs
+++ b/src/text/glyph.rs
@@ -1,0 +1,221 @@
+//! Logic and types specific to individual glyph layout.
+
+use crate::geom::{Range, Rect};
+use crate::text::{self, FontSize, Scalar};
+
+/// Some position along the X axis (used within `CharXs`).
+pub type X = Scalar;
+
+/// The half of the width of some character (used within `CharXs`).
+pub type HalfW = Scalar;
+
+/// An iterator yielding the `Rect` for each `char`'s `Glyph` in the given `text`.
+pub struct Rects<'a, 'b> {
+    /// The *y* axis `Range` of the `Line` for which character `Rect`s are being yielded.
+    ///
+    /// Every yielded `Rect` will use this as its `y` `Range`.
+    y: Range,
+    /// The position of the next `Rect`'s left edge along the *x* axis.
+    next_left: Scalar,
+    /// `PositionedGlyphs` yielded by the RustType `LayoutIter`.
+    layout: text::LayoutIter<'a, 'b>,
+}
+
+/// An iterator that, for every `(line, line_rect)` pair yielded by the given iterator,
+/// produces an iterator that yields a `Rect` for every character in that line.
+pub struct RectsPerLine<'a, I> {
+    lines_with_rects: I,
+    font: &'a text::Font,
+    font_size: FontSize,
+}
+
+/// Yields a `Rect` for each selected character in a single line of text.
+///
+/// This iterator can only be produced by the `SelectedCharRectsPerLine` iterator.
+pub struct SelectedRects<'a, 'b> {
+    enumerated_rects: std::iter::Enumerate<Rects<'a, 'b>>,
+    end_char_idx: usize,
+}
+
+/// Yields an iteraor yielding `Rect`s for each selected character in each line of text within
+/// the given iterator yielding char `Rect`s.
+///
+/// Given some `start` and `end` indices, only `Rect`s for `char`s between these two indices
+/// will be produced.
+///
+/// All lines that have no selected `Rect`s will be skipped.
+pub struct SelectedRectsPerLine<'a, I> {
+    enumerated_rects_per_line: std::iter::Enumerate<RectsPerLine<'a, I>>,
+    start_cursor_idx: text::cursor::Index,
+    end_cursor_idx: text::cursor::Index,
+}
+
+impl<'a, 'b> Iterator for Rects<'a, 'b> {
+    type Item = Rect;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Rects {
+            ref mut next_left,
+            ref mut layout,
+            y,
+        } = *self;
+        layout.next().map(|g| {
+            let left = *next_left;
+            let right = g
+                .pixel_bounding_box()
+                .map(|bb| bb.max.x as Scalar)
+                .unwrap_or_else(|| left + g.unpositioned().h_metrics().advance_width as Scalar);
+            *next_left = right;
+            let x = Range::new(left, right);
+            Rect { x: x, y: y }
+        })
+    }
+}
+
+impl<'a, I> Iterator for RectsPerLine<'a, I>
+where
+    I: Iterator<Item = (&'a str, Rect)>,
+{
+    type Item = Rects<'a, 'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let RectsPerLine {
+            ref mut lines_with_rects,
+            font,
+            font_size,
+        } = *self;
+        let scale = text::pt_to_scale(font_size);
+        lines_with_rects.next().map(|(line, line_rect)| {
+            let (x, y) = (line_rect.left() as f32, line_rect.top() as f32);
+            let point = text::rt::Point { x: x, y: y };
+            Rects {
+                next_left: line_rect.x.start,
+                layout: font.layout(line, scale, point),
+                y: line_rect.y,
+            }
+        })
+    }
+}
+
+impl<'a, 'b> Iterator for SelectedRects<'a, 'b> {
+    type Item = Rect;
+    fn next(&mut self) -> Option<Self::Item> {
+        let SelectedRects {
+            ref mut enumerated_rects,
+            end_char_idx,
+        } = *self;
+        enumerated_rects.next().and_then(
+            |(i, rect)| {
+                if i < end_char_idx {
+                    Some(rect)
+                } else {
+                    None
+                }
+            },
+        )
+    }
+}
+
+impl<'a, I> Iterator for SelectedRectsPerLine<'a, I>
+where
+    I: Iterator<Item = (&'a str, Rect)>,
+{
+    type Item = SelectedRects<'a, 'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let SelectedRectsPerLine {
+            ref mut enumerated_rects_per_line,
+            start_cursor_idx,
+            end_cursor_idx,
+        } = *self;
+
+        enumerated_rects_per_line.next().map(|(i, rects)| {
+            let end_char_idx =
+                // If this is the last line, the end is the char after the final selected char.
+                if i == end_cursor_idx.line {
+                    end_cursor_idx.char
+                // Otherwise if in range, every char in the line is selected.
+                } else if start_cursor_idx.line <= i && i < end_cursor_idx.line {
+                    std::u32::MAX as usize
+                // Otherwise if out of range, no chars are selected.
+                } else {
+                    0
+                };
+
+            let mut enumerated_rects = rects.enumerate();
+
+            // If this is the first line, skip all non-selected chars.
+            if i == start_cursor_idx.line {
+                for _ in 0..start_cursor_idx.char {
+                    enumerated_rects.next();
+                }
+            }
+
+            SelectedRects {
+                enumerated_rects: enumerated_rects,
+                end_char_idx: end_char_idx,
+            }
+        })
+    }
+}
+
+/// Produce an iterator that, for every `(line, line_rect)` pair yielded by the given iterator,
+/// produces an iterator that yields a `Rect` for every character in that line.
+///
+/// This is useful when information about character positioning is needed when reasoning about
+/// text layout.
+pub fn rects_per_line<'a, I>(
+    lines_with_rects: I,
+    font: &'a text::Font,
+    font_size: FontSize,
+) -> RectsPerLine<'a, I>
+where
+    I: Iterator<Item = (&'a str, Rect)>,
+{
+    RectsPerLine {
+        lines_with_rects: lines_with_rects,
+        font: font,
+        font_size: font_size,
+    }
+}
+
+/// Find the index of the character that directly follows the cursor at the given `cursor_idx`.
+///
+/// Returns `None` if either the given `cursor::Index` `line` or `idx` fields are out of bounds
+/// of the line information yielded by the `line_infos` iterator.
+pub fn index_after_cursor<I>(mut line_infos: I, cursor_idx: text::cursor::Index) -> Option<usize>
+where
+    I: Iterator<Item = text::line::Info>,
+{
+    line_infos.nth(cursor_idx.line).and_then(|line_info| {
+        let start_char = line_info.start_char;
+        let end_char = line_info.end_char();
+        let char_index = start_char + cursor_idx.char;
+        if char_index <= end_char {
+            Some(char_index)
+        } else {
+            None
+        }
+    })
+}
+
+/// Produces an iterator that yields iteraors yielding `Rect`s for each selected character in
+/// each line of text within the given iterator yielding char `Rect`s.
+///
+/// Given some `start` and `end` indices, only `Rect`s for `char`s between these two indices
+/// will be produced.
+///
+/// All lines that have no selected `Rect`s will be skipped.
+pub fn selected_rects_per_line<'a, I>(
+    lines_with_rects: I,
+    font: &'a text::Font,
+    font_size: FontSize,
+    start: text::cursor::Index,
+    end: text::cursor::Index,
+) -> SelectedRectsPerLine<'a, I>
+where
+    I: Iterator<Item = (&'a str, Rect)>,
+{
+    SelectedRectsPerLine {
+        enumerated_rects_per_line: rects_per_line(lines_with_rects, font, font_size).enumerate(),
+        start_cursor_idx: start,
+        end_cursor_idx: end,
+    }
+}

--- a/src/text/glyph.rs
+++ b/src/text/glyph.rs
@@ -233,7 +233,7 @@ fn rt_segment_start(s: &rusttype::Segment) -> rusttype::Point<f32> {
 ///
 /// In the resulting path events [0.0, 0.0] is the bottom left of the rect.
 pub fn contours_to_path<'a, I>(
-    exact_bounding_box: rusttype::Rect<f32>,
+    _exact_bounding_box: rusttype::Rect<f32>,
     contours: I,
 ) -> impl Iterator<Item = lyon::path::PathEvent>
 where

--- a/src/text/layout.rs
+++ b/src/text/layout.rs
@@ -27,7 +27,7 @@ pub struct Layout {
 pub const DEFAULT_LINE_WRAP: Option<Wrap> = Some(Wrap::Whitespace);
 pub const DEFAULT_FONT_SIZE: u32 = 12;
 pub const DEFAULT_LINE_SPACING: f32 = 0.0;
-pub const DEFAULT_JUSTIFY: Justify = Justify::Left;
+pub const DEFAULT_JUSTIFY: Justify = Justify::Center;
 pub const DEFAULT_Y_ALIGN: Align = Align::Middle;
 
 impl Builder {

--- a/src/text/layout.rs
+++ b/src/text/layout.rs
@@ -1,0 +1,130 @@
+//! Items related to the styling of text.
+
+use crate::text::{font, Font, FontSize, Justify, Scalar, Wrap};
+
+/// A context for building a text layout.
+#[derive(Clone, Debug, Default)]
+pub struct Builder {
+    pub line_spacing: Option<Scalar>,
+    pub line_wrap: Option<Option<Wrap>>,
+    pub font_size: Option<FontSize>,
+    pub justify: Option<Justify>,
+    pub font: Option<Option<Font>>,
+}
+
+/// Properties related to the layout of multi-line text for a single font and font size.
+#[derive(Clone, Debug)]
+pub struct Layout {
+    pub line_spacing: Scalar,
+    pub line_wrap: Option<Wrap>,
+    pub justify: Justify,
+    pub font_size: FontSize,
+    pub font: Option<Font>,
+}
+
+pub const DEFAULT_LINE_WRAP: Option<Wrap> = Some(Wrap::Whitespace);
+pub const DEFAULT_FONT_SIZE: u32 = 12;
+pub const DEFAULT_LINE_SPACING: f32 = 0.0;
+pub const DEFAULT_JUSTIFY: Justify = Justify::Left;
+
+impl Builder {
+    /// The font size to use for the text.
+    pub fn font_size(mut self, size: FontSize) -> Self {
+        self.font_size = Some(size);
+        self
+    }
+
+    /// Specify whether or not text should be wrapped around some width and how to do so.
+    ///
+    /// The default value is `DEFAULT_LINE_WRAP`.
+    pub fn line_wrap(mut self, line_wrap: Option<Wrap>) -> Self {
+        self.line_wrap = Some(line_wrap);
+        self
+    }
+
+    /// Specify that the **Text** should not wrap lines around the width.
+    ///
+    /// Shorthand for `builder.line_wrap(None)`.
+    pub fn no_line_wrap(self) -> Self {
+        self.line_wrap(None)
+    }
+
+    /// Line wrap the **Text** at the beginning of the first word that exceeds the width.
+    ///
+    /// Shorthand for `builder.line_wrap(Some(Wrap::Whitespace))`.
+    pub fn wrap_by_word(self) -> Self {
+        self.line_wrap(Some(Wrap::Whitespace))
+    }
+
+    /// Line wrap the **Text** at the beginning of the first character that exceeds the width.
+    ///
+    /// Shorthand for `builder.line_wrap(Some(Wrap::Character))`.
+    pub fn wrap_by_character(self) -> Self {
+        self.line_wrap(Some(Wrap::Character))
+    }
+
+    /// A method for specifying the `Font` used for displaying the `Text`.
+    pub fn font(mut self, font: Font) -> Self {
+        self.font = Some(Some(font));
+        self
+    }
+
+    /// Describe the end along the *x* axis to which the text should be aligned.
+    pub fn justify(mut self, justify: Justify) -> Self {
+        self.justify = Some(justify);
+        self
+    }
+
+    /// Align the text to the left of its bounding **Rect**'s *x* axis range.
+    pub fn left_justify(self) -> Self {
+        self.justify(Justify::Left)
+    }
+
+    /// Align the text to the middle of its bounding **Rect**'s *x* axis range.
+    pub fn center_justify(self) -> Self {
+        self.justify(Justify::Center)
+    }
+
+    /// Align the text to the right of its bounding **Rect**'s *x* axis range.
+    pub fn right_justify(self) -> Self {
+        self.justify(Justify::Right)
+    }
+
+    /// Specify how much vertical space should separate each line of text.
+    pub fn line_spacing(mut self, spacing: Scalar) -> Self {
+        self.line_spacing = Some(spacing);
+        self
+    }
+
+    /// Set all the parameters via an existing `Layout`
+    pub fn layout(mut self, layout: &Layout) -> Self {
+        self.font = Some(layout.font.clone());
+        self.line_spacing(layout.line_spacing)
+            .line_wrap(layout.line_wrap)
+            .justify(layout.justify)
+            .font_size(layout.font_size)
+    }
+
+    /// Build the text layout.
+    pub fn build(self) -> Layout {
+        Layout {
+            line_spacing: self.line_spacing.unwrap_or(DEFAULT_LINE_SPACING),
+            line_wrap: self.line_wrap.unwrap_or(DEFAULT_LINE_WRAP),
+            justify: self.justify.unwrap_or(DEFAULT_JUSTIFY),
+            font_size: self.font_size.unwrap_or(DEFAULT_FONT_SIZE),
+            font: self.font.unwrap_or(None),
+        }
+    }
+}
+
+impl Default for Layout {
+    fn default() -> Self {
+        Layout {
+            line_spacing: DEFAULT_LINE_SPACING,
+            line_wrap: DEFAULT_LINE_WRAP,
+            justify: DEFAULT_JUSTIFY,
+            font_size: DEFAULT_FONT_SIZE,
+            font: None,
+        }
+    }
+}

--- a/src/text/layout.rs
+++ b/src/text/layout.rs
@@ -1,6 +1,6 @@
 //! Items related to the styling of text.
 
-use crate::text::{font, Font, FontSize, Justify, Scalar, Wrap};
+use crate::text::{Align, Font, FontSize, Justify, Scalar, Wrap};
 
 /// A context for building a text layout.
 #[derive(Clone, Debug, Default)]
@@ -10,6 +10,7 @@ pub struct Builder {
     pub font_size: Option<FontSize>,
     pub justify: Option<Justify>,
     pub font: Option<Option<Font>>,
+    pub y_align: Option<Align>,
 }
 
 /// Properties related to the layout of multi-line text for a single font and font size.
@@ -20,12 +21,14 @@ pub struct Layout {
     pub justify: Justify,
     pub font_size: FontSize,
     pub font: Option<Font>,
+    pub y_align: Align,
 }
 
 pub const DEFAULT_LINE_WRAP: Option<Wrap> = Some(Wrap::Whitespace);
 pub const DEFAULT_FONT_SIZE: u32 = 12;
 pub const DEFAULT_LINE_SPACING: f32 = 0.0;
 pub const DEFAULT_JUSTIFY: Justify = Justify::Left;
+pub const DEFAULT_Y_ALIGN: Align = Align::Middle;
 
 impl Builder {
     /// The font size to use for the text.
@@ -96,6 +99,29 @@ impl Builder {
         self
     }
 
+    /// Specify how the whole text should be aligned along the y axis of its bounding rectangle
+    pub fn y_align(mut self, align: Align) -> Self {
+        self.y_align = Some(align);
+        self
+    }
+
+    /// Align the top edge of the text with the top edge of its bounding rectangle.
+    pub fn align_top(self) -> Self {
+        self.y_align(Align::End)
+    }
+
+    /// Align the middle of the text with the middle of the bounding rect along the y axis..
+    ///
+    /// This is the default behaviour.
+    pub fn align_middle_y(self) -> Self {
+        self.y_align(Align::Middle)
+    }
+
+    /// Align the bottom edge of the text with the bottom edge of its bounding rectangle.
+    pub fn align_bottom(self) -> Self {
+        self.y_align(Align::Start)
+    }
+
     /// Set all the parameters via an existing `Layout`
     pub fn layout(mut self, layout: &Layout) -> Self {
         self.font = Some(layout.font.clone());
@@ -103,6 +129,7 @@ impl Builder {
             .line_wrap(layout.line_wrap)
             .justify(layout.justify)
             .font_size(layout.font_size)
+            .y_align(layout.y_align)
     }
 
     /// Build the text layout.
@@ -113,6 +140,7 @@ impl Builder {
             justify: self.justify.unwrap_or(DEFAULT_JUSTIFY),
             font_size: self.font_size.unwrap_or(DEFAULT_FONT_SIZE),
             font: self.font.unwrap_or(None),
+            y_align: self.y_align.unwrap_or(DEFAULT_Y_ALIGN),
         }
     }
 }
@@ -125,6 +153,7 @@ impl Default for Layout {
             justify: DEFAULT_JUSTIFY,
             font_size: DEFAULT_FONT_SIZE,
             font: None,
+            y_align: DEFAULT_Y_ALIGN,
         }
     }
 }

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -410,7 +410,7 @@ fn next_break_by_whitespace(
         }
 
         // Add the character's width to the width so far.
-        let (adv_w, h) = advance_width_and_height(ch, font, scale, &mut last_glyph);;
+        let (adv_w, h) = advance_width_and_height(ch, font, scale, &mut last_glyph);
         let new_width = width + adv_w;
 
         // Check for a line wrap.

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -1,0 +1,690 @@
+//! Text handling logic related to individual lines of text.
+//!
+//! This module is the core of multi-line text handling.
+
+use crate::geom::{Range, Rect};
+use crate::text::{self, Align, FontSize, Scalar};
+
+/// The two types of **Break** indices returned by the **WrapIndicesBy** iterators.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Break {
+    /// A break caused by the text exceeding some maximum width.
+    Wrap {
+        /// The byte index at which the break occurs.
+        byte: usize,
+        /// The char index at which the string should wrap due to exceeding a maximum width.
+        char: usize,
+        /// The byte length which should be skipped in order to reach the first non-whitespace
+        /// character to use as the beginning of the next line.
+        len_bytes: usize,
+    },
+    /// A break caused by a newline character.
+    Newline {
+        /// The byte index at which the string should wrap due to exceeding a maximum width.
+        byte: usize,
+        /// The char index at which the string should wrap due to exceeding a maximum width.
+        char: usize,
+        /// The width of the "newline" token in bytes.
+        len_bytes: usize,
+    },
+    /// The end of the string has been reached, with the given length.
+    End {
+        /// The ending byte index.
+        byte: usize,
+        /// The ending char index.
+        char: usize,
+    },
+}
+
+/// Information about a single line of text within a `&str`.
+///
+/// `Info` is a minimal amount of information that can be stored for efficient reasoning about
+/// blocks of text given some `&str`. The `start` and `end_break` can be used for indexing into
+/// the `&str`, and the `width` can be used for calculating line `Rect`s, alignment, etc.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Info {
+    /// The index into the `&str` that represents the first character within the line.
+    pub start_byte: usize,
+    /// The character index of the first character in the line.
+    pub start_char: usize,
+    /// The index within the `&str` at which this line breaks into a new line, along with the
+    /// index at which the following line begins. The variant describes whether the break is
+    /// caused by a `Newline` character or a `Wrap` by the given wrap function.
+    pub end_break: Break,
+    /// The total width of all characters within the line.
+    pub width: Scalar,
+}
+
+/// An iterator yielding an `Info` struct for each line in the given `text` wrapped by the
+/// given `next_break_fn`.
+///
+/// `Infos` is a fundamental part of performing lazy reasoning about text within conrod.
+///
+/// Construct an `Infos` iterator via the [infos function](./fn.infos.html) and its two builder
+/// methods, [wrap_by_character](./struct.Infos.html#method.wrap_by_character) and
+/// [wrap_by_whitespace](./struct.Infos.html#method.wrap_by_whitespace).
+pub struct Infos<'a, F> {
+    text: &'a str,
+    font: &'a text::Font,
+    font_size: FontSize,
+    max_width: Scalar,
+    next_break_fn: F,
+    /// The index that indicates the start of the next line to be yielded.
+    start_byte: usize,
+    /// The character index that indicates the start of the next line to be yielded.
+    start_char: usize,
+    /// The break type of the previously yielded line
+    last_break: Option<Break>,
+}
+
+/// An iterator yielding a `Rect` for each line in
+#[derive(Clone)]
+pub struct Rects<I> {
+    infos: I,
+    x_align: text::Justify,
+    line_spacing: Scalar,
+    next: Option<Rect>,
+}
+
+/// An iterator yielding a `Rect` for each selected line in a block of text.
+///
+/// The yielded `Rect`s represent the selected range within each line of text.
+///
+/// Lines that do not contain any selected text will be skipped.
+pub struct SelectedRects<'a, I> {
+    selected_char_rects_per_line: text::glyph::SelectedRectsPerLine<'a, I>,
+}
+
+/// An alias for function pointers that are compatible with the `Block`'s required text
+/// wrapping function.
+pub type NextBreakFnPtr = fn(&str, &text::Font, FontSize, Scalar) -> (Break, Scalar);
+
+impl Break {
+    /// Return the index at which the break occurs.
+    pub fn byte_index(self) -> usize {
+        match self {
+            Break::Wrap { byte, .. } | Break::Newline { byte, .. } | Break::End { byte, .. } => {
+                byte
+            }
+        }
+    }
+
+    /// Return the index of the `char` at which the break occurs.
+    ///
+    /// To clarify, this index is to be used in relation to the `Chars` iterator.
+    pub fn char_index(self) -> usize {
+        match self {
+            Break::Wrap { char, .. } | Break::Newline { char, .. } | Break::End { char, .. } => {
+                char
+            }
+        }
+    }
+}
+
+impl<'a, F> Clone for Infos<'a, F>
+where
+    F: Clone,
+{
+    fn clone(&self) -> Self {
+        Infos {
+            text: self.text,
+            font: self.font,
+            font_size: self.font_size,
+            max_width: self.max_width,
+            next_break_fn: self.next_break_fn.clone(),
+            start_byte: self.start_byte,
+            start_char: self.start_char,
+            last_break: None,
+        }
+    }
+}
+
+impl Info {
+    /// The end of the byte index range for indexing into the slice.
+    pub fn end_byte(&self) -> usize {
+        self.end_break.byte_index()
+    }
+
+    /// The end of the index range for indexing into the slice.
+    pub fn end_char(&self) -> usize {
+        self.end_break.char_index()
+    }
+
+    /// The index range for indexing (via bytes) into the original str slice.
+    pub fn byte_range(self) -> std::ops::Range<usize> {
+        self.start_byte..self.end_byte()
+    }
+
+    /// The index range for indexing into a `char` iterator over the original str slice.
+    pub fn char_range(self) -> std::ops::Range<usize> {
+        self.start_char..self.end_char()
+    }
+}
+
+impl<'a> Infos<'a, NextBreakFnPtr> {
+    /// Converts `Self` into an `Infos` whose lines are wrapped at the character that first
+    /// causes the line width to exceed the given `max_width`.
+    pub fn wrap_by_character(mut self, max_width: Scalar) -> Self {
+        self.next_break_fn = next_break_by_character;
+        self.max_width = max_width;
+        self
+    }
+
+    /// Converts `Self` into an `Infos` whose lines are wrapped at the whitespace prior to the
+    /// character that causes the line width to exceed the given `max_width`.
+    pub fn wrap_by_whitespace(mut self, max_width: Scalar) -> Self {
+        self.next_break_fn = next_break_by_whitespace;
+        self.max_width = max_width;
+        self
+    }
+}
+
+/// A function for finding the advance width between the given character that also considers
+/// the kerning for some previous glyph.
+///
+/// This also updates the `last_glyph` with the glyph produced for the given `char`.
+///
+/// This is primarily for use within the `next_break` functions below.
+///
+/// The following code is adapted from the rusttype::LayoutIter::next src.
+fn advance_width(
+    ch: char,
+    font: &text::Font,
+    scale: text::Scale,
+    last_glyph: &mut Option<text::GlyphId>,
+) -> Scalar {
+    let g = font.glyph(ch).scaled(scale);
+    let kern = last_glyph
+        .map(|last| font.pair_kerning(scale, last, g.id()))
+        .unwrap_or(0.0);
+    let advance_width = g.h_metrics().advance_width;
+    *last_glyph = Some(g.id());
+    (kern + advance_width) as Scalar
+}
+
+/// Returns the next index at which the text naturally breaks via a newline character,
+/// along with the width of the line.
+fn next_break(text: &str, font: &text::Font, font_size: FontSize) -> (Break, Scalar) {
+    let scale = text::pt_to_scale(font_size);
+    let mut width = 0.0;
+    let mut char_i = 0;
+    let mut char_indices = text.char_indices().peekable();
+    let mut last_glyph = None;
+    while let Some((byte_i, ch)) = char_indices.next() {
+        // Check for a newline.
+        if ch == '\r' {
+            if let Some(&(_, '\n')) = char_indices.peek() {
+                let break_ = Break::Newline {
+                    byte: byte_i,
+                    char: char_i,
+                    len_bytes: 2,
+                };
+                return (break_, width);
+            }
+        } else if ch == '\n' {
+            let break_ = Break::Newline {
+                byte: byte_i,
+                char: char_i,
+                len_bytes: 1,
+            };
+            return (break_, width);
+        }
+
+        // Update the width.
+        width += advance_width(ch, font, scale, &mut last_glyph);
+        char_i += 1;
+    }
+    let break_ = Break::End {
+        byte: text.len(),
+        char: char_i,
+    };
+    (break_, width)
+}
+
+/// Returns the next index at which the text will break by either:
+/// - A newline character.
+/// - A line wrap at the beginning of the first character exceeding the `max_width`.
+///
+/// Also returns the width of each line alongside the Break.
+fn next_break_by_character(
+    text: &str,
+    font: &text::Font,
+    font_size: FontSize,
+    max_width: Scalar,
+) -> (Break, Scalar) {
+    let scale = text::pt_to_scale(font_size);
+    let mut width = 0.0;
+    let mut char_i = 0;
+    let mut char_indices = text.char_indices().peekable();
+    let mut last_glyph = None;
+    while let Some((byte_i, ch)) = char_indices.next() {
+        // Check for a newline.
+        if ch == '\r' {
+            if let Some(&(_, '\n')) = char_indices.peek() {
+                let break_ = Break::Newline {
+                    byte: byte_i,
+                    char: char_i,
+                    len_bytes: 2,
+                };
+                return (break_, width);
+            }
+        } else if ch == '\n' {
+            let break_ = Break::Newline {
+                byte: byte_i,
+                char: char_i,
+                len_bytes: 1,
+            };
+            return (break_, width);
+        }
+
+        // Add the character's width to the width so far.
+        let new_width = width + advance_width(ch, font, scale, &mut last_glyph);
+
+        // Check for a line wrap.
+        if new_width > max_width {
+            let break_ = Break::Wrap {
+                byte: byte_i,
+                char: char_i,
+                len_bytes: 0,
+            };
+            return (break_, width);
+        }
+
+        width = new_width;
+        char_i += 1;
+    }
+
+    let break_ = Break::End {
+        byte: text.len(),
+        char: char_i,
+    };
+    (break_, width)
+}
+
+/// Returns the next index at which the text will break by either:
+/// - A newline character.
+/// - A line wrap at the beginning of the whitespace that preceeds the first word
+/// exceeding the `max_width`.
+/// - A line wrap at the beginning of the first character exceeding the `max_width`,
+/// if no whitespace appears for `max_width` characters.
+///
+/// Also returns the width the line alongside the Break.
+fn next_break_by_whitespace(
+    text: &str,
+    font: &text::Font,
+    font_size: FontSize,
+    max_width: Scalar,
+) -> (Break, Scalar) {
+    struct Last {
+        byte: usize,
+        char: usize,
+        width_before: Scalar,
+    }
+    let scale = text::pt_to_scale(font_size);
+    let mut last_whitespace_start = None;
+    let mut width = 0.0;
+    let mut char_i = 0;
+    let mut char_indices = text.char_indices().peekable();
+    let mut last_glyph = None;
+    while let Some((byte_i, ch)) = char_indices.next() {
+        // Check for a newline.
+        if ch == '\r' {
+            if let Some(&(_, '\n')) = char_indices.peek() {
+                let break_ = Break::Newline {
+                    byte: byte_i,
+                    char: char_i,
+                    len_bytes: 2,
+                };
+                return (break_, width);
+            }
+        } else if ch == '\n' {
+            let break_ = Break::Newline {
+                byte: byte_i,
+                char: char_i,
+                len_bytes: 1,
+            };
+            return (break_, width);
+        }
+
+        // Add the character's width to the width so far.
+        let new_width = width + advance_width(ch, font, scale, &mut last_glyph);
+
+        // Check for a line wrap.
+        if width > max_width {
+            match last_whitespace_start {
+                Some(Last {
+                    byte,
+                    char,
+                    width_before,
+                }) => {
+                    let break_ = Break::Wrap {
+                        byte: byte,
+                        char: char,
+                        len_bytes: 1,
+                    };
+                    return (break_, width_before);
+                }
+                None => {
+                    let break_ = Break::Wrap {
+                        byte: byte_i,
+                        char: char_i,
+                        len_bytes: 0,
+                    };
+                    return (break_, width);
+                }
+            }
+        }
+
+        // Check for a new whitespace.
+        if ch.is_whitespace() {
+            last_whitespace_start = Some(Last {
+                byte: byte_i,
+                char: char_i,
+                width_before: width,
+            });
+        }
+
+        width = new_width;
+        char_i += 1;
+    }
+
+    let break_ = Break::End {
+        byte: text.len(),
+        char: char_i,
+    };
+    (break_, width)
+}
+
+/// Produce the width of the given line of text including spaces (i.e. ' ').
+pub fn width(text: &str, font: &text::Font, font_size: FontSize) -> Scalar {
+    let scale = text::Scale::uniform(text::pt_to_px(font_size));
+    let point = text::rt::Point { x: 0.0, y: 0.0 };
+
+    let mut total_w = 0.0;
+    for g in font.layout(text, scale, point) {
+        match g.pixel_bounding_box() {
+            Some(bb) => total_w = bb.max.x as f32,
+            None => total_w += g.unpositioned().h_metrics().advance_width,
+        }
+    }
+
+    total_w as Scalar
+}
+
+/// Produce an `Infos` iterator wrapped by the given `next_break_fn`.
+pub fn infos_wrapped_by<'a, F>(
+    text: &'a str,
+    font: &'a text::Font,
+    font_size: FontSize,
+    max_width: Scalar,
+    next_break_fn: F,
+) -> Infos<'a, F>
+where
+    F: for<'b> FnMut(&'b str, &'b text::Font, FontSize, Scalar) -> (Break, Scalar),
+{
+    Infos {
+        text: text,
+        font: font,
+        font_size: font_size,
+        max_width: max_width,
+        next_break_fn: next_break_fn,
+        start_byte: 0,
+        start_char: 0,
+        last_break: None,
+    }
+}
+
+/// Produce an `Infos` iterator that yields an `Info` for every line in the given text.
+///
+/// The produced `Infos` iterator will not wrap the text, and only break each line via newline
+/// characters within the text (either `\n` or `\r\n`).
+pub fn infos<'a>(
+    text: &'a str,
+    font: &'a text::Font,
+    font_size: FontSize,
+) -> Infos<'a, NextBreakFnPtr> {
+    fn no_wrap(
+        text: &str,
+        font: &text::Font,
+        font_size: FontSize,
+        _max_width: Scalar,
+    ) -> (Break, Scalar) {
+        next_break(text, font, font_size)
+    }
+
+    infos_wrapped_by(text, font, font_size, std::f32::MAX, no_wrap)
+}
+
+/// Produce an iterator yielding the bounding `Rect` for each line in the text.
+///
+/// This function assumes that `font_size` is the same `FontSize` used to produce the `Info`s
+/// yielded by the `infos` Iterator.
+pub fn rects<I>(
+    mut infos: I,
+    font_size: FontSize,
+    bounding_rect: Rect,
+    x_align: text::Justify,
+    y_align: Align,
+    line_spacing: Scalar,
+) -> Rects<I>
+where
+    I: Iterator<Item = Info> + ExactSizeIterator,
+{
+    let num_lines = infos.len();
+    let first_rect = infos.next().map(|first_info| {
+        // Calculate the `x` `Range` of the first line `Rect`.
+        let range = Range::new(0.0, first_info.width);
+        let x = match x_align {
+            text::Justify::Left => range.align_start_of(bounding_rect.x),
+            text::Justify::Center => range.align_middle_of(bounding_rect.x),
+            text::Justify::Right => range.align_end_of(bounding_rect.x),
+        };
+
+        // Calculate the `y` `Range` of the first line `Rect`.
+        let total_text_height = text::height(num_lines, font_size, line_spacing);
+        let total_text_y_range = Range::new(0.0, total_text_height);
+        let total_text_y = match y_align {
+            Align::Start => total_text_y_range.align_start_of(bounding_rect.y),
+            Align::Middle => total_text_y_range.align_middle_of(bounding_rect.y),
+            Align::End => total_text_y_range.align_end_of(bounding_rect.y),
+        };
+        let range = Range::new(0.0, font_size as Scalar);
+        let y = range.align_end_of(total_text_y);
+
+        Rect { x: x, y: y }
+    });
+
+    Rects {
+        infos: infos,
+        next: first_rect,
+        x_align: x_align,
+        line_spacing: line_spacing,
+    }
+}
+
+/// Produces an iterator yielding a `Rect` for the selected range in each selected line in a block
+/// of text.
+///
+/// The yielded `Rect`s represent the selected range within each line of text.
+///
+/// Lines that do not contain any selected text will be skipped.
+pub fn selected_rects<'a, I>(
+    lines_with_rects: I,
+    font: &'a text::Font,
+    font_size: FontSize,
+    start: text::cursor::Index,
+    end: text::cursor::Index,
+) -> SelectedRects<'a, I>
+where
+    I: Iterator<Item = (&'a str, Rect)>,
+{
+    SelectedRects {
+        selected_char_rects_per_line: text::glyph::selected_rects_per_line(
+            lines_with_rects,
+            font,
+            font_size,
+            start,
+            end,
+        ),
+    }
+}
+
+impl<'a, F> Iterator for Infos<'a, F>
+where
+    F: for<'b> FnMut(&'b str, &'b text::Font, FontSize, Scalar) -> (Break, Scalar),
+{
+    type Item = Info;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Infos {
+            text,
+            font,
+            font_size,
+            max_width,
+            ref mut next_break_fn,
+            ref mut start_byte,
+            ref mut start_char,
+            ref mut last_break,
+        } = *self;
+
+        match next_break_fn(&text[*start_byte..], font, font_size, max_width) {
+            (next @ Break::Newline { .. }, width) | (next @ Break::Wrap { .. }, width) => {
+                let next_break = match next {
+                    Break::Newline {
+                        byte,
+                        char,
+                        len_bytes,
+                    } => Break::Newline {
+                        byte: *start_byte + byte,
+                        char: *start_char + char,
+                        len_bytes: len_bytes,
+                    },
+                    Break::Wrap {
+                        byte,
+                        char,
+                        len_bytes,
+                    } => Break::Wrap {
+                        byte: *start_byte + byte,
+                        char: *start_char + char,
+                        len_bytes: len_bytes,
+                    },
+                    _ => unreachable!(),
+                };
+
+                let info = Info {
+                    start_byte: *start_byte,
+                    start_char: *start_char,
+                    end_break: next_break,
+                    width: width,
+                };
+
+                match next {
+                    Break::Newline {
+                        byte,
+                        char,
+                        len_bytes,
+                    }
+                    | Break::Wrap {
+                        byte,
+                        char,
+                        len_bytes,
+                    } => {
+                        *start_byte = info.start_byte + byte + len_bytes;
+                        *start_char = info.start_char + char + 1;
+                    }
+                    _ => unreachable!(),
+                };
+                *last_break = Some(next_break);
+                Some(info)
+            }
+
+            (Break::End { char, .. }, width) => {
+                // if the last line ends in a new line, or the entire text is empty, return an empty line Info
+                let empty_line = {
+                    match *last_break {
+                        Some(last_break_) => match last_break_ {
+                            Break::Newline { .. } => true,
+                            _ => false,
+                        },
+                        None => true,
+                    }
+                };
+                if *start_byte < text.len() || empty_line {
+                    let total_bytes = text.len();
+                    let total_chars = *start_char + char;
+                    let end_break = Break::End {
+                        byte: total_bytes,
+                        char: total_chars,
+                    };
+                    let info = Info {
+                        start_byte: *start_byte,
+                        start_char: *start_char,
+                        end_break: end_break,
+                        width: width,
+                    };
+                    *start_byte = total_bytes;
+                    *start_char = total_chars;
+                    *last_break = Some(end_break);
+                    Some(info)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+impl<I> Iterator for Rects<I>
+where
+    I: Iterator<Item = Info>,
+{
+    type Item = Rect;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Rects {
+            ref mut next,
+            ref mut infos,
+            x_align,
+            line_spacing,
+        } = *self;
+        next.map(|line_rect| {
+            *next = infos.next().map(|info| {
+                let y = {
+                    let h = line_rect.h();
+                    let y = line_rect.y() - h - line_spacing;
+                    Range::from_pos_and_len(y, h)
+                };
+
+                let x = {
+                    let range = Range::new(0.0, info.width);
+                    match x_align {
+                        text::Justify::Left => range.align_start_of(line_rect.x),
+                        text::Justify::Center => range.align_middle_of(line_rect.x),
+                        text::Justify::Right => range.align_end_of(line_rect.x),
+                    }
+                };
+
+                Rect { x: x, y: y }
+            });
+
+            line_rect
+        })
+    }
+}
+
+impl<'a, I> Iterator for SelectedRects<'a, I>
+where
+    I: Iterator<Item = (&'a str, Rect)>,
+{
+    type Item = Rect;
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(mut rects) = self.selected_char_rects_per_line.next() {
+            if let Some(first_rect) = rects.next() {
+                let total_selected_rect = rects.fold(first_rect, |mut total, next| {
+                    total.x.end = next.x.end;
+                    total
+                });
+                return Some(total_selected_rect);
+            }
+        }
+        None
+    }
+}

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -44,7 +44,7 @@ pub struct NextBreak {
     /// The total width of the line.
     pub width: Scalar,
     /// The maximum heigh of the line.
-    pub height: Scalar
+    pub height: Scalar,
 }
 
 /// Information about a single line of text within a `&str`.
@@ -213,7 +213,8 @@ fn advance_width_and_height(
         .map(|last| font.pair_kerning(scale, last, g.id()))
         .unwrap_or(0.0);
     let advance_width = g.h_metrics().advance_width;
-    let height = g.exact_bounding_box()
+    let height = g
+        .exact_bounding_box()
         .map(|bb| bb.min.y.abs() as Scalar)
         .unwrap_or(0.0);
     *last_glyph = Some(g.id());
@@ -239,7 +240,11 @@ fn next_break(text: &str, font: &text::Font, font_size: FontSize) -> NextBreak {
                     char: char_i,
                     len_bytes: 2,
                 };
-                return NextBreak { break_, width, height };
+                return NextBreak {
+                    break_,
+                    width,
+                    height,
+                };
             }
         } else if ch == '\n' {
             let break_ = Break::Newline {
@@ -247,7 +252,11 @@ fn next_break(text: &str, font: &text::Font, font_size: FontSize) -> NextBreak {
                 char: char_i,
                 len_bytes: 1,
             };
-            return NextBreak { break_, width, height };
+            return NextBreak {
+                break_,
+                width,
+                height,
+            };
         }
 
         // Update the width.
@@ -260,7 +269,11 @@ fn next_break(text: &str, font: &text::Font, font_size: FontSize) -> NextBreak {
         byte: text.len(),
         char: char_i,
     };
-    NextBreak { break_, width, height }
+    NextBreak {
+        break_,
+        width,
+        height,
+    }
 }
 
 /// Returns the next index at which the text will break by either:
@@ -289,7 +302,11 @@ fn next_break_by_character(
                     char: char_i,
                     len_bytes: 2,
                 };
-                return NextBreak { break_, width, height };
+                return NextBreak {
+                    break_,
+                    width,
+                    height,
+                };
             }
         } else if ch == '\n' {
             let break_ = Break::Newline {
@@ -297,7 +314,11 @@ fn next_break_by_character(
                 char: char_i,
                 len_bytes: 1,
             };
-            return NextBreak { break_, width, height };
+            return NextBreak {
+                break_,
+                width,
+                height,
+            };
         }
 
         // Add the character's width to the width so far.
@@ -311,7 +332,11 @@ fn next_break_by_character(
                 char: char_i,
                 len_bytes: 0,
             };
-            return NextBreak { break_, width, height };
+            return NextBreak {
+                break_,
+                width,
+                height,
+            };
         }
 
         height = height.max(h);
@@ -323,7 +348,11 @@ fn next_break_by_character(
         byte: text.len(),
         char: char_i,
     };
-    NextBreak { break_, width, height }
+    NextBreak {
+        break_,
+        width,
+        height,
+    }
 }
 
 /// Returns the next index at which the text will break by either:
@@ -361,7 +390,11 @@ fn next_break_by_whitespace(
                     char: char_i,
                     len_bytes: 2,
                 };
-                return NextBreak { break_, width, height };
+                return NextBreak {
+                    break_,
+                    width,
+                    height,
+                };
             }
         } else if ch == '\n' {
             let break_ = Break::Newline {
@@ -369,7 +402,11 @@ fn next_break_by_whitespace(
                 char: char_i,
                 len_bytes: 1,
             };
-            return NextBreak { break_, width, height };
+            return NextBreak {
+                break_,
+                width,
+                height,
+            };
         }
 
         // Add the character's width to the width so far.
@@ -390,7 +427,11 @@ fn next_break_by_whitespace(
                         len_bytes: 1,
                     };
                     let width = width_before;
-                    return NextBreak { break_, width, height };
+                    return NextBreak {
+                        break_,
+                        width,
+                        height,
+                    };
                 }
                 None => {
                     let break_ = Break::Wrap {
@@ -398,7 +439,11 @@ fn next_break_by_whitespace(
                         char: char_i,
                         len_bytes: 0,
                     };
-                    return NextBreak { break_, width, height };
+                    return NextBreak {
+                        break_,
+                        width,
+                        height,
+                    };
                 }
             }
         }
@@ -421,7 +466,11 @@ fn next_break_by_whitespace(
         byte: text.len(),
         char: char_i,
     };
-    NextBreak { break_, width, height }
+    NextBreak {
+        break_,
+        width,
+        height,
+    }
 }
 
 /// Produce the width of the given line of text including spaces (i.e. ' ').

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -265,7 +265,7 @@ impl<'a> Builder<'a> {
             } else {
                 let assets = crate::app::find_assets_path().expect(
                     "failed to detect the assets directory when searching for a default font",
-                );;
+                );
                 font::default(&assets).expect("failed to detect a default font")
             }
         });

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -291,6 +291,11 @@ impl<'a> Text<'a> {
         &self.layout
     }
 
+    /// The font used for this text instance.
+    pub fn font(&self) -> &Font {
+        &self.font
+    }
+
     /// The number of lines in the text.
     pub fn num_lines(&self) -> usize {
         self.line_infos.len()
@@ -568,8 +573,6 @@ pub fn position_offset(
 }
 
 /// Produce the position of each glyph ready for the rusttype glyph cache.
-///
-/// The top-left of the top line's rectangle will be positioned at [0.0, 0.0].
 pub fn rt_positioned_glyphs<'a, I>(
     lines_with_rects: I,
     font: &'a Font,

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,0 +1,122 @@
+//! Text layout logic.
+//!
+//! Currently, this crate is used primarily by the `draw.text()` API but will also play an
+//! important role in future GUI work.
+
+pub mod cursor;
+pub mod font;
+pub mod glyph;
+pub mod line;
+pub mod rt {
+    //! Re-exported RustType geometric types.
+    pub use rusttype::{gpu_cache, point, vector, Point, Rect, Vector};
+}
+
+// Re-export all relevant rusttype types here.
+pub use rusttype::gpu_cache::Cache as GlyphCache;
+pub use rusttype::{Glyph, GlyphId, GlyphIter, LayoutIter, Scale};
+
+/// The RustType `FontCollection` type used by conrod.
+pub type FontCollection = rusttype::FontCollection<'static>;
+/// The RustType `Font` type used by conrod.
+pub type Font = rusttype::Font<'static>;
+/// The RustType `PositionedGlyph` type used by conrod.
+pub type PositionedGlyph = rusttype::PositionedGlyph<'static>;
+
+/// The type used for scalar values.
+pub type Scalar = crate::geom::scalar::Default;
+
+/// The point type used when working with text.
+pub type Point<S = Scalar> = crate::geom::Point2<S>;
+
+/// The type used to specify `FontSize` in font points.
+pub type FontSize = u32;
+
+/// An iterator yielding each line within the given `text` as a new `&str`, where the start and end
+/// indices into each line are provided by the given iterator.
+#[derive(Clone)]
+pub struct Lines<'a, I> {
+    text: &'a str,
+    ranges: I,
+}
+
+/// Alignment along an axis.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Align {
+    Start,
+    Middle,
+    End,
+}
+
+/// A type used for referring to typographic alignment of `Text`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Justify {
+    /// Align text to the start of the bounding `Rect`'s *x* axis.
+    Left,
+    /// Symmetrically align text along the *y* axis.
+    Center,
+    /// Align text to the end of the bounding `Rect`'s *x* axis.
+    Right,
+    // /// Align wrapped text to both the start and end of the bounding `Rect`s *x* axis.
+    // ///
+    // /// Extra space is added between words in order to achieve this alignment.
+    // TODO: Full,
+}
+
+impl<'a, I> Iterator for Lines<'a, I>
+where
+    I: Iterator<Item = std::ops::Range<usize>>,
+{
+    type Item = &'a str;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Lines {
+            text,
+            ref mut ranges,
+        } = *self;
+        ranges.next().map(|range| &text[range])
+    }
+}
+
+/// Determine the total height of a block of text with the given number of lines, font size and
+/// `line_spacing` (the space that separates each line of text).
+pub fn height(num_lines: usize, font_size: FontSize, line_spacing: Scalar) -> Scalar {
+    if num_lines > 0 {
+        num_lines as Scalar * font_size as Scalar + (num_lines - 1) as Scalar * line_spacing
+    } else {
+        0.0
+    }
+}
+
+/// Produce an iterator yielding each line within the given `text` as a new `&str`, where the
+/// start and end indices into each line are provided by the given iterator.
+pub fn lines<I>(text: &str, ranges: I) -> Lines<I>
+where
+    I: Iterator<Item = std::ops::Range<usize>>,
+{
+    Lines {
+        text: text,
+        ranges: ranges,
+    }
+}
+
+/// Converts the given font size in "points" to its font size in pixels.
+/// This is useful for when the font size is not an integer.
+pub fn f32_pt_to_px(font_size_in_points: f32) -> f32 {
+    font_size_in_points * 4.0 / 3.0
+}
+
+/// Converts the given font size in "points" to a uniform `rusttype::Scale`.
+/// This is useful for when the font size is not an integer.
+pub fn f32_pt_to_scale(font_size_in_points: f32) -> Scale {
+    Scale::uniform(f32_pt_to_px(font_size_in_points))
+}
+
+/// Converts the given font size in "points" to its font size in pixels.
+pub fn pt_to_px(font_size_in_points: FontSize) -> f32 {
+    f32_pt_to_px(font_size_in_points as f32)
+}
+
+/// Converts the given font size in "points" to a uniform `rusttype::Scale`.
+pub fn pt_to_scale(font_size_in_points: FontSize) -> Scale {
+    Scale::uniform(pt_to_px(font_size_in_points))
+}

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -6,6 +6,7 @@
 pub mod cursor;
 pub mod font;
 pub mod glyph;
+pub mod layout;
 pub mod line;
 pub mod rt {
     //! Re-exported RustType geometric types.
@@ -14,13 +15,17 @@ pub mod rt {
 
 // Re-export all relevant rusttype types here.
 pub use rusttype::gpu_cache::Cache as GlyphCache;
-pub use rusttype::{Glyph, GlyphId, GlyphIter, LayoutIter, Scale};
+pub use rusttype::{Glyph, GlyphId, GlyphIter, LayoutIter, Scale, ScaledGlyph};
+pub use self::layout::Layout;
 
-/// The RustType `FontCollection` type used by conrod.
+use crate::geom;
+use std::borrow::Cow;
+
+/// The RustType `FontCollection` type used by nannou.
 pub type FontCollection = rusttype::FontCollection<'static>;
-/// The RustType `Font` type used by conrod.
+/// The RustType `Font` type used by nannou.
 pub type Font = rusttype::Font<'static>;
-/// The RustType `PositionedGlyph` type used by conrod.
+/// The RustType `PositionedGlyph` type used by nannou.
 pub type PositionedGlyph = rusttype::PositionedGlyph<'static>;
 
 /// The type used for scalar values.
@@ -32,6 +37,21 @@ pub type Point<S = Scalar> = crate::geom::Point2<S>;
 /// The type used to specify `FontSize` in font points.
 pub type FontSize = u32;
 
+/// A context for building some **Text**.
+pub struct Builder<'a> {
+    text: Cow<'a, str>,
+    layout_builder: layout::Builder,
+}
+
+/// An instance of some multi-line text and its layout.
+pub struct Text<'a> {
+    text: Cow<'a, str>,
+    font: Font,
+    layout: Layout,
+    line_infos: Vec<line::Info>,
+    max_width: Scalar,
+}
+
 /// An iterator yielding each line within the given `text` as a new `&str`, where the start and end
 /// indices into each line are provided by the given iterator.
 #[derive(Clone)]
@@ -39,6 +59,29 @@ pub struct Lines<'a, I> {
     text: &'a str,
     ranges: I,
 }
+
+/// An alias for the line info iterator yielded by `Text::line_infos`.
+pub type TextLineInfos<'a> = line::Infos<'a, line::NextBreakFnPtr>;
+
+/// An alias for the line iterator yielded by `Text::lines`.
+pub type TextLines<'a> =
+    Lines<'a, std::iter::Map<std::slice::Iter<'a, line::Info>, fn(&line::Info) -> std::ops::Range<usize>>>;
+
+/// An alias for the line rect iterator yielded by `Text::line_rects`.
+pub type TextLineRects<'a> = line::Rects<std::iter::Cloned<std::slice::Iter<'a, line::Info>>>;
+
+/// An alias for the iterator yielded by `Text::lines_with_rects`.
+pub type TextLinesWithRects<'a> = std::iter::Zip<TextLines<'a>, TextLineRects<'a>>;
+
+/// An alias for the iterator yielded by `Text::glyphs_per_line`.
+pub type TextGlyphsPerLine<'a> = glyph::RectsPerLine<'a, TextLinesWithRects<'a>>;
+
+/// An alias for the iterator yielded by `Text::glyphs`.
+pub type TextGlyphs<'a> = std::iter::FlatMap<
+    TextGlyphsPerLine<'a>,
+    glyph::Rects<'a, 'a>,
+    fn(glyph::Rects<'a, 'a>) -> glyph::Rects<'a, 'a>
+>;
 
 /// Alignment along an axis.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
@@ -61,6 +104,309 @@ pub enum Justify {
     // ///
     // /// Extra space is added between words in order to achieve this alignment.
     // TODO: Full,
+}
+
+/// The way in which text should wrap around the width.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Wrap {
+    /// Wrap at the first character that exceeds the width.
+    Character,
+    /// Wrap at the first word that exceeds the width.
+    Whitespace,
+}
+
+impl<'a> From<Cow<'a, str>> for Builder<'a> {
+    fn from(text: Cow<'a, str>) -> Self {
+        let layout_builder = Default::default();
+        Builder { text, layout_builder }
+    }
+}
+
+impl<'a> From<&'a str> for Builder<'a> {
+    fn from(s: &'a str) -> Self {
+        let text = Cow::Borrowed(s);
+        Self::from(text)
+    }
+}
+
+impl From<String> for Builder<'static> {
+    fn from(s: String) -> Self {
+        let text = Cow::Owned(s);
+        Self::from(text)
+    }
+}
+
+impl<'a> Builder<'a> {
+    /// Apply the given function to the inner text layout.
+    fn map_layout<F>(mut self, map: F) -> Self
+    where
+        F: FnOnce(layout::Builder) -> layout::Builder,
+    {
+        self.layout_builder = map(self.layout_builder);
+        self
+    }
+
+    /// The font size to use for the text.
+    pub fn font_size(self, size: FontSize) -> Self {
+        self.map_layout(|l| l.font_size(size))
+    }
+
+    /// Specify whether or not text should be wrapped around some width and how to do so.
+    ///
+    /// The default value is `DEFAULT_LINE_WRAP`.
+    pub fn line_wrap(self, line_wrap: Option<Wrap>) -> Self {
+        self.map_layout(|l| l.line_wrap(line_wrap))
+    }
+
+    /// Specify that the **Text** should not wrap lines around the width.
+    ///
+    /// Shorthand for `builder.line_wrap(None)`.
+    pub fn no_line_wrap(self) -> Self {
+        self.map_layout(|l| l.no_line_wrap())
+    }
+
+    /// Line wrap the **Text** at the beginning of the first word that exceeds the width.
+    ///
+    /// Shorthand for `builder.line_wrap(Some(Wrap::Whitespace))`.
+    pub fn wrap_by_word(self) -> Self {
+        self.map_layout(|l| l.wrap_by_word())
+    }
+
+    /// Line wrap the **Text** at the beginning of the first character that exceeds the width.
+    ///
+    /// Shorthand for `builder.line_wrap(Some(Wrap::Character))`.
+    pub fn wrap_by_character(self) -> Self {
+        self.map_layout(|l| l.wrap_by_character())
+    }
+
+    /// A method for specifying the `Font` used for displaying the `Text`.
+    pub fn font(self, font: Font) -> Self {
+        self.map_layout(|l| l.font(font))
+    }
+
+    /// Describe the end along the *x* axis to which the text should be aligned.
+    pub fn justify(self, justify: Justify) -> Self {
+        self.map_layout(|l| l.justify(justify))
+    }
+
+    /// Align the text to the left of its bounding **Rect**'s *x* axis range.
+    pub fn left_justify(self) -> Self {
+        self.map_layout(|l| l.left_justify())
+    }
+
+    /// Align the text to the middle of its bounding **Rect**'s *x* axis range.
+    pub fn center_justify(self) -> Self {
+        self.map_layout(|l| l.center_justify())
+    }
+
+    /// Align the text to the right of its bounding **Rect**'s *x* axis range.
+    pub fn right_justify(self) -> Self {
+        self.map_layout(|l| l.right_justify())
+    }
+
+    /// Specify how much vertical space should separate each line of text.
+    pub fn line_spacing(self, spacing: Scalar) -> Self {
+        self.map_layout(|l| l.line_spacing(spacing))
+    }
+
+    /// Set all the parameters via an existing `Layout`
+    pub fn layout(self, layout: &Layout) -> Self {
+        self.map_layout(|l| l.layout(layout))
+    }
+
+    /// Build the text.
+    ///
+    /// This iterates over the text in order to pre-calculates the text's multi-line information
+    /// using the `line::infos` function.
+    pub fn build(self, max_width: Scalar, assets: &std::path::Path) -> Text<'a> {
+        let text = self.text;
+        let layout = self.layout_builder.build();
+        let font = layout.font.clone()
+            .unwrap_or_else(|| font::default(assets).expect("failed to find default font"));
+        // let font = layout.font_id
+        //     .or_else(|| fonts.ids().next())
+        //     .and_then(|id| fonts.get(id))
+        //     .map(|font| font.clone())
+        //     .expect("no fonts in font map");
+        let line_infos = line::infos_maybe_wrapped(
+            &text,
+            &font,
+            layout.font_size,
+            layout.line_wrap,
+            max_width,
+        ).collect();
+        Text { text, font, layout, line_infos, max_width }
+    }
+}
+
+impl<'a> Text<'a> {
+    /// Produce an iterator yielding information about each line.
+    ///
+    /// `max_width` describes the maximum width a line may be before it requires wrapping.
+    pub fn line_infos(&self) -> &[line::Info] {
+        &self.line_infos
+    }
+
+    /// The full string of text as a slice.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// The layout parameters for this text instance.
+    pub fn layout(&self) -> &Layout {
+        &self.layout
+    }
+
+    /// The number of lines in the text.
+    pub fn num_lines(&self) -> usize {
+        self.line_infos.len()
+    }
+
+    /// The width around which the text was wrapped.
+    pub fn max_width(&self) -> Scalar {
+        self.max_width
+    }
+
+    /// The width of the widest line of text.
+    pub fn width(&self) -> Scalar {
+        self.line_infos.iter().fold(0.0, |max, info| max.max(info.width))
+    }
+
+    /// The total height of the text.
+    pub fn height(&self) -> Scalar {
+        height(self.num_lines(), self.layout.font_size, self.layout.line_spacing)
+    }
+
+    /// Produce an iterator yielding each wrapped line within the **Text**.
+    pub fn lines(&self) -> TextLines {
+        fn info_byte_range(info: &line::Info) -> std::ops::Range<usize> {
+            info.byte_range()
+        }
+        lines(&self.text, self.line_infos.iter().map(info_byte_range))
+    }
+
+    /// The bounding rectangle for each line.
+    pub fn line_rects(&self) -> TextLineRects {
+        line::rects(
+            self.line_infos.iter().cloned(),
+            self.layout.font_size,
+            self.max_width,
+            self.layout.justify,
+            self.layout.line_spacing,
+        )
+    }
+
+    /// Produce an iterator yielding all lines of text alongside their bounding rects.
+    pub fn lines_with_rects(&self) -> TextLinesWithRects {
+        self.lines().zip(self.line_rects())
+    }
+
+    /// Produce an iterator yielding iterators yielding every glyph alongside its bounding rect for
+    /// each line.
+    pub fn glyphs_per_line(&self) -> TextGlyphsPerLine {
+        glyph::rects_per_line(self.lines_with_rects(), &self.font, self.layout.font_size)
+    }
+
+    /// Produce an iterator yielding every glyph alongside its bounding rect.
+    ///
+    /// This is the "flattened" version of the `glyphs_per_line` method.
+    pub fn glyphs(&self) -> TextGlyphs {
+        self.glyphs_per_line().flat_map(std::convert::identity)
+    }
+
+    /// Produce an iterator yielding the path events for every glyph in every line.
+    pub fn path_events<'b>(&'b self) -> impl 'b + Iterator<Item = lyon::path::PathEvent> {
+        use lyon::geom::{CubicBezierSegment, LineSegment, QuadraticBezierSegment};
+        use lyon::path::PathEvent;
+
+        // Translate the given lyon point by the given vector.
+        fn trans_lyon_point(p: &lyon::math::Point, v: geom::Vector2) -> lyon::math::Point {
+            lyon::math::point(p.x + v.x, p.y + v.y)
+        }
+
+        // Translate the given path event in 2D space.
+        fn trans_path_event(e: &PathEvent, v: geom::Vector2) -> PathEvent {
+            match *e {
+                PathEvent::MoveTo(ref p) => PathEvent::MoveTo(trans_lyon_point(p, v)),
+                PathEvent::Line(ref e) => PathEvent::Line(LineSegment {
+                    from: trans_lyon_point(&e.from, v),
+                    to: trans_lyon_point(&e.to, v),
+                }),
+                PathEvent::Quadratic(ref e) => PathEvent::Quadratic(QuadraticBezierSegment {
+                    from: trans_lyon_point(&e.from, v),
+                    ctrl: trans_lyon_point(&e.ctrl, v),
+                    to: trans_lyon_point(&e.to, v),
+                }),
+                PathEvent::Cubic(ref e) => PathEvent::Cubic(CubicBezierSegment {
+                    from: trans_lyon_point(&e.from, v),
+                    ctrl1: trans_lyon_point(&e.ctrl1, v),
+                    ctrl2: trans_lyon_point(&e.ctrl2, v),
+                    to: trans_lyon_point(&e.to, v),
+                }),
+                PathEvent::Close(ref e) => PathEvent::Close(LineSegment {
+                    from: trans_lyon_point(&e.from, v),
+                    to: trans_lyon_point(&e.to, v),
+                }),
+            }
+        }
+
+        self.glyphs()
+            .flat_map(|(g, r)| {
+                glyph::path_events(g)
+                    .into_iter()
+                    .flat_map(|es| es)
+                    .map(move |e| trans_path_event(&e, r.bottom_left()))
+            })
+    }
+
+    /// Produces the offset required in order to lay out text so that the left-most point is at the
+    /// given `left` value and that the text is vertically aligned within the given `y` range.
+    pub fn offset_into_rect(&self, left: Scalar, y: geom::Range, y_align: Align) -> geom::Vector2 {
+        let x = geom::Range::new(left, left + self.max_width);
+        let bounding_rect = geom::Rect { x, y };
+        position_offset(
+            self.num_lines(),
+            self.layout.font_size,
+            self.layout.line_spacing,
+            bounding_rect,
+            y_align,
+        )
+    }
+
+    /// Produce an iterator yielding positioned rusttype glyphs ready for caching.
+    ///
+    /// The window dimensions and DPI are required to transform glyph positions into rusttype's
+    /// pixel-space, ready for caching into the rusttype glyph cache pixel buffer.
+    pub fn rt_glyphs<'b: 'a>(
+        &'b self,
+        window_dims: geom::Vector2,
+        dpi_factor: Scalar,
+        left: Scalar,
+        y: geom::Range,
+        y_align: Align,
+    ) -> impl 'a + 'b + Iterator<Item = PositionedGlyph> {
+        let x = geom::Range::new(left, left + self.max_width);
+        let bounding_rect = geom::Rect { x, y };
+        positioned_glyphs(
+            &self.text,
+            &self.line_infos,
+            bounding_rect,
+            y_align,
+            self.layout.line_spacing,
+            self.layout.font_size,
+            self.layout.justify,
+            &self.font,
+            window_dims,
+            dpi_factor,
+        )
+    }
+
+    /// Converts this `Text` instance into an instance that owns the inner text string.
+    pub fn into_owned(self) -> Text<'static> {
+        let Text { text, font, layout, line_infos, max_width } = self;
+        let text = Cow::Owned(text.into_owned());
+        Text { text, font, layout, line_infos, max_width }
+    }
 }
 
 impl<'a, I> Iterator for Lines<'a, I>
@@ -99,6 +445,71 @@ where
     }
 }
 
+/// The position offset required to shift the associated text into the given bounding rectangle.
+///
+/// This function assumes the `max_width` used to produce the `line_infos` is equal to the given
+/// `bounding_rect` max width.
+pub fn position_offset(
+    num_lines: usize,
+    font_size: FontSize,
+    line_spacing: f32,
+    bounding_rect: geom::Rect,
+    y_align: Align,
+) -> geom::Vector2 {
+    let x_offset = bounding_rect.x.start;
+    let y_offset = {
+        // Calculate the `y` `Range` of the first line `Rect`.
+        let total_text_height = height(num_lines, font_size, line_spacing);
+        let total_text_y_range = geom::Range::new(0.0, total_text_height);
+        let total_text_y = match y_align {
+            Align::Start => total_text_y_range.align_start_of(bounding_rect.y),
+            Align::Middle => total_text_y_range.align_middle_of(bounding_rect.y),
+            Align::End => total_text_y_range.align_end_of(bounding_rect.y),
+        };
+        total_text_y.end
+    };
+    geom::vec2(x_offset, y_offset)
+}
+
+/// Produce the position of each glyph.
+///
+/// The top-left of the top line's rectangle will be positioned at [0.0, 0.0].
+pub fn positioned_glyphs<'a>(
+    text: &'a str,
+    line_infos: &'a [line::Info],
+    bounding_rect: geom::Rect,
+    y_align: Align,
+    line_spacing: Scalar,
+    font_size: u32,
+    justify: Justify,
+    font: &'a Font,
+    window_dim: geom::Vector2,
+    dpi_factor: Scalar,
+) -> impl 'a + Iterator<Item = PositionedGlyph> {
+    // Produce the text layout iterators.
+    let n_lines = line_infos.len();
+    let line_infos = line_infos.iter().cloned();
+    let lines = line_infos.clone().map(move |info| &text[info.byte_range()]);
+    let bounding_w = bounding_rect.x.len();
+    let offset = position_offset(n_lines, font_size, line_spacing, bounding_rect, y_align);
+    let line_rects = line::rects(line_infos, font_size, bounding_w, justify, line_spacing)
+        .map(move |r| r.shift(offset));
+
+    // Functions for converting nannou coordinates to rusttype pixel coordinates.
+    let trans_x = move |x: Scalar| (x + window_dim[0] / 2.0) * dpi_factor as Scalar;
+    let trans_y = move |y: Scalar| ((-y) + window_dim[1] / 2.0) * dpi_factor as Scalar;
+
+    // Clear the existing glyphs and fill the buffer with glyphs for this Text.
+    let scale = f32_pt_to_scale(font_size as f32 * dpi_factor);
+    lines
+        .zip(line_rects)
+        .flat_map(move |(line, line_rect)| {
+            let (x, y) = (trans_x(line_rect.left()) as f32, trans_y(line_rect.bottom()) as f32);
+            let point = rt::Point { x: x, y: y };
+            font.layout(line, scale, point).map(|g| g.standalone())
+        })
+}
+
 /// Converts the given font size in "points" to its font size in pixels.
 /// This is useful for when the font size is not an integer.
 pub fn f32_pt_to_px(font_size_in_points: f32) -> f32 {
@@ -119,4 +530,9 @@ pub fn pt_to_px(font_size_in_points: FontSize) -> f32 {
 /// Converts the given font size in "points" to a uniform `rusttype::Scale`.
 pub fn pt_to_scale(font_size_in_points: FontSize) -> Scale {
     Scale::uniform(pt_to_px(font_size_in_points))
+}
+
+/// Begin building a **Text** instance.
+pub fn text(s: &str) -> Builder {
+    Builder::from(s)
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -35,7 +35,7 @@ use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt;
 use std::ops::Deref;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{mpsc, Arc, Mutex};
 use winit;
 


### PR DESCRIPTION
The new text module extends the `rusttype` crate with simplified interop
with nannou's geometry types and provides functionality for handling
layout of aligned and justified multi-line text.

The new `draw.text("some text")` API takes advantage of this new
module to allow for displaying multi-line text, handling line
wrapping, alignment, justification, font sizes and different fonts.

TODO:

- [x] Add a simple text layout builder type and high-level API to text mod.
- [x] Add support for converting text into lyon path events to allow for
path tessellation.
- [x] Add a text buffer to `draw::State` for buffering text. This allows
to avoid the need for specifying complicated lifetimes in the `Text`
type itself in a fairly efficient manner.
- [x] Add a glyph cache to the `draw::backend::vulkano::Renderer`. Can
likely copy the implementation of the Ui's glyph cache.
- [x] Create a `positioned_glyphs` iterator that yields all glyphs for a
single text instance.
- ~~Add a font map to the `Draw` API state.~~ *Bailing on this in favour of using fonts directly.*
- [ ] Write `positioned_glyphs` into mesh while updating the CPU half
of the glyph cache. For now, assume tex_coords channel in main draw
mesh refers to text cache image sampler coordinates.
- [x] Add a `text` example demonstrating alignment, justification, etc.

Closes #77.