### PR TITLE
Use a separate job for validating docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ matrix:
               - cargo doc --no-deps -v
 
 script:
-    - cargo fmt --all -- --check
+    - |
+      if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+        cargo fmt --all -- --check
+      fi
     - cargo build -v
     - cargo test -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: rust
-before_script:
-- rustup component add rustfmt
 
 addons:
     apt:
@@ -21,6 +19,12 @@ matrix:
           rust: stable
           script:
               - cargo doc --no-deps -v
+
+before_script:
+    - |
+      if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+        rustup component add rustfmt
+      fi
 
 script:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,24 @@ addons:
     apt:
         packages:
             - libasound2-dev
-rust:
-    - nightly
-    - beta
-    - stable
+matrix:
+    include:
+        - name: "Test nightly"
+          rust: nightly
+
+        - name: "Test beta"
+          rust: beta
+
+        - name: "Test stable"
+          rust: stable
+
+        - name: "Validate doc"
+          rust: stable
+          script:
+              - cargo doc --no-deps -v
 
 script:
     - cargo fmt --all -- --check
     - cargo build -v
     - cargo test -v
-    - cargo doc -v
+


### PR DESCRIPTION
(Disclaimer: I'm a very newbie to Rust. I'm sorry if my understanding is wrong...)

Since it seems `cargo doc` is a separate thing from `cargo test`, I think it can be moved to a separate job to reduce the time per job so that it'll be less likely to be timed out.

Besides, I added `--no-deps` option. If I understand correctly, it's not necessary to generate documents for all the dependencies just to test the nannou's doc is correct, right?