### PR TITLE
Adding grayscale values in Colors

### DIFF
--- a/examples/generative_design/color/p_1_2_1_01.rs
+++ b/examples/generative_design/color/p_1_2_1_01.rs
@@ -126,7 +126,7 @@ fn shake_colors(model: &mut Model) {
     }
 }
 
-fn mouse_released(app: &App, model: &mut Model, _button: MouseButton) {
+fn mouse_released(_app: &App, model: &mut Model, _button: MouseButton) {
     shake_colors(model);
 }
 

--- a/examples/generative_design/color/p_1_2_3_03.rs
+++ b/examples/generative_design/color/p_1_2_3_03.rs
@@ -144,8 +144,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
                 let h = row_height as f32 * 1.5;
 
                 let index = counter % model.color_count;
-                let col1 = hsva(0.0, 0.0, 0.0, 0.0);
-                let col2 = hsva(
+                let col = hsva(
                     model.hue_values[index as usize],
                     model.saturation_values[index as usize],
                     model.brightness_values[index as usize],
@@ -155,7 +154,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
                 draw.rect()
                     .x_y(x + (w / 2.0), y - (h / 2.0))
                     .w_h(w, h)
-                    .color(col2);
+                    .color(col);
 
                 counter += 1;
             }

--- a/examples/generative_design/oscillation_figures/m_2_1_01.rs
+++ b/examples/generative_design/oscillation_figures/m_2_1_01.rs
@@ -109,7 +109,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
         draw.ellipse()
             .x_y(win.left() + 125.0, 0.0)
             .radius(100.0)
-            .stroke(rgb(0.0, 0.0, 0.0))
+            .stroke(gray(0.0))
             .no_fill();
 
         // Lines
@@ -166,13 +166,13 @@ fn view(app: &App, model: &Model, frame: &Frame) {
             .x_y(x_start, phi_y)
             .radius(4.0)
             .color(c)
-            .stroke(rgb(1.0, 1.0, 1.0))
+            .stroke(gray(1.0))
             .stroke_weight(2.0);
         draw.ellipse()
             .x_y(x_start + phi_x, phi_y)
             .radius(4.0)
             .color(c)
-            .stroke(rgb(1.0, 1.0, 1.0))
+            .stroke(gray(1.0))
             .stroke_weight(2.0);
 
         // dot on curve
@@ -180,7 +180,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
             .x_y(x_start + t * model.point_count as f32, model.y)
             .radius(5.0)
             .color(c)
-            .stroke(rgb(1.0, 1.0, 1.0))
+            .stroke(gray(1.0))
             .stroke_weight(2.0);
 
         // dot on circle
@@ -188,7 +188,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
             .x_y(x_start + model.x, model.y)
             .radius(5.0)
             .color(c)
-            .stroke(rgb(1.0, 1.0, 1.0))
+            .stroke(gray(1.0))
             .stroke_weight(2.0);
     }
 

--- a/examples/generative_design/oscillation_figures/m_2_2_01.rs
+++ b/examples/generative_design/oscillation_figures/m_2_2_01.rs
@@ -172,20 +172,20 @@ fn view(app: &App, model: &Model, frame: &Frame) {
         draw.ellipse()
             .x_y(xs + model.x, ys - osc_xy)
             .radius(4.0)
-            .stroke(rgb(1.0, 1.0, 1.0))
+            .stroke(gray(1.0))
             .stroke_weight(2.0)
             .color(c);
         draw.ellipse()
             .x_y(xs + osc_yx, ys - model.y)
             .radius(4.0)
-            .stroke(rgb(1.0, 1.0, 1.0))
+            .stroke(gray(1.0))
             .stroke_weight(2.0)
             .color(c);
 
         draw.ellipse()
             .x_y(xs + model.x, ys - model.y)
             .radius(5.0)
-            .stroke(rgb(1.0, 1.0, 1.0))
+            .stroke(gray(1.0))
             .stroke_weight(2.0)
             .color(c);
     }

--- a/examples/nature_of_code/chp_01_vectors/1_10_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_10_motion101_acceleration.rs
@@ -52,7 +52,7 @@ impl Mover {
         draw.ellipse()
             .xy(self.position)
             .w_h(48.0, 48.0)
-            .rgb(0.5, 0.5, 0.5)
+            .gray(0.5)
             .stroke(BLACK)
             .stroke_weight(2.0);
     }

--- a/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors.rs
@@ -52,7 +52,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
     draw.ellipse()
         .x_y(model.position.x, model.position.y)
         .w_h(16.0, 16.0)
-        .rgb(0.5, 0.5, 0.5)
+        .gray(0.5)
         .stroke(BLACK);
 
     // Write the result of our drawing to the window's frame.

--- a/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors_object.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors_object.rs
@@ -42,7 +42,7 @@ impl Ball {
         draw.ellipse()
             .xy(self.position)
             .w_h(16.0, 16.0)
-            .rgb(0.5, 0.5, 0.5)
+            .gray(0.5)
             .stroke(BLACK);
     }
 }

--- a/examples/nature_of_code/chp_01_vectors/1_7_motion101.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_7_motion101.rs
@@ -51,8 +51,8 @@ impl Mover {
         draw.ellipse()
             .xy(self.position)
             .w_h(48.0, 48.0)
-            .rgb(0.5, 0.5, 0.5)
-            .stroke(rgb(0.0, 0.0, 0.0));
+            .gray(0.5)
+            .stroke(gray(0.0));
     }
 }
 

--- a/examples/nature_of_code/chp_01_vectors/1_8_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_8_motion101_acceleration.rs
@@ -61,7 +61,7 @@ impl Mover {
         draw.ellipse()
             .xy(self.position)
             .w_h(48.0, 48.0)
-            .rgb(0.5, 0.5, 0.5)
+            .gray(0.5)
             .stroke(BLACK)
             .stroke_weight(2.0);
     }

--- a/examples/nature_of_code/chp_01_vectors/1_9_motion101_acceleration.rs
+++ b/examples/nature_of_code/chp_01_vectors/1_9_motion101_acceleration.rs
@@ -63,7 +63,7 @@ impl Mover {
         draw.ellipse()
             .xy(self.position)
             .w_h(48.0, 48.0)
-            .rgb(0.5, 0.5, 0.5)
+            .gray(0.5)
             .stroke(BLACK)
             .stroke_weight(2.0);
     }

--- a/examples/nature_of_code/chp_02_forces/2_10_exercise_attract_repel.rs
+++ b/examples/nature_of_code/chp_02_forces/2_10_exercise_attract_repel.rs
@@ -66,7 +66,7 @@ impl Attractor {
         draw.ellipse()
             .xy(self.position)
             .w_h(self.radius * 2.0, self.radius * 2.0)
-            .rgb(gray, gray, gray);
+            .gray(gray);
     }
 
     // The methods below are for mouse interaction

--- a/examples/nature_of_code/chp_02_forces/2_1_forces.rs
+++ b/examples/nature_of_code/chp_02_forces/2_1_forces.rs
@@ -64,7 +64,7 @@ impl Mover {
         draw.ellipse()
             .xy(self.position)
             .w_h(48.0, 48.0)
-            .rgb(0.3, 0.3, 0.3)
+            .gray(0.3)
             .stroke(BLACK)
             .stroke_weight(2.0);
     }

--- a/examples/nature_of_code/chp_02_forces/2_5_fluid_resistance.rs
+++ b/examples/nature_of_code/chp_02_forces/2_5_fluid_resistance.rs
@@ -62,10 +62,7 @@ impl Liquid {
     }
 
     fn display(&self, draw: &app::Draw) {
-        draw.rect()
-            .xy(self.rect.xy())
-            .wh(self.rect.wh())
-            .rgb(0.1, 0.1, 0.1);
+        draw.rect().xy(self.rect.xy()).wh(self.rect.wh()).gray(0.1);
     }
 }
 

--- a/examples/nature_of_code/chp_02_forces/2_6_attraction.rs
+++ b/examples/nature_of_code/chp_02_forces/2_6_attraction.rs
@@ -133,7 +133,7 @@ impl Mover {
         draw.ellipse()
             .xy(self.position)
             .w_h(16.0, 16.0)
-            .rgb(0.3, 0.3, 0.3)
+            .gray(0.3)
             .stroke(BLACK)
             .stroke_weight(2.0);
     }

--- a/examples/nature_of_code/chp_03_oscillation/3_02_forces_angular_motion.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_02_forces_angular_motion.rs
@@ -38,7 +38,7 @@ impl Attractor {
         draw.ellipse()
             .x_y(self.location.x, self.location.y)
             .w_h(48.0, 48.0)
-            .rgb(0.5, 0.5, 0.5)
+            .gray(0.5)
             .stroke(BLACK)
             .stroke_weight(2.0);
     }

--- a/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian.rs
@@ -51,7 +51,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
     draw.ellipse()
         .x_y(x, y)
         .w_h(48.0, 48.0)
-        .rgb(0.5, 0.5, 0.5)
+        .gray(0.5)
         .stroke(BLACK)
         .stroke_weight(2.0);
 

--- a/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian_trail.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian_trail.rs
@@ -54,7 +54,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
     draw.ellipse()
         .x_y(x, y)
         .w_h(48.0, 48.0)
-        .rgb(0.5, 0.5, 0.5)
+        .gray(0.5)
         .stroke(BLACK)
         .stroke_weight(2.0);
 

--- a/examples/nature_of_code/chp_03_oscillation/3_extra_oscillating_up_and_down.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_extra_oscillating_up_and_down.rs
@@ -41,7 +41,7 @@ fn view(app: &App, model: &Model, frame: &Frame) {
     draw.ellipse()
         .x_y(0.0, y)
         .w_h(16.0, 16.0)
-        .rgb(0.4, 0.4, 0.4)
+        .gray(0.4)
         .stroke(BLACK);
 
     // Write the result of our drawing to the window's frame.

--- a/examples/nature_of_code/chp_03_oscillation/3_oop_wave_particles.rs
+++ b/examples/nature_of_code/chp_03_oscillation/3_oop_wave_particles.rs
@@ -44,7 +44,7 @@ impl Particle {
         draw.ellipse()
             .xy(self.position)
             .w_h(16.0, 16.0)
-            .rgb(random_color, random_color, random_color)
+            .gray(random_color)
             .stroke(BLACK);
     }
 }

--- a/examples/nature_of_code/chp_04_systems/4_02_vector_particle.rs
+++ b/examples/nature_of_code/chp_04_systems/4_02_vector_particle.rs
@@ -44,7 +44,6 @@ impl Particle {
 
     // Method to display
     fn display(&self, draw: &app::Draw) {
-        let size = 5.0 + (255.0 - self.life_span) * 0.13;
         draw.ellipse()
             .xy(self.position)
             .w_h(12.0, 12.0)

--- a/examples/nature_of_code/chp_06_agents/6_01_seek.rs
+++ b/examples/nature_of_code/chp_06_agents/6_01_seek.rs
@@ -92,7 +92,7 @@ fn view(app: &App, m: &Model, frame: &Frame) {
         .x_y(mouse.x, mouse.y)
         .radius(48.0)
         .rgb(0.78, 0.78, 0.78)
-        .stroke(rgb(0.0, 0.0, 0.0))
+        .stroke(gray(0.0))
         .stroke_weight(2.0);
 
     display(&m.vehicle, &draw);

--- a/examples/nature_of_code/chp_06_agents/6_02_arrive.rs
+++ b/examples/nature_of_code/chp_06_agents/6_02_arrive.rs
@@ -89,7 +89,7 @@ fn view(app: &App, m: &Model, frame: &Frame) {
         .x_y(mouse.x, mouse.y)
         .radius(24.0)
         .rgb(0.78, 0.78, 0.78)
-        .stroke(rgb(0.0, 0.0, 0.0))
+        .stroke(gray(0.0))
         .stroke_weight(2.0);
 
     display(&m.vehicle, &draw);

--- a/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_figures.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_figures.rs
@@ -94,7 +94,7 @@ impl Ca {
                     rect.top() as f32 - (self.generation * self.scl - (self.scl / 2)) as f32,
                 )
                 .w_h(self.scl as f32, self.scl as f32)
-                .rgb(fill, fill, fill)
+                .gray(fill)
                 .stroke(BLACK);
         }
     }

--- a/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_simple.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_simple.rs
@@ -71,7 +71,7 @@ impl Ca {
                     rect.top() as f32 - (self.generation * self.w - (self.w / 2)) as f32,
                 )
                 .w_h(self.w as f32, self.w as f32)
-                .rgb(fill, fill, fill);
+                .gray(fill);
         }
     }
 

--- a/examples/nature_of_code/chp_07_cellular_automata/7_02_game_of_life_simple.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_02_game_of_life_simple.rs
@@ -118,7 +118,7 @@ impl Gol {
                         offset + (j * self.w) as f32 - rect.top() as f32,
                     )
                     .w_h(self.w as f32, self.w as f32)
-                    .rgb(fill, fill, fill)
+                    .gray(fill)
                     .stroke(BLACK);
             }
         }

--- a/examples/nature_of_code/chp_07_cellular_automata/7_03_game_of_life_oop.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_03_game_of_life_oop.rs
@@ -41,11 +41,11 @@ impl Cell {
         let fill = if self.previous == 0 && self.state == 1 {
             rgb(0.0, 0.0, 1.0)
         } else if self.state == 1 {
-            rgb(0.0, 0.0, 0.0)
+            gray(0.0)
         } else if self.previous == 1 && self.state == 0 {
             rgb(1.0, 0.0, 0.0)
         } else {
-            rgb(1.0, 1.0, 1.0)
+            gray(1.0)
         };
         draw.rect()
             .x_y(x, y)

--- a/examples/nature_of_code/chp_07_cellular_automata/7_04_exercise_wolfram_ca_scrolling.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_04_exercise_wolfram_ca_scrolling.rs
@@ -101,7 +101,7 @@ impl Ca {
                 draw.rect()
                     .x_y(x, y)
                     .w_h(self.w as f32, self.w as f32)
-                    .rgb(fill, fill, fill);
+                    .gray(fill);
             }
         }
     }

--- a/examples/nature_of_code/chp_07_cellular_automata/7_game_of_life_wrap_around.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_game_of_life_wrap_around.rs
@@ -103,7 +103,7 @@ impl Gol {
                         offset + (j * self.w) as f32 - rect.top() as f32,
                     )
                     .w_h(self.w as f32, self.w as f32)
-                    .rgb(fill, fill, fill)
+                    .gray(fill)
                     .stroke(BLACK);
             }
         }

--- a/examples/nature_of_code/chp_07_cellular_automata/7_game_of_life_wrap_around.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_game_of_life_wrap_around.rs
@@ -12,7 +12,6 @@
 // Cells wrap around
 
 use nannou::prelude::*;
-use std::ops::Range;
 
 fn main() {
     nannou::app(model).update(update).run();

--- a/examples/nature_of_code/chp_07_cellular_automata/7_hexagon_cells.rs
+++ b/examples/nature_of_code/chp_07_cellular_automata/7_hexagon_cells.rs
@@ -27,9 +27,9 @@ impl Cell {
 
     fn display(&self, draw: &app::Draw, rect: &Rect) {
         let fill = if self.state == 1 {
-            rgb(0.0, 0.0, 0.0)
+            gray(0.0)
         } else {
-            rgb(1.0, 1.0, 1.0)
+            gray(1.0)
         };
 
         let n_points = 6;

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -29,6 +29,14 @@ pub type Rgb<S = DefaultScalar> = Srgb<S>;
 /// the `palette` crate's generic `Rgb` type.
 pub type Rgba<S = DefaultScalar> = Srgba<S>;
 
+/// A color represented as gray intensity.
+///
+/// This type is an alias for the `Srgb` type, a type that represents the sRGB color space.
+///
+/// If you are looking for more advanced control over the RGB space and component type, please see
+/// the `palette` crate's generic `Rgb` type.
+pub type Gray<S = DefaultScalar> = Srgb<S>;
+
 /// A short-hand constructor for `Rgb::new`.
 pub fn rgb<T>(r: T, g: T, b: T) -> Rgb<T>
 where
@@ -107,4 +115,12 @@ pub fn hsv(h: f32, s: f32, v: f32) -> Hsv {
 /// 360 degrees (or 2 PI radians).
 pub fn hsva(h: f32, s: f32, v: f32, a: f32) -> Hsva {
     Hsva::new(RgbHue::from_degrees(h * 360.0), s, v, a)
+}
+
+/// A short-hand constructor for `Gray::new`.
+pub fn gray<T>(g: T) -> Gray<T>
+where
+    T: Component,
+{
+    srgb(g, g, g)
 }

--- a/src/draw/drawing.rs
+++ b/src/draw/drawing.rs
@@ -312,6 +312,13 @@ where
     pub fn hsva(self, h: ColorScalar, s: ColorScalar, v: ColorScalar, a: ColorScalar) -> Self {
         self.map_ty(|ty| SetColor::hsva(ty, h, s, v, a))
     }
+
+    /// Specify the color as gray scale
+    ///
+    /// The given g expects a value between `0.0` and `1.0` where `0.0` is black and `1.0` is white
+    pub fn gray(self, g: ColorScalar) -> Self {
+        self.map_ty(|ty| SetColor::gray(ty, g))
+    }
 }
 
 // SetDimensions implementations.

--- a/src/draw/properties/color.rs
+++ b/src/draw/properties/color.rs
@@ -113,6 +113,17 @@ where
         let hue = color::RgbHue::from_degrees(h * S::from(360.0).unwrap());
         self.color(color::Hsva::new(hue, s, v, a))
     }
+
+    /// Specify the color as gray scale
+    ///
+    /// The given g expects a value between `0.0` and `1.0` where `0.0` is black and `1.0` is white
+    fn gray<T>(self, g: T) -> Self
+    where
+        T: Component,
+        S: Float,
+    {
+        self.color(color::Srgb::new(g, g, g))
+    }
 }
 
 impl<S> SetColor<S> for Option<LinSrgba<S>>

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,8 +2,8 @@
 
 pub use crate::app::{self, App, LoopMode};
 pub use crate::color::named::*;
-pub use crate::color::{hsl, hsla, hsv, hsva, lin_srgb, lin_srgba, rgb, rgba, srgb, srgba, gray};
-pub use crate::color::{Hsl, Hsla, Hsv, Hsva, LinSrgb, LinSrgba, Rgb, Rgba, Srgb, Srgba, Gray};
+pub use crate::color::{gray, hsl, hsla, hsv, hsva, lin_srgb, lin_srgba, rgb, rgba, srgb, srgba};
+pub use crate::color::{Gray, Hsl, Hsla, Hsv, Hsva, LinSrgb, LinSrgba, Rgb, Rgba, Srgb, Srgba};
 pub use crate::event::WindowEvent::*;
 pub use crate::event::{
     AxisMotion, Event, Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,8 +2,8 @@
 
 pub use crate::app::{self, App, LoopMode};
 pub use crate::color::named::*;
-pub use crate::color::{hsl, hsla, hsv, hsva, lin_srgb, lin_srgba, rgb, rgba, srgb, srgba};
-pub use crate::color::{Hsl, Hsla, Hsv, Hsva, LinSrgb, LinSrgba, Rgb, Rgba, Srgb, Srgba};
+pub use crate::color::{hsl, hsla, hsv, hsva, lin_srgb, lin_srgba, rgb, rgba, srgb, srgba, gray};
+pub use crate::color::{Hsl, Hsla, Hsv, Hsva, LinSrgb, LinSrgba, Rgb, Rgba, Srgb, Srgba, Gray};
 pub use crate::event::WindowEvent::*;
 pub use crate::event::{
     AxisMotion, Event, Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase,


### PR DESCRIPTION
Also changing all the example to use grayscale instead of rgb (when they use the same 3 values).
Fixing the warning we get when compiling the project (only with cargo build, cargo clippy still gives a lot of warnings).

closes #84