### PR TITLE
Fix simple audio example

### DIFF
--- a/examples/simple_audio.rs
+++ b/examples/simple_audio.rs
@@ -68,7 +68,13 @@ fn key_pressed(_app: &App, model: &mut Model, key: Key) {
             model
                 .stream
                 .send(|audio| {
-                    audio.hz += 10.0;
+                    // * avoid wrap-around / overflow
+                    // * 28kHz upper boundary for hearing according to https://asa.scitation.org/doi/full/10.1121/1.2761883
+                    if audio.hz > 28000.0 {
+                        audio.hz = 28000.0;
+                    } else {
+                        audio.hz += 10.0;
+                    }
                 })
                 .unwrap();
         }

--- a/examples/simple_audio.rs
+++ b/examples/simple_audio.rs
@@ -77,7 +77,12 @@ fn key_pressed(_app: &App, model: &mut Model, key: Key) {
             model
                 .stream
                 .send(|audio| {
-                    audio.hz -= 10.0;
+                    // avoid wrap-around / underflow
+                    if audio.hz != 0.0 {
+                        audio.hz -= 10.0;
+                    } else {
+                        audio.hz = 0.0;
+                    }
                 })
                 .unwrap();
         }


### PR DESCRIPTION
Hi there,

I adjusted the simple audio example to not underrun (only pressing down results in a frequency increase at some point) or overrun (since f64 is way larger than the human hearing range).

Cheers,
tpltnt