### PR TITLE
Publish 0.13.1 to include essential texture methods missing from 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"


### PR DESCRIPTION
Without these methods, it's significantly more difficult to use a
texture as an image within a nannou `Ui`. I didn't pick up on this until
trying to update the [spatial audio server](https://github.com/museumsvictoria/spatial_audio_server)