### PR TITLE
Publish 0.11.1 - Includes three major fixes for 0.11.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -265,9 +265,8 @@ impl<'a> Builder<'a> {
             {
                 return font::default_notosans();
             }
-            let assets = crate::app::find_assets_path().expect(
-                "failed to detect the assets directory when searching for a default font",
-            );
+            let assets = crate::app::find_assets_path()
+                .expect("failed to detect the assets directory when searching for a default font");
             font::default(&assets).expect("failed to detect a default font")
         });
         let max_width = rect.w();


### PR DESCRIPTION
This patch release includes 3 major fixes:

- Fixes a bug that occurred when drawing a mesh after a path #404.
- Fixes an issue where text could not be positioned #403.
- Fixes a bug where UI default font detection failed when assets directory did not exist #405.