### PR TITLE
Fix `app.project_dir()`, rename to `app.project_path()`

### DIFF
--- a/examples/capture_hi_res.rs
+++ b/examples/capture_hi_res.rs
@@ -194,5 +194,7 @@ fn exit(_app: &App, model: Model) {
 
 // The directory where we'll save the frames.
 fn capture_directory(app: &App) -> std::path::PathBuf {
-    app.project_dir().join(app.exe_name().unwrap())
+    app.project_path()
+        .expect("could not locate project_path")
+        .join(app.exe_name().unwrap())
 }

--- a/examples/simple_capture.rs
+++ b/examples/simple_capture.rs
@@ -41,19 +41,22 @@ fn view(app: &App, frame: Frame) {
 
     draw.to_frame(app, &frame).unwrap();
 
+    // Capture the frame!
+    //
+    // NOTE: You can speed this up with `capture_frame_threaded`, however be aware that if the
+    // image writing threads can't keep up you may quickly begin to run out of RAM!
+    let file_path = captured_frame_path(app, &frame);
+    app.main_window().capture_frame(file_path);
+}
+
+fn captured_frame_path(app: &App, frame: &Frame) -> std::path::PathBuf {
     // Create a path that we want to save this frame to.
-    let file_path = app
-        .project_dir()
+    app.project_path()
+        .expect("failed to locate `project_path`")
         // Capture all frames to a directory called `/<path_to_nannou>/nannou/simple_capture`.
         .join(app.exe_name().unwrap())
         // Name each file after the number of the frame.
         .join(frame.nth().to_string())
         // The extension will be PNG. We also support tiff, bmp, gif, jpeg, webp and some others.
-        .with_extension("png");
-
-    // Capture the frame!
-    //
-    // NOTE: You can speed this up with `capture_frame_threaded`, however be aware that if the
-    // image writing threads can't keep up you may quickly begin to run out of RAM!
-    app.main_window().capture_frame(file_path);
+        .with_extension("png")
 }


### PR DESCRIPTION
This fixes a bug where the `app.project_dir()` method would return the
path to the nannou build dependency directory rather than the actual
project directory. This PR fixes this issue.

Renames `project_dir` to `project_path` in order to match the
`assets_path` convention.