### PR TITLE
Update vulkano, conrod and shade_runner. Publish 0.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ addons:
     apt:
         packages:
             - libasound2-dev
+            - libxcb-composite0-dev
 matrix:
     include:
         - name: "Test nightly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Unreleased
 
+# Version 0.12.0 (2019-11-03)
 
+- Update vulkano dependencies to 0.16 in order to address `metal` related bug on
+  macOS.
+- Update conrod dependencies to 0.68 for vulkano patch. New version includes
+  copy/paste, double-click select and shift-click select support for the
+  `TextEdit` widget.
+- [Breaking] Small change to Vulkan debug items.
+- [Breaking] New fields have been added to `DynamicState`.
+- Update shade_runner to 0.3 for vulkano patch.
+- Frame command buffer builder no longer provides access to unrelated
+  `secondary` buffer methods.
 
 # Version 0.11.0 (2019-09-17)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ audrey = "0.2"
 nannou_audio = "0.2"
 nannou_laser = "0.3"
 nannou_osc = "0.1"
-shade_runner = { git = "https://github.com/mitchmindtree/shade_runner", branch = "update_vulkano" }
+shade_runner = "0.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 moltenvk_deps = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"
@@ -16,9 +16,9 @@ default = ["notosans"]
 [dependencies]
 approx = "0.1"
 cgmath = { version = "0.16", features = ["serde"] }
-conrod_core = "0.67"
-conrod_winit = "0.67"
-conrod_vulkano = "0.67"
+conrod_core = "0.68"
+conrod_winit = "0.68"
+conrod_vulkano = "0.68"
 daggy = "0.6"
 find_folder = "0.3"
 image = "0.21"
@@ -33,9 +33,9 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 toml = "0.4"
-vulkano = "0.14"
-vulkano-win = "0.14"
-vulkano-shaders = "0.14"
+vulkano = "0.16"
+vulkano-win = "0.16"
+vulkano-shaders = "0.16"
 walkdir = "2"
 winit = "0.19"
 
@@ -44,7 +44,7 @@ audrey = "0.2"
 nannou_audio = "0.2"
 nannou_laser = "0.3"
 nannou_osc = "0.1"
-shade_runner = "0.2"
+shade_runner = { git = "https://github.com/mitchmindtree/shade_runner", branch = "update_vulkano" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 moltenvk_deps = "0.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -554,7 +554,7 @@ where
 
                 vk_builder
                     .add_extensions(vk::InstanceExtensions {
-                        ext_debug_report: true,
+                        ext_debug_utils: true,
                         ..vk::InstanceExtensions::none()
                     })
                     .layers(vec!["VK_LAYER_LUNARG_standard_validation"])

--- a/src/vk.rs
+++ b/src/vk.rs
@@ -432,7 +432,8 @@ impl DebugCallbackBuilder {
             message_type,
             user_callback,
         } = self;
-        let message_severity = message_severity.unwrap_or_else(MessageSeverity::errors_and_warnings);
+        let message_severity =
+            message_severity.unwrap_or_else(MessageSeverity::errors_and_warnings);
         let message_type = message_type.unwrap_or_else(MessageType::all);
         let user_callback = move |msg: &Message| {
             match user_callback {
@@ -460,7 +461,10 @@ impl DebugCallbackBuilder {
                         "unknown type"
                     };
 
-                    println!("[vulkan] {} {} {}: {}", msg.layer_prefix, ty, sev, msg.description);
+                    println!(
+                        "[vulkan] {} {} {}: {}",
+                        msg.layer_prefix, ty, sev, msg.description
+                    );
                 }
             };
         };


### PR DESCRIPTION
_Currently pending freesig/shade_runner#22 being merged and published._

This one is mostly to address an issue some macOS users have been
running into with an old version of the `metal` crate. Updating conrod
for this also has the nice benefit that the `TextEdit` and `TextBox`
widgets now support copy/paste, double-click-select and
shift-click-select!

Some small sections of the Vulkan API have required some breaking
changes while updating to a later version of the spec, though they are
minor and can be found in the code diff for this commit.

See the CHANGELOG for full note.

Closes #418.