### PR TITLE
added feature to use .rgb8(u8,u8,u8) as an option to color stuff

### DIFF
--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -29,11 +29,19 @@ pub type Rgb<S = DefaultScalar> = Srgb<S>;
 /// the `palette` crate's generic `Rgb` type.
 pub type Rgba<S = DefaultScalar> = Srgba<S>;
 
+/// The same as `Rgb`, but with `u8`'s.
+pub type Rgb8 = Rgb<u8>;
+
 /// A short-hand constructor for `Rgb::new`.
 pub fn rgb<T>(r: T, g: T, b: T) -> Rgb<T>
 where
     T: Component,
 {
+    srgb(r, g, b)
+}
+
+/// A short-hand constructor for `Rgb::<u8>::new` .
+pub fn rgb8(r: u8, g: u8, b: u8) -> Rgb8 {
     srgb(r, g, b)
 }
 

--- a/src/draw/drawing.rs
+++ b/src/draw/drawing.rs
@@ -256,6 +256,11 @@ where
         self.map_ty(|ty| SetColor::rgb(ty, r, g, b))
     }
 
+    /// Specify the color via `u8` red, green and blue channels.
+    pub fn rgb8(self, r: u8, g: u8, b: u8) -> Self {
+        self.map_ty(|ty| SetColor::rgb8(ty, r, g, b))
+    }
+
     /// Specify the color via red, green, blue and alpha channels.
     pub fn rgba(self, r: ColorScalar, g: ColorScalar, b: ColorScalar, a: ColorScalar) -> Self {
         self.map_ty(|ty| SetColor::rgba(ty, r, g, b, a))

--- a/src/draw/properties/color.rs
+++ b/src/draw/properties/color.rs
@@ -37,6 +37,14 @@ where
         self.color(color::Srgb::new(r, g, b))
     }
 
+    /// Specify the color via `u8` red, green and blue channels.
+    fn rgb8(self, r: u8, g: u8, b: u8) -> Self
+    where
+        S: Float,
+    {
+        self.color(color::Srgb::<u8>::new(r, g, b))
+    }
+
     /// Specify the color via red, green, blue and alpha channels.
     fn rgba<T>(self, r: T, g: T, b: T, a: T) -> Self
     where

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,8 +2,8 @@
 
 pub use crate::app::{self, App, LoopMode};
 pub use crate::color::named::*;
-pub use crate::color::{hsl, hsla, hsv, hsva, lin_srgb, lin_srgba, rgb, rgba, srgb, srgba};
-pub use crate::color::{Hsl, Hsla, Hsv, Hsva, LinSrgb, LinSrgba, Rgb, Rgba, Srgb, Srgba};
+pub use crate::color::{hsl, hsla, hsv, hsva, lin_srgb, lin_srgba, rgb, rgb8, rgba, srgb, srgba};
+pub use crate::color::{Hsl, Hsla, Hsv, Hsva, LinSrgb, LinSrgba, Rgb, Rgb8, Rgba, Srgb, Srgba};
 pub use crate::event::WindowEvent::*;
 pub use crate::event::{
     AxisMotion, Event, Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase,


### PR DESCRIPTION
also `rgb8(u8, u8, u8)` has been added as a shortcut to `Rgb::<u8>::new()`

#180 