### PR TITLE
Remove `secondary` from methods of the command buffer builder

### DIFF
--- a/examples/vulkan/vk_compute_shader_rendering.rs
+++ b/examples/vulkan/vk_compute_shader_rendering.rs
@@ -169,7 +169,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
             push_constants,
         )
         .expect("failed to add `dispatch` command")
-        .begin_render_pass(model.view_fbo.borrow().expect_inner(), false, clear_values)
+        .begin_render_pass(model.view_fbo.borrow().expect_inner(), clear_values)
         .unwrap()
         .draw(
             model.pipeline.clone(),

--- a/examples/vulkan/vk_hotload.rs
+++ b/examples/vulkan/vk_hotload.rs
@@ -197,7 +197,7 @@ fn view(_app: &App, model: &Model, frame: &Frame) {
     // Submit the draw commands.
     frame
         .add_commands()
-        .begin_render_pass(model.view_fbo.borrow().expect_inner(), false, clear_values)
+        .begin_render_pass(model.view_fbo.borrow().expect_inner(), clear_values)
         .unwrap()
         .draw(
             model.pipeline.clone().unwrap(),

--- a/examples/vulkan/vk_image.rs
+++ b/examples/vulkan/vk_image.rs
@@ -141,7 +141,7 @@ fn view(_app: &App, model: &Model, frame: &Frame) {
 
     frame
         .add_commands()
-        .begin_render_pass(model.view_fbo.borrow().expect_inner(), false, clear_values)
+        .begin_render_pass(model.view_fbo.borrow().expect_inner(), clear_values)
         .unwrap()
         .draw(
             model.pipeline.clone(),

--- a/examples/vulkan/vk_image_sequence.rs
+++ b/examples/vulkan/vk_image_sequence.rs
@@ -153,7 +153,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
 
     frame
         .add_commands()
-        .begin_render_pass(model.view_fbo.borrow().expect_inner(), false, clear_values)
+        .begin_render_pass(model.view_fbo.borrow().expect_inner(), clear_values)
         .unwrap()
         .draw(
             model.pipeline.clone(),

--- a/examples/vulkan/vk_images.rs
+++ b/examples/vulkan/vk_images.rs
@@ -158,7 +158,7 @@ fn view(_app: &App, model: &Model, frame: &Frame) {
 
     frame
         .add_commands()
-        .begin_render_pass(model.view_fbo.borrow().expect_inner(), false, clear_values)
+        .begin_render_pass(model.view_fbo.borrow().expect_inner(), clear_values)
         .unwrap()
         .draw(
             model.pipeline.clone(),

--- a/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
+++ b/examples/vulkan/vk_quad_warp/vk_quad_warp.rs
@@ -277,7 +277,6 @@ fn view(app: &App, model: &Model, frame: &Frame) {
         .begin_render_pass(
             graphics.framebuffer.clone(),
             //graphics.framebuffers[frame.swapchain_image_index()].clone(),
-            false,
             clear_values,
         )
         .unwrap()

--- a/examples/vulkan/vk_quad_warp/warp.rs
+++ b/examples/vulkan/vk_quad_warp/warp.rs
@@ -158,7 +158,7 @@ pub(crate) fn view(app: &App, model: &Model, inter_image: Arc<vk::AttachmentImag
 
     frame
         .add_commands()
-        .begin_render_pass(warp.view_fbo.borrow().expect_inner(), false, clear_values)
+        .begin_render_pass(warp.view_fbo.borrow().expect_inner(), clear_values)
         .expect("Failed to start render pass")
         .draw(
             warp.pipeline.clone(),

--- a/examples/vulkan/vk_shader_include/mod.rs
+++ b/examples/vulkan/vk_shader_include/mod.rs
@@ -121,7 +121,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
 
     frame
         .add_commands()
-        .begin_render_pass(model.view_fbo.borrow().expect_inner(), false, clear_values)
+        .begin_render_pass(model.view_fbo.borrow().expect_inner(), clear_values)
         .unwrap()
         .draw(
             model.pipeline.clone(),

--- a/examples/vulkan/vk_teapot.rs
+++ b/examples/vulkan/vk_teapot.rs
@@ -210,7 +210,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
     // Submit the draw commands.
     frame
         .add_commands()
-        .begin_render_pass(graphics.view_fbo.expect_inner(), false, clear_values)
+        .begin_render_pass(graphics.view_fbo.expect_inner(), clear_values)
         .unwrap()
         .draw_indexed(
             graphics.graphics_pipeline.clone(),

--- a/examples/vulkan/vk_teapot_camera.rs
+++ b/examples/vulkan/vk_teapot_camera.rs
@@ -340,7 +340,7 @@ fn view(_app: &App, model: &Model, frame: &Frame) {
     // Submit the draw commands.
     frame
         .add_commands()
-        .begin_render_pass(graphics.view_fbo.expect_inner(), false, clear_values)
+        .begin_render_pass(graphics.view_fbo.expect_inner(), clear_values)
         .unwrap()
         .draw_indexed(
             graphics.graphics_pipeline.clone(),

--- a/examples/vulkan/vk_triangle.rs
+++ b/examples/vulkan/vk_triangle.rs
@@ -137,7 +137,7 @@ fn view(_app: &App, model: &Model, frame: &Frame) {
     // Submit the draw commands.
     frame
         .add_commands()
-        .begin_render_pass(model.view_fbo.borrow().expect_inner(), false, clear_values)
+        .begin_render_pass(model.view_fbo.borrow().expect_inner(), clear_values)
         .unwrap()
         .draw(
             model.pipeline.clone(),

--- a/examples/vulkan/vk_triangle_raw_frame.rs
+++ b/examples/vulkan/vk_triangle_raw_frame.rs
@@ -141,7 +141,6 @@ fn view(_app: &App, model: &Model, frame: &RawFrame) {
         .add_commands()
         .begin_render_pass(
             model.framebuffers.borrow()[frame.swapchain_image_index()].clone(),
-            false,
             clear_values,
         )
         .unwrap()

--- a/src/draw/backend/vulkano.rs
+++ b/src/draw/backend/vulkano.rs
@@ -403,7 +403,7 @@ impl Renderer {
         // Submit the draw commands.
         frame
             .add_commands()
-            .begin_render_pass(view_fbo.expect_inner(), false, clear_values)?
+            .begin_render_pass(view_fbo.expect_inner(), clear_values)?
             .draw_indexed(
                 graphics_pipeline.clone(),
                 &dynamic_state,

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -183,11 +183,10 @@ impl Frame {
 
         // Resolve the MSAA if necessary.
         let clear_values = vec![vk::ClearValue::None, vk::ClearValue::None];
-        let is_secondary = false;
         if let Some(fbo) = data.intermediary.resolve_framebuffer.as_ref() {
             raw_frame
                 .add_commands()
-                .begin_render_pass(fbo.clone(), is_secondary, clear_values)?
+                .begin_render_pass(fbo.clone(), clear_values)?
                 .end_render_pass()
                 .expect("failed to add `end_render_pass` command");
         }

--- a/src/frame/raw.rs
+++ b/src/frame/raw.rs
@@ -261,19 +261,14 @@ impl<'a> AddCommands<'a> {
 
     /// Adds a command that enters a render pass.
     ///
-    /// If `secondary` is true, then you will only be able to add secondary command buffers while
-    /// you're inside the first subpass of the render pass. If `secondary` is false, you will only
-    /// be able to add inline draw commands and not secondary command buffers.
-    ///
     /// C must contain exactly one clear value for each attachment in the framebuffer.
     ///
     /// You must call this before you can add draw commands.
     ///
-    /// [*Documentation taken from the corresponding vulkano method.*](https://docs.rs/vulkano/latest/vulkano/command_buffer/struct.AutoCommandBufferBuilder.html)
+    /// [*Documentation adapted from the corresponding vulkano method.*](https://docs.rs/vulkano/latest/vulkano/command_buffer/struct.AutoCommandBufferBuilder.html)
     pub fn begin_render_pass<F, C>(
         self,
         framebuffer: F,
-        secondary: bool,
         clear_values: C,
     ) -> Result<Self, BeginRenderPassError>
     where
@@ -284,15 +279,12 @@ impl<'a> AddCommands<'a> {
             + Sync
             + 'static,
     {
-        self.map_cb(move |cb| cb.begin_render_pass(framebuffer, secondary, clear_values))
+        self.map_cb(move |cb| cb.begin_render_pass(framebuffer, false, clear_values))
     }
 
     /// Adds a command that jumps to the next subpass of the current render pass.
-    pub fn next_subpass(
-        self,
-        secondary: bool,
-    ) -> Result<Self, AutoCommandBufferBuilderContextError> {
-        self.map_cb(move |cb| cb.next_subpass(secondary))
+    pub fn next_subpass(self) -> Result<Self, AutoCommandBufferBuilderContextError> {
+        self.map_cb(move |cb| cb.next_subpass(false))
     }
 
     /// Adds a command that ends the current render pass.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -652,7 +652,7 @@ pub fn draw_primitives(
         let clear_values = vec![color, depth];
         frame
             .add_commands()
-            .begin_render_pass(view_fbo.expect_inner(), false, clear_values.clone())
+            .begin_render_pass(view_fbo.expect_inner(), clear_values.clone())
             .unwrap();
         for cmd in cmds {
             let conrod_vulkano::DrawCommand {


### PR DESCRIPTION
Remove the argument `secondary` from the methods `begin_render_pass()` and `next_subpass()` of the command buffer builder `AddCommands`.
This change is motivated by the fact that `AddCommands` doesn't offer the possibility to use secondary command buffers, which means that `secondary` had to be always set to `false`.