### PR TITLE
Bugfix: mouse position validity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 .DS_Store
+.vscode/

--- a/src/app.rs
+++ b/src/app.rs
@@ -1873,9 +1873,13 @@ where
                     app.mouse.x = x;
                     app.mouse.y = y;
                     app.mouse.window = Some(window_id);
+                    app.mouse.is_position_valid = true;
                 }
 
                 winit::WindowEvent::MouseInput { state, button, .. } => {
+                    if app.mouse.window != Some(window_id) {
+                        app.mouse.is_position_valid = false;
+                    }
                     match state {
                         event::ElementState::Pressed => {
                             let p = app.mouse.position();

--- a/src/state.rs
+++ b/src/state.rs
@@ -89,6 +89,9 @@ pub mod mouse {
         pub x: S,
         /// *y* position relative to the middle of `window`.
         pub y: S,
+        /// In special cases, the mouse position might be invalid
+        /// (for example: first press in unfocused window when using several windows)
+        pub is_position_valid: bool,
         /// A map describing the state of each mouse button.
         pub buttons: ButtonMap,
     }
@@ -125,6 +128,7 @@ pub mod mouse {
             Mouse {
                 window: None,
                 buttons: ButtonMap::new(),
+                is_position_valid: false,
                 x: S::zero(),
                 y: S::zero(),
             }


### PR DESCRIPTION
fixes https://github.com/nannou-org/nannou/issues/392

When at least two windows are being used, when you click inside another window (without moving the mouse after clicking), app.mouse.window and app.mouse.buttons (pressed state) are updated, but not app.mouse.x nor app.mouse.y.
So these two values are invalid, as well as the position in the pressed state of the mouse (which uses the position of app.mouse).
To deal with that, we define the bool `app.mouse.is_position_valid` which assesses the validity of the position.

NB: ideally the winit should send a CursorMoved event before any pressed event (I saw in the git history of winit that they did that at some point of their history, but somehow it is not the case here)... maybe it is a question of configuring winit correctly?