### PR TITLE
[nannou-new] Fix build with 2018 edition

### DIFF
--- a/nannou-new/Cargo.toml
+++ b/nannou-new/Cargo.toml
@@ -8,8 +8,9 @@ keywords = ["tool", "build", "nannou", "creative", "sketch"]
 license = "MIT"
 repository = "https://github.com/nannou-org/nannou.git"
 homepage = "https://github.com/nannou-org/nannou/tree/master/nannou-new"
+edition = "2018"
 
 [dependencies]
-cargo = "0.28" # For retrieving the latest `nannou` version and working with cargo-clone.
+cargo = "0.42" # For retrieving the latest `nannou` version and working with cargo-clone.
 names = "0.11" # For generating random project names.
-rand = "0.4" # For generating random beverages (very important).
+rand = "0.7" # For generating random beverages (very important).


### PR DESCRIPTION
I was looking into #448 so I tried to build the `nannou-new` binary but it is failing because of the 2018 edition changes, it can't find the `cargo` crate.

### Changes

- set the edition to 2018 in the _Cargo.toml_ file.
  This is the required change to fix the build
- update dependencies and make the required changes
- fix issue with downloading a random version of the `nannou` package
  I didn't investigate if this happens with the previous cargo version, but in the 0.42 the `query` method doesn't yield a package summary in any order, so the last one that is downloaded could be any version.