### PR TITLE
Add a suite of builder types to simplify bind group and pipeline creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Add `RenderPipelineBuilder`.
+- Add `BindGroupLayoutBuilder`.
+- Add `BindGroupBuilder`.
+- Add `RenderPassBuilder`.
 
 # Version 0.13.1 (2020-03-05)
 

--- a/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
+++ b/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
@@ -202,22 +202,17 @@ fn create_uniforms(time: f32, mouse_x: f32, win_rect: geom::Rect) -> Uniforms {
 }
 
 fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    let oscillator_buffer_binding = wgpu::BindGroupLayoutBinding {
-        binding: 0,
-        visibility: wgpu::ShaderStage::COMPUTE,
-        ty: wgpu::BindingType::StorageBuffer {
-            dynamic: false,
-            readonly: false,
-        },
-    };
-    let uniforms_binding = wgpu::BindGroupLayoutBinding {
-        binding: 1,
-        visibility: wgpu::ShaderStage::COMPUTE,
-        ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-    };
-    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-        bindings: &[oscillator_buffer_binding, uniforms_binding],
-    })
+    let storage_dynamic = false;
+    let storage_readonly = false;
+    let uniform_dynamic = false;
+    wgpu::BindGroupLayoutBuilder::new()
+        .storage_buffer(
+            wgpu::ShaderStage::COMPUTE,
+            storage_dynamic,
+            storage_readonly,
+        )
+        .uniform_buffer(wgpu::ShaderStage::COMPUTE, uniform_dynamic)
+        .build(device)
 }
 
 fn create_bind_group(

--- a/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
+++ b/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
@@ -222,22 +222,10 @@ fn create_bind_group(
     oscillator_buffer_size: wgpu::BufferAddress,
     uniform_buffer: &wgpu::Buffer,
 ) -> wgpu::BindGroup {
-    let oscillator_buffer_binding = wgpu::Binding {
-        binding: 0,
-        resource: wgpu::BindingResource::Buffer {
-            buffer: &oscillator_buffer,
-            range: 0..oscillator_buffer_size,
-        },
-    };
-    let uniforms_binding = wgpu::Binding {
-        binding: 1,
-        resource: wgpu::BindingResource::Buffer {
-            buffer: &uniform_buffer,
-            range: 0..std::mem::size_of::<Uniforms>() as wgpu::BufferAddress,
-        },
-    };
-    let bindings = &[oscillator_buffer_binding, uniforms_binding];
-    device.create_bind_group(&wgpu::BindGroupDescriptor { layout, bindings })
+    wgpu::BindGroupBuilder::new()
+        .buffer_bytes(oscillator_buffer, 0..oscillator_buffer_size)
+        .buffer::<Uniforms>(uniform_buffer, 0..1)
+        .build(device, layout)
 }
 
 fn create_pipeline_layout(

--- a/examples/wgpu/wgpu_image/wgpu_image.rs
+++ b/examples/wgpu/wgpu_image/wgpu_image.rs
@@ -149,17 +149,10 @@ fn create_bind_group(
     texture: &wgpu::TextureView,
     sampler: &wgpu::Sampler,
 ) -> wgpu::BindGroup {
-    let texture_binding = wgpu::Binding {
-        binding: 0,
-        resource: wgpu::BindingResource::TextureView(&texture),
-    };
-    let sampler_binding = wgpu::Binding {
-        binding: 1,
-        resource: wgpu::BindingResource::Sampler(&sampler),
-    };
-    let bindings = &[texture_binding, sampler_binding];
-    let desc = wgpu::BindGroupDescriptor { layout, bindings };
-    device.create_bind_group(&desc)
+    wgpu::BindGroupBuilder::new()
+        .texture_view(texture)
+        .sampler(sampler)
+        .build(device, layout)
 }
 
 fn create_pipeline_layout(

--- a/examples/wgpu/wgpu_image/wgpu_image.rs
+++ b/examples/wgpu/wgpu_image/wgpu_image.rs
@@ -110,23 +110,12 @@ fn model(app: &App) -> Model {
 
 fn view(_app: &App, model: &Model, frame: Frame) {
     let mut encoder = frame.command_encoder();
-
-    let render_pass_desc = wgpu::RenderPassDescriptor {
-        color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
-            attachment: frame.texture_view(),
-            resolve_target: None,
-            load_op: wgpu::LoadOp::Clear,
-            store_op: wgpu::StoreOp::Store,
-            clear_color: wgpu::Color::TRANSPARENT,
-        }],
-        depth_stencil_attachment: None,
-    };
-
-    let mut render_pass = encoder.begin_render_pass(&render_pass_desc);
+    let mut render_pass = wgpu::RenderPassBuilder::new()
+        .color_attachment(frame.texture_view(), |color| color)
+        .begin(&mut encoder);
     render_pass.set_bind_group(0, &model.bind_group, &[]);
     render_pass.set_pipeline(&model.render_pipeline);
     render_pass.set_vertex_buffers(0, &[(&model.vertex_buffer, 0)]);
-
     let vertex_range = 0..VERTICES.len() as u32;
     let instance_range = 0..1;
     render_pass.draw(vertex_range, instance_range);

--- a/examples/wgpu/wgpu_image/wgpu_image.rs
+++ b/examples/wgpu/wgpu_image/wgpu_image.rs
@@ -133,22 +133,14 @@ fn view(_app: &App, model: &Model, frame: Frame) {
 }
 
 fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    let texture_binding = wgpu::BindGroupLayoutBinding {
-        binding: 0,
-        visibility: wgpu::ShaderStage::FRAGMENT,
-        ty: wgpu::BindingType::SampledTexture {
-            multisampled: false,
-            dimension: wgpu::TextureViewDimension::D2,
-        },
-    };
-    let sampler_binding = wgpu::BindGroupLayoutBinding {
-        binding: 1,
-        visibility: wgpu::ShaderStage::FRAGMENT,
-        ty: wgpu::BindingType::Sampler,
-    };
-    let bindings = &[texture_binding, sampler_binding];
-    let desc = wgpu::BindGroupLayoutDescriptor { bindings };
-    device.create_bind_group_layout(&desc)
+    wgpu::BindGroupLayoutBuilder::new()
+        .sampled_texture(
+            wgpu::ShaderStage::FRAGMENT,
+            false,
+            wgpu::TextureViewDimension::D2,
+        )
+        .sampler(wgpu::ShaderStage::FRAGMENT)
+        .build(device)
 }
 
 fn create_bind_group(

--- a/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
+++ b/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
@@ -175,23 +175,12 @@ fn update(app: &App, model: &mut Model, update: Update) {
 
 fn view(_app: &App, model: &Model, frame: Frame) {
     let mut encoder = frame.command_encoder();
-
-    let render_pass_desc = wgpu::RenderPassDescriptor {
-        color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
-            attachment: frame.texture_view(),
-            resolve_target: None,
-            load_op: wgpu::LoadOp::Clear,
-            store_op: wgpu::StoreOp::Store,
-            clear_color: wgpu::Color::TRANSPARENT,
-        }],
-        depth_stencil_attachment: None,
-    };
-
-    let mut render_pass = encoder.begin_render_pass(&render_pass_desc);
+    let mut render_pass = wgpu::RenderPassBuilder::new()
+        .color_attachment(frame.texture_view(), |color| color)
+        .begin(&mut encoder);
     render_pass.set_bind_group(0, &model.bind_group, &[]);
     render_pass.set_pipeline(&model.render_pipeline);
     render_pass.set_vertex_buffers(0, &[(&model.vertex_buffer, 0)]);
-
     let vertex_range = 0..VERTICES.len() as u32;
     let instance_range = 0..1;
     render_pass.draw(vertex_range, instance_range);

--- a/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
+++ b/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
@@ -237,17 +237,10 @@ fn create_bind_group(
     texture: &wgpu::TextureView,
     sampler: &wgpu::Sampler,
 ) -> wgpu::BindGroup {
-    let texture_binding = wgpu::Binding {
-        binding: 0,
-        resource: wgpu::BindingResource::TextureView(&texture),
-    };
-    let sampler_binding = wgpu::Binding {
-        binding: 1,
-        resource: wgpu::BindingResource::Sampler(&sampler),
-    };
-    let bindings = &[texture_binding, sampler_binding];
-    let desc = wgpu::BindGroupDescriptor { layout, bindings };
-    device.create_bind_group(&desc)
+    wgpu::BindGroupBuilder::new()
+        .texture_view(texture)
+        .sampler(sampler)
+        .build(device, layout)
 }
 
 fn create_pipeline_layout(

--- a/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
+++ b/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
@@ -47,6 +47,16 @@ const VERTICES: [Vertex; 4] = [
     },
 ];
 
+impl wgpu::VertexDescriptor for Vertex {
+    const STRIDE: wgpu::BufferAddress = std::mem::size_of::<Vertex>() as _;
+    const ATTRIBUTES: &'static [wgpu::VertexAttributeDescriptor] =
+        &[wgpu::VertexAttributeDescriptor {
+            format: wgpu::VertexFormat::Float2,
+            offset: 0,
+            shader_location: 0,
+        }];
+}
+
 fn main() {
     nannou::app(model).update(update).run();
 }
@@ -264,14 +274,6 @@ fn create_pipeline_layout(
     device.create_pipeline_layout(&desc)
 }
 
-fn vertex_attrs() -> [wgpu::VertexAttributeDescriptor; 1] {
-    [wgpu::VertexAttributeDescriptor {
-        format: wgpu::VertexFormat::Float2,
-        offset: 0,
-        shader_location: 0,
-    }]
-}
-
 fn create_render_pipeline(
     device: &wgpu::Device,
     layout: &wgpu::PipelineLayout,
@@ -280,46 +282,11 @@ fn create_render_pipeline(
     dst_format: wgpu::TextureFormat,
     sample_count: u32,
 ) -> wgpu::RenderPipeline {
-    let vs_desc = wgpu::ProgrammableStageDescriptor {
-        module: &vs_mod,
-        entry_point: "main",
-    };
-    let fs_desc = wgpu::ProgrammableStageDescriptor {
-        module: &fs_mod,
-        entry_point: "main",
-    };
-    let raster_desc = wgpu::RasterizationStateDescriptor {
-        front_face: wgpu::FrontFace::Ccw,
-        cull_mode: wgpu::CullMode::None,
-        depth_bias: 0,
-        depth_bias_slope_scale: 0.0,
-        depth_bias_clamp: 0.0,
-    };
-    let color_state_desc = wgpu::ColorStateDescriptor {
-        format: dst_format,
-        color_blend: wgpu::BlendDescriptor::REPLACE,
-        alpha_blend: wgpu::BlendDescriptor::REPLACE,
-        write_mask: wgpu::ColorWrite::ALL,
-    };
-    let vertex_attrs = vertex_attrs();
-    let vertex_buffer_desc = wgpu::VertexBufferDescriptor {
-        stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
-        step_mode: wgpu::InputStepMode::Vertex,
-        attributes: &vertex_attrs[..],
-    };
-    let desc = wgpu::RenderPipelineDescriptor {
-        layout,
-        vertex_stage: vs_desc,
-        fragment_stage: Some(fs_desc),
-        rasterization_state: Some(raster_desc),
-        primitive_topology: wgpu::PrimitiveTopology::TriangleStrip,
-        color_states: &[color_state_desc],
-        depth_stencil_state: None,
-        index_format: wgpu::IndexFormat::Uint16,
-        vertex_buffers: &[vertex_buffer_desc],
-        sample_count,
-        sample_mask: !0,
-        alpha_to_coverage_enabled: false,
-    };
-    device.create_render_pipeline(&desc)
+    wgpu::RenderPipelineBuilder::from_layout(layout, vs_mod)
+        .fragment_shader(fs_mod)
+        .color_format(dst_format)
+        .add_vertex_buffer::<Vertex>()
+        .sample_count(sample_count)
+        .primitive_topology(wgpu::PrimitiveTopology::TriangleStrip)
+        .build(device)
 }

--- a/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
+++ b/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
@@ -224,14 +224,9 @@ fn create_depth_texture(
 }
 
 fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    let uniforms_binding = wgpu::BindGroupLayoutBinding {
-        binding: 0,
-        visibility: wgpu::ShaderStage::VERTEX,
-        ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-    };
-    let bindings = &[uniforms_binding];
-    let desc = wgpu::BindGroupLayoutDescriptor { bindings };
-    device.create_bind_group_layout(&desc)
+    wgpu::BindGroupLayoutBuilder::new()
+        .uniform_buffer(wgpu::ShaderStage::VERTEX, false)
+        .build(device)
 }
 
 fn create_bind_group(

--- a/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
+++ b/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
@@ -42,6 +42,26 @@ pub struct Uniforms {
 
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 
+impl wgpu::VertexDescriptor for Vertex {
+    const STRIDE: wgpu::BufferAddress = std::mem::size_of::<Vertex>() as _;
+    const ATTRIBUTES: &'static [wgpu::VertexAttributeDescriptor] =
+        &[wgpu::VertexAttributeDescriptor {
+            format: wgpu::VertexFormat::Float3,
+            offset: 0,
+            shader_location: 0,
+        }];
+}
+
+impl wgpu::VertexDescriptor for Normal {
+    const STRIDE: wgpu::BufferAddress = std::mem::size_of::<Normal>() as _;
+    const ATTRIBUTES: &'static [wgpu::VertexAttributeDescriptor] =
+        &[wgpu::VertexAttributeDescriptor {
+            format: wgpu::VertexFormat::Float3,
+            offset: 0,
+            shader_location: 1,
+        }];
+}
+
 fn main() {
     nannou::app(model).run();
 }
@@ -241,36 +261,6 @@ fn create_pipeline_layout(
     device.create_pipeline_layout(&desc)
 }
 
-fn vertex_attrs() -> [wgpu::VertexAttributeDescriptor; 1] {
-    [wgpu::VertexAttributeDescriptor {
-        format: wgpu::VertexFormat::Float3,
-        offset: 0,
-        shader_location: 0,
-    }]
-}
-
-fn normal_attrs() -> [wgpu::VertexAttributeDescriptor; 1] {
-    [wgpu::VertexAttributeDescriptor {
-        format: wgpu::VertexFormat::Float3,
-        offset: 0,
-        shader_location: 1,
-    }]
-}
-
-fn depth_stencil_state_descriptor(
-    format: wgpu::TextureFormat,
-) -> wgpu::DepthStencilStateDescriptor {
-    wgpu::DepthStencilStateDescriptor {
-        format: format,
-        depth_write_enabled: true,
-        depth_compare: wgpu::CompareFunction::LessEqual,
-        stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
-        stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
-        stencil_read_mask: 0,
-        stencil_write_mask: 0,
-    }
-}
-
 fn create_render_pipeline(
     device: &wgpu::Device,
     layout: &wgpu::PipelineLayout,
@@ -280,53 +270,15 @@ fn create_render_pipeline(
     depth_format: wgpu::TextureFormat,
     sample_count: u32,
 ) -> wgpu::RenderPipeline {
-    let vs_desc = wgpu::ProgrammableStageDescriptor {
-        module: &vs_mod,
-        entry_point: "main",
-    };
-    let fs_desc = wgpu::ProgrammableStageDescriptor {
-        module: &fs_mod,
-        entry_point: "main",
-    };
-    let raster_desc = wgpu::RasterizationStateDescriptor {
-        front_face: wgpu::FrontFace::Ccw,
-        cull_mode: wgpu::CullMode::None,
-        depth_bias: 0,
-        depth_bias_slope_scale: 0.0,
-        depth_bias_clamp: 0.0,
-    };
-    let color_state_desc = wgpu::ColorStateDescriptor {
-        format: dst_format,
-        color_blend: wgpu::BlendDescriptor::REPLACE,
-        alpha_blend: wgpu::BlendDescriptor::REPLACE,
-        write_mask: wgpu::ColorWrite::ALL,
-    };
-    let vertex_attrs = vertex_attrs();
-    let vertex_buffer_desc = wgpu::VertexBufferDescriptor {
-        stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
-        step_mode: wgpu::InputStepMode::Vertex,
-        attributes: &vertex_attrs[..],
-    };
-    let normal_attrs = normal_attrs();
-    let normal_buffer_desc = wgpu::VertexBufferDescriptor {
-        stride: std::mem::size_of::<Normal>() as wgpu::BufferAddress,
-        step_mode: wgpu::InputStepMode::Vertex,
-        attributes: &normal_attrs[..],
-    };
-    let depth_stencil_state_desc = depth_stencil_state_descriptor(depth_format);
-    let desc = wgpu::RenderPipelineDescriptor {
-        layout,
-        vertex_stage: vs_desc,
-        fragment_stage: Some(fs_desc),
-        rasterization_state: Some(raster_desc),
-        primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-        color_states: &[color_state_desc],
-        depth_stencil_state: Some(depth_stencil_state_desc),
-        index_format: wgpu::IndexFormat::Uint16,
-        vertex_buffers: &[vertex_buffer_desc, normal_buffer_desc],
-        sample_count,
-        sample_mask: !0,
-        alpha_to_coverage_enabled: false,
-    };
-    device.create_render_pipeline(&desc)
+    wgpu::RenderPipelineBuilder::from_layout(layout, vs_mod)
+        .fragment_shader(&fs_mod)
+        .color_format(dst_format)
+        .color_blend(wgpu::BlendDescriptor::REPLACE)
+        .alpha_blend(wgpu::BlendDescriptor::REPLACE)
+        .add_vertex_buffer::<Vertex>()
+        .add_vertex_buffer::<Normal>()
+        .depth_format(depth_format)
+        .index_format(wgpu::IndexFormat::Uint16)
+        .sample_count(sample_count)
+        .build(device)
 }

--- a/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
+++ b/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
@@ -149,26 +149,6 @@ fn view(app: &App, model: &Model, frame: Frame) {
         g.depth_texture_view = g.depth_texture.create_default_view();
     }
 
-    let render_pass_desc = wgpu::RenderPassDescriptor {
-        color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
-            attachment: frame.texture_view(),
-            resolve_target: None,
-            load_op: wgpu::LoadOp::Clear,
-            store_op: wgpu::StoreOp::Store,
-            clear_color: wgpu::Color::TRANSPARENT,
-        }],
-        // We'll use a depth texture to assist with the order of rendering fragments based on depth.
-        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
-            attachment: &g.depth_texture_view,
-            depth_load_op: wgpu::LoadOp::Clear,
-            depth_store_op: wgpu::StoreOp::Store,
-            clear_depth: 1.0,
-            stencil_load_op: wgpu::LoadOp::Clear,
-            stencil_store_op: wgpu::StoreOp::Store,
-            clear_stencil: 0,
-        }),
-    };
-
     // Update the uniforms (rotate around the teapot).
     let rotation = app.time;
     let uniforms = create_uniforms(rotation, frame_size);
@@ -179,7 +159,11 @@ fn view(app: &App, model: &Model, frame: Frame) {
 
     let mut encoder = frame.command_encoder();
     encoder.copy_buffer_to_buffer(&new_uniform_buffer, 0, &g.uniform_buffer, 0, uniforms_size);
-    let mut render_pass = encoder.begin_render_pass(&render_pass_desc);
+    let mut render_pass = wgpu::RenderPassBuilder::new()
+        .color_attachment(frame.texture_view(), |color| color)
+        // We'll use a depth texture to assist with the order of rendering fragments based on depth.
+        .depth_stencil_attachment(&g.depth_texture_view, |depth| depth)
+        .begin(&mut encoder);
     render_pass.set_bind_group(0, &g.bind_group, &[]);
     render_pass.set_pipeline(&g.render_pipeline);
     render_pass.set_vertex_buffers(0, &[(&g.vertex_buffer, 0), (&g.normal_buffer, 0)]);

--- a/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
+++ b/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
@@ -234,16 +234,9 @@ fn create_bind_group(
     layout: &wgpu::BindGroupLayout,
     uniform_buffer: &wgpu::Buffer,
 ) -> wgpu::BindGroup {
-    let uniforms_binding = wgpu::Binding {
-        binding: 0,
-        resource: wgpu::BindingResource::Buffer {
-            buffer: uniform_buffer,
-            range: 0..std::mem::size_of::<Uniforms>() as wgpu::BufferAddress,
-        },
-    };
-    let bindings = &[uniforms_binding];
-    let desc = wgpu::BindGroupDescriptor { layout, bindings };
-    device.create_bind_group(&desc)
+    wgpu::BindGroupBuilder::new()
+        .buffer::<Uniforms>(uniform_buffer, 0..1)
+        .build(device, layout)
 }
 
 fn create_pipeline_layout(

--- a/examples/wgpu/wgpu_teapot_camera/wgpu_teapot_camera.rs
+++ b/examples/wgpu/wgpu_teapot_camera/wgpu_teapot_camera.rs
@@ -361,16 +361,9 @@ fn create_bind_group(
     layout: &wgpu::BindGroupLayout,
     uniform_buffer: &wgpu::Buffer,
 ) -> wgpu::BindGroup {
-    let uniforms_binding = wgpu::Binding {
-        binding: 0,
-        resource: wgpu::BindingResource::Buffer {
-            buffer: uniform_buffer,
-            range: 0..std::mem::size_of::<Uniforms>() as wgpu::BufferAddress,
-        },
-    };
-    let bindings = &[uniforms_binding];
-    let desc = wgpu::BindGroupDescriptor { layout, bindings };
-    device.create_bind_group(&desc)
+    wgpu::BindGroupBuilder::new()
+        .buffer::<Uniforms>(uniform_buffer, 0..1)
+        .build(device, layout)
 }
 
 fn create_pipeline_layout(

--- a/examples/wgpu/wgpu_teapot_camera/wgpu_teapot_camera.rs
+++ b/examples/wgpu/wgpu_teapot_camera/wgpu_teapot_camera.rs
@@ -351,14 +351,9 @@ fn create_depth_texture(
 }
 
 fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    let uniforms_binding = wgpu::BindGroupLayoutBinding {
-        binding: 0,
-        visibility: wgpu::ShaderStage::VERTEX,
-        ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-    };
-    let bindings = &[uniforms_binding];
-    let desc = wgpu::BindGroupLayoutDescriptor { bindings };
-    device.create_bind_group_layout(&desc)
+    wgpu::BindGroupLayoutBuilder::new()
+        .uniform_buffer(wgpu::ShaderStage::VERTEX, false)
+        .build(device)
 }
 
 fn create_bind_group(

--- a/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
+++ b/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
@@ -122,9 +122,7 @@ fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
 }
 
 fn create_bind_group(device: &wgpu::Device, layout: &wgpu::BindGroupLayout) -> wgpu::BindGroup {
-    let bindings = &[];
-    let desc = wgpu::BindGroupDescriptor { layout, bindings };
-    device.create_bind_group(&desc)
+    wgpu::BindGroupBuilder::new().build(device, layout)
 }
 
 fn create_pipeline_layout(

--- a/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
+++ b/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
@@ -1,3 +1,11 @@
+//! A simple demonstration on how to create and draw with a custom wgpu render pipeline in nannou!
+//!
+//! The aim of this example is not to show the simplest way of drawing a triangle in nannou, but
+//! rather provide a reference on how to get started creating your own rendering pipeline from
+//! scratch. While nannou's provided graphics-y APIs can do a lot of things quite efficiently,
+//! writing a custom pipeline that does only exactly what you need it to can sometimes result in
+//! better performance.
+
 use nannou::prelude::*;
 
 struct Model {
@@ -87,22 +95,12 @@ fn view(_app: &App, model: &Model, frame: Frame) {
     // Using this we will encode commands that will be submitted to the GPU.
     let mut encoder = frame.command_encoder();
 
-    // A render pass describes how to draw to an output "attachment".
-    let render_pass_desc = wgpu::RenderPassDescriptor {
-        color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
-            attachment: frame.texture_view(),
-            resolve_target: None,
-            load_op: wgpu::LoadOp::Clear,
-            store_op: wgpu::StoreOp::Store,
-            clear_color: wgpu::Color::TRANSPARENT,
-        }],
-        depth_stencil_attachment: None,
-    };
-
-    // The render pass can be thought of a single large command consisting of sub commands.
-    // Here we begin the render pass and add sub-commands for setting the bind group, render
-    // pipeline, vertex buffers and then finally drawing.
-    let mut render_pass = encoder.begin_render_pass(&render_pass_desc);
+    // The render pass can be thought of a single large command consisting of sub commands. Here we
+    // begin a render pass that outputs to the frame's texture. Then we add sub-commands for
+    // setting the bind group, render pipeline, vertex buffers and then finally drawing.
+    let mut render_pass = wgpu::RenderPassBuilder::new()
+        .color_attachment(frame.texture_view(), |color| color)
+        .begin(&mut encoder);
     render_pass.set_bind_group(0, &model.bind_group, &[]);
     render_pass.set_pipeline(&model.render_pipeline);
     render_pass.set_vertex_buffers(0, &[(&model.vertex_buffer, 0)]);

--- a/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
+++ b/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
@@ -26,6 +26,16 @@ const VERTICES: [Vertex; 3] = [
     },
 ];
 
+impl wgpu::VertexDescriptor for Vertex {
+    const STRIDE: wgpu::BufferAddress = std::mem::size_of::<Vertex>() as _;
+    const ATTRIBUTES: &'static [wgpu::VertexAttributeDescriptor] =
+        &[wgpu::VertexAttributeDescriptor {
+            format: wgpu::VertexFormat::Float2,
+            offset: 0,
+            shader_location: 0,
+        }];
+}
+
 fn main() {
     nannou::app(model).run();
 }
@@ -129,14 +139,6 @@ fn create_pipeline_layout(
     device.create_pipeline_layout(&desc)
 }
 
-fn vertex_attrs() -> [wgpu::VertexAttributeDescriptor; 1] {
-    [wgpu::VertexAttributeDescriptor {
-        format: wgpu::VertexFormat::Float2,
-        offset: 0,
-        shader_location: 0,
-    }]
-}
-
 fn create_render_pipeline(
     device: &wgpu::Device,
     layout: &wgpu::PipelineLayout,
@@ -145,46 +147,10 @@ fn create_render_pipeline(
     dst_format: wgpu::TextureFormat,
     sample_count: u32,
 ) -> wgpu::RenderPipeline {
-    let vs_desc = wgpu::ProgrammableStageDescriptor {
-        module: &vs_mod,
-        entry_point: "main",
-    };
-    let fs_desc = wgpu::ProgrammableStageDescriptor {
-        module: &fs_mod,
-        entry_point: "main",
-    };
-    let raster_desc = wgpu::RasterizationStateDescriptor {
-        front_face: wgpu::FrontFace::Ccw,
-        cull_mode: wgpu::CullMode::None,
-        depth_bias: 0,
-        depth_bias_slope_scale: 0.0,
-        depth_bias_clamp: 0.0,
-    };
-    let color_state_desc = wgpu::ColorStateDescriptor {
-        format: dst_format,
-        color_blend: wgpu::BlendDescriptor::REPLACE,
-        alpha_blend: wgpu::BlendDescriptor::REPLACE,
-        write_mask: wgpu::ColorWrite::ALL,
-    };
-    let vertex_attrs = vertex_attrs();
-    let vertex_buffer_desc = wgpu::VertexBufferDescriptor {
-        stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
-        step_mode: wgpu::InputStepMode::Vertex,
-        attributes: &vertex_attrs[..],
-    };
-    let desc = wgpu::RenderPipelineDescriptor {
-        layout,
-        vertex_stage: vs_desc,
-        fragment_stage: Some(fs_desc),
-        rasterization_state: Some(raster_desc),
-        primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-        color_states: &[color_state_desc],
-        depth_stencil_state: None,
-        index_format: wgpu::IndexFormat::Uint16,
-        vertex_buffers: &[vertex_buffer_desc],
-        sample_count,
-        sample_mask: !0,
-        alpha_to_coverage_enabled: false,
-    };
-    device.create_render_pipeline(&desc)
+    wgpu::RenderPipelineBuilder::from_layout(layout, vs_mod)
+        .fragment_shader(fs_mod)
+        .color_format(dst_format)
+        .add_vertex_buffer::<Vertex>()
+        .sample_count(sample_count)
+        .build(device)
 }

--- a/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
+++ b/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
@@ -118,9 +118,7 @@ fn view(_app: &App, model: &Model, frame: Frame) {
 }
 
 fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    let bindings = &[];
-    let desc = wgpu::BindGroupLayoutDescriptor { bindings };
-    device.create_bind_group_layout(&desc)
+    wgpu::BindGroupLayoutBuilder::new().build(device)
 }
 
 fn create_bind_group(device: &wgpu::Device, layout: &wgpu::BindGroupLayout) -> wgpu::BindGroup {

--- a/examples/wgpu/wgpu_triangle_raw_frame/wgpu_triangle_raw_frame.rs
+++ b/examples/wgpu/wgpu_triangle_raw_frame/wgpu_triangle_raw_frame.rs
@@ -107,9 +107,7 @@ fn view(_app: &App, model: &Model, frame: RawFrame) {
 }
 
 fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    let bindings = &[];
-    let desc = wgpu::BindGroupLayoutDescriptor { bindings };
-    device.create_bind_group_layout(&desc)
+    wgpu::BindGroupLayoutBuilder::new().build(device)
 }
 
 fn create_bind_group(device: &wgpu::Device, layout: &wgpu::BindGroupLayout) -> wgpu::BindGroup {

--- a/examples/wgpu/wgpu_triangle_raw_frame/wgpu_triangle_raw_frame.rs
+++ b/examples/wgpu/wgpu_triangle_raw_frame/wgpu_triangle_raw_frame.rs
@@ -111,9 +111,7 @@ fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
 }
 
 fn create_bind_group(device: &wgpu::Device, layout: &wgpu::BindGroupLayout) -> wgpu::BindGroup {
-    let bindings = &[];
-    let desc = wgpu::BindGroupDescriptor { layout, bindings };
-    device.create_bind_group(&desc)
+    wgpu::BindGroupBuilder::new().build(device, layout)
 }
 
 fn create_pipeline_layout(

--- a/examples/wgpu/wgpu_triangle_raw_frame/wgpu_triangle_raw_frame.rs
+++ b/examples/wgpu/wgpu_triangle_raw_frame/wgpu_triangle_raw_frame.rs
@@ -67,9 +67,9 @@ fn model(app: &App) -> Model {
         .create_buffer_mapped(VERTICES.len(), wgpu::BufferUsage::VERTEX)
         .fill_from_slice(&VERTICES[..]);
 
-    let bind_group_layout = create_bind_group_layout(device);
-    let bind_group = create_bind_group(device, &bind_group_layout);
-    let pipeline_layout = create_pipeline_layout(device, &bind_group_layout);
+    let bind_group_layout = wgpu::BindGroupLayoutBuilder::new().build(device);
+    let bind_group = wgpu::BindGroupBuilder::new().build(device, &bind_group_layout);
+    let pipeline_layout = wgpu::create_pipeline_layout(device, &[&bind_group_layout]);
     let render_pipeline = wgpu::RenderPipelineBuilder::from_layout(&pipeline_layout, &vs_mod)
         .fragment_shader(&fs_mod)
         .color_format(format)
@@ -104,22 +104,4 @@ fn view(_app: &App, model: &Model, frame: RawFrame) {
     render_pass.set_bind_group(0, &model.bind_group, &[]);
     render_pass.set_vertex_buffers(0, &[(&model.vertex_buffer, 0)]);
     render_pass.draw(vertex_range, instance_range);
-}
-
-fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    wgpu::BindGroupLayoutBuilder::new().build(device)
-}
-
-fn create_bind_group(device: &wgpu::Device, layout: &wgpu::BindGroupLayout) -> wgpu::BindGroup {
-    wgpu::BindGroupBuilder::new().build(device, layout)
-}
-
-fn create_pipeline_layout(
-    device: &wgpu::Device,
-    bind_group_layout: &wgpu::BindGroupLayout,
-) -> wgpu::PipelineLayout {
-    let desc = wgpu::PipelineLayoutDescriptor {
-        bind_group_layouts: &[&bind_group_layout],
-    };
-    device.create_pipeline_layout(&desc)
 }

--- a/examples/wgpu/wgpu_triangle_raw_frame/wgpu_triangle_raw_frame.rs
+++ b/examples/wgpu/wgpu_triangle_raw_frame/wgpu_triangle_raw_frame.rs
@@ -1,5 +1,5 @@
-// The same as the `wgpu_triangle` example, but demonstrates how to draw directly to the swap chain
-// texture (`RawFrame`) rather than to nannou's intermediary `Frame`.
+//! The same as the `wgpu_triangle` example, but demonstrates how to draw directly to the swap
+//! chain texture (`RawFrame`) rather than to nannou's intermediary `Frame`.
 
 use nannou::prelude::*;
 
@@ -84,24 +84,16 @@ fn model(app: &App) -> Model {
 }
 
 fn view(_app: &App, model: &Model, frame: RawFrame) {
-    let vertex_range = 0..VERTICES.len() as u32;
-    let instance_range = 0..1;
-    let render_pass_desc = wgpu::RenderPassDescriptor {
-        color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
-            // NOTE: We are drawing to the swap chain texture directly rather than the intermediary
-            // texture as in `wgpu_triangle`.
-            attachment: frame.swap_chain_texture(),
-            resolve_target: None,
-            load_op: wgpu::LoadOp::Clear,
-            store_op: wgpu::StoreOp::Store,
-            clear_color: wgpu::Color::TRANSPARENT,
-        }],
-        depth_stencil_attachment: None,
-    };
     let mut encoder = frame.command_encoder();
-    let mut render_pass = encoder.begin_render_pass(&render_pass_desc);
+    let mut render_pass = wgpu::RenderPassBuilder::new()
+        // NOTE: We are drawing to the swap chain texture directly rather than the intermediary
+        // texture as in `wgpu_triangle`.
+        .color_attachment(frame.swap_chain_texture(), |color| color)
+        .begin(&mut encoder);
     render_pass.set_pipeline(&model.render_pipeline);
     render_pass.set_bind_group(0, &model.bind_group, &[]);
     render_pass.set_vertex_buffers(0, &[(&model.vertex_buffer, 0)]);
+    let vertex_range = 0..VERTICES.len() as u32;
+    let instance_range = 0..1;
     render_pass.draw(vertex_range, instance_range);
 }

--- a/src/draw/backend/wgpu/mod.rs
+++ b/src/draw/backend/wgpu/mod.rs
@@ -367,15 +367,11 @@ fn create_depth_texture(
 }
 
 fn bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    let bindings = &[];
-    let desc = wgpu::BindGroupLayoutDescriptor { bindings };
-    device.create_bind_group_layout(&desc)
+    wgpu::BindGroupLayoutBuilder::new().build(device)
 }
 
 fn bind_group(device: &wgpu::Device, layout: &wgpu::BindGroupLayout) -> wgpu::BindGroup {
-    let bindings = &[];
-    let desc = wgpu::BindGroupDescriptor { layout, bindings };
-    device.create_bind_group(&desc)
+    wgpu::BindGroupBuilder::new().build(device, layout)
 }
 
 fn render_pipeline(

--- a/src/draw/backend/wgpu/mod.rs
+++ b/src/draw/backend/wgpu/mod.rs
@@ -50,6 +50,37 @@ pub struct Vertex {
     // pub mode: u32,
 }
 
+impl wgpu::VertexDescriptor for Vertex {
+    const STRIDE: wgpu::BufferAddress = std::mem::size_of::<Self>() as _;
+    const ATTRIBUTES: &'static [wgpu::VertexAttributeDescriptor] = {
+        let position_offset = 0;
+        let position_size = std::mem::size_of::<[f32; 3]>() as wgpu::BufferAddress;
+        let rgba_offset = position_offset + position_size;
+        let rgba_size = std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress;
+        let tex_coords_offset = rgba_offset + rgba_size;
+        &[
+            // position
+            wgpu::VertexAttributeDescriptor {
+                format: wgpu::VertexFormat::Float3,
+                offset: position_offset,
+                shader_location: 0,
+            },
+            // rgba
+            wgpu::VertexAttributeDescriptor {
+                format: wgpu::VertexFormat::Float4,
+                offset: rgba_offset,
+                shader_location: 1,
+            },
+            // tex_coords
+            wgpu::VertexAttributeDescriptor {
+                format: wgpu::VertexFormat::Float2,
+                offset: tex_coords_offset,
+                shader_location: 2,
+            },
+        ]
+    };
+}
+
 impl Vertex {
     /// Create a vertex from the given mesh vertex.
     pub fn from_mesh_vertex<S>(
@@ -143,10 +174,9 @@ impl Renderer {
         // Create the render pipeline.
         let bind_group_layout = bind_group_layout(device);
         let bind_group = bind_group(device, &bind_group_layout);
-        let pipeline_layout = pipeline_layout(device, &bind_group_layout);
         let render_pipeline = render_pipeline(
             device,
-            &pipeline_layout,
+            &bind_group_layout,
             &vs_mod,
             &fs_mod,
             output_attachment_color_format,
@@ -348,116 +378,20 @@ fn bind_group(device: &wgpu::Device, layout: &wgpu::BindGroupLayout) -> wgpu::Bi
     device.create_bind_group(&desc)
 }
 
-fn pipeline_layout(
-    device: &wgpu::Device,
-    bind_group_layout: &wgpu::BindGroupLayout,
-) -> wgpu::PipelineLayout {
-    let desc = wgpu::PipelineLayoutDescriptor {
-        bind_group_layouts: &[&bind_group_layout],
-    };
-    device.create_pipeline_layout(&desc)
-}
-
-fn vertex_attrs() -> [wgpu::VertexAttributeDescriptor; 3] {
-    let position_offset = 0;
-    let position_size = std::mem::size_of::<[f32; 3]>() as wgpu::BufferAddress;
-    let rgba_offset = position_offset + position_size;
-    let rgba_size = std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress;
-    let tex_coords_offset = rgba_offset + rgba_size;
-    [
-        // position
-        wgpu::VertexAttributeDescriptor {
-            format: wgpu::VertexFormat::Float3,
-            offset: position_offset,
-            shader_location: 0,
-        },
-        // rgba
-        wgpu::VertexAttributeDescriptor {
-            format: wgpu::VertexFormat::Float4,
-            offset: rgba_offset,
-            shader_location: 1,
-        },
-        // tex_coords
-        wgpu::VertexAttributeDescriptor {
-            format: wgpu::VertexFormat::Float2,
-            offset: tex_coords_offset,
-            shader_location: 2,
-        },
-    ]
-}
-
-fn depth_stencil_state_descriptor(
-    format: wgpu::TextureFormat,
-) -> wgpu::DepthStencilStateDescriptor {
-    wgpu::DepthStencilStateDescriptor {
-        format: format,
-        depth_write_enabled: true,
-        depth_compare: wgpu::CompareFunction::LessEqual,
-        stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
-        stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
-        stencil_read_mask: 0,
-        stencil_write_mask: 0,
-    }
-}
-
 fn render_pipeline(
     device: &wgpu::Device,
-    layout: &wgpu::PipelineLayout,
+    layout: &wgpu::BindGroupLayout,
     vs_mod: &wgpu::ShaderModule,
     fs_mod: &wgpu::ShaderModule,
     dst_format: wgpu::TextureFormat,
     depth_format: wgpu::TextureFormat,
     msaa_samples: u32,
 ) -> wgpu::RenderPipeline {
-    let vs_desc = wgpu::ProgrammableStageDescriptor {
-        module: &vs_mod,
-        entry_point: "main",
-    };
-    let fs_desc = wgpu::ProgrammableStageDescriptor {
-        module: &fs_mod,
-        entry_point: "main",
-    };
-    let raster_desc = wgpu::RasterizationStateDescriptor {
-        front_face: wgpu::FrontFace::Ccw,
-        cull_mode: wgpu::CullMode::None,
-        depth_bias: 0,
-        depth_bias_slope_scale: 0.0,
-        depth_bias_clamp: 0.0,
-    };
-    let color_state_desc = wgpu::ColorStateDescriptor {
-        format: dst_format,
-        color_blend: wgpu::BlendDescriptor {
-            src_factor: wgpu::BlendFactor::SrcAlpha,
-            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-            operation: wgpu::BlendOperation::Add,
-        },
-        alpha_blend: wgpu::BlendDescriptor {
-            src_factor: wgpu::BlendFactor::One,
-            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-            operation: wgpu::BlendOperation::Add,
-        },
-        write_mask: wgpu::ColorWrite::ALL,
-    };
-    let vertex_attrs = vertex_attrs();
-    let vertex_buffer_desc = wgpu::VertexBufferDescriptor {
-        stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
-        step_mode: wgpu::InputStepMode::Vertex,
-        attributes: &vertex_attrs[..],
-    };
-    let depth_stencil_state_desc = depth_stencil_state_descriptor(depth_format);
-    let desc = wgpu::RenderPipelineDescriptor {
-        layout,
-        vertex_stage: vs_desc,
-        fragment_stage: Some(fs_desc),
-        rasterization_state: Some(raster_desc),
-        primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-        color_states: &[color_state_desc],
-        depth_stencil_state: Some(depth_stencil_state_desc),
-        index_format: wgpu::IndexFormat::Uint32,
-        vertex_buffers: &[vertex_buffer_desc],
-        sample_count: msaa_samples,
-        sample_mask: !0,
-        alpha_to_coverage_enabled: false,
-    };
-    device.create_render_pipeline(&desc)
+    wgpu::RenderPipelineBuilder::from_layout_descriptor(&[layout][..], vs_mod)
+        .fragment_shader(fs_mod)
+        .color_format(dst_format)
+        .add_vertex_buffer::<Vertex>()
+        .depth_format(depth_format)
+        .sample_count(msaa_samples)
+        .build(device)
 }

--- a/src/wgpu/bind_group_builder.rs
+++ b/src/wgpu/bind_group_builder.rs
@@ -1,0 +1,109 @@
+use crate::wgpu;
+
+/// A type aimed at simplifying the creation of a bind group layout.
+#[derive(Debug, Default)]
+pub struct LayoutBuilder {
+    bindings: Vec<(wgpu::ShaderStage, wgpu::BindingType)>,
+}
+
+impl LayoutBuilder {
+    /// Create a new empty builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Specify a new binding.
+    ///
+    /// The `binding` position of each binding will be inferred as the index within the order that
+    /// they are added to this builder type. If you require manually specifying the binding
+    /// location, you may be better off not using the `BindGroupBuilder` and instead constructing
+    /// the `BindGroupLayout` and `BindGroup` manually.
+    pub fn binding(mut self, visibility: wgpu::ShaderStage, ty: wgpu::BindingType) -> Self {
+        self.bindings.push((visibility, ty));
+        self
+    }
+
+    /// Add a uniform buffer binding to the layout.
+    pub fn uniform_buffer(self, visibility: wgpu::ShaderStage, dynamic: bool) -> Self {
+        let ty = wgpu::BindingType::UniformBuffer { dynamic };
+        self.binding(visibility, ty)
+    }
+
+    /// Add a storage buffer binding to the layout.
+    pub fn storage_buffer(
+        self,
+        visibility: wgpu::ShaderStage,
+        dynamic: bool,
+        readonly: bool,
+    ) -> Self {
+        let ty = wgpu::BindingType::StorageBuffer { dynamic, readonly };
+        self.binding(visibility, ty)
+    }
+
+    /// Add a sampler binding to the layout.
+    pub fn sampler(self, visibility: wgpu::ShaderStage) -> Self {
+        let ty = wgpu::BindingType::Sampler;
+        self.binding(visibility, ty)
+    }
+
+    /// Add a sampled texture binding to the layout.
+    pub fn sampled_texture(
+        self,
+        visibility: wgpu::ShaderStage,
+        multisampled: bool,
+        dimension: wgpu::TextureViewDimension,
+    ) -> Self {
+        let ty = wgpu::BindingType::SampledTexture {
+            multisampled,
+            dimension,
+        };
+        self.binding(visibility, ty)
+    }
+
+    /// Short-hand for adding a sampled textured binding for a full view of the given texture to
+    /// the layout.
+    ///
+    /// The `multisampled` and `dimension` parameters are retrieved from the `Texture` itself.
+    ///
+    /// Note that if you wish to take a `Cube` or `CubeArray` view of the given texture, you will
+    /// need to manually specify the `TextureViewDimension` via the `sampled_texture` method
+    /// instead.
+    pub fn sampled_texture_from(
+        self,
+        visibility: wgpu::ShaderStage,
+        texture: &wgpu::Texture,
+    ) -> Self {
+        self.sampled_texture(
+            visibility,
+            texture.sample_count() > 1,
+            texture.view_dimension(),
+        )
+    }
+
+    /// Add a storage texture binding to the layout.
+    pub fn storage_texture(
+        self,
+        visibility: wgpu::ShaderStage,
+        dimension: wgpu::TextureViewDimension,
+    ) -> Self {
+        let ty = wgpu::BindingType::StorageTexture { dimension };
+        self.binding(visibility, ty)
+    }
+
+    /// Build the bind group layout from the specified parameters.
+    pub fn build(self, device: &wgpu::Device) -> wgpu::BindGroupLayout {
+        let mut bindings = Vec::with_capacity(self.bindings.len());
+        for (i, (visibility, ty)) in self.bindings.into_iter().enumerate() {
+            let layout_binding = wgpu::BindGroupLayoutBinding {
+                binding: i as u32,
+                visibility,
+                ty,
+            };
+            bindings.push(layout_binding);
+        }
+        let descriptor = wgpu::BindGroupLayoutDescriptor {
+            bindings: &bindings,
+        };
+        device.create_bind_group_layout(&descriptor)
+    }
+}

--- a/src/wgpu/mod.rs
+++ b/src/wgpu/mod.rs
@@ -16,6 +16,7 @@
 //! - WebGPU [on wikipedia](https://en.wikipedia.org/wiki/WebGPU).
 
 mod device_map;
+mod render_pipeline_builder;
 mod sampler_builder;
 mod texture;
 
@@ -26,6 +27,7 @@ mod texture;
 pub use self::device_map::{
     ActiveAdapter, AdapterMap, AdapterMapKey, DeviceMap, DeviceMapKey, DeviceQueuePair,
 };
+pub use self::render_pipeline_builder::{RenderPipelineBuilder, VertexDescriptor};
 pub use self::sampler_builder::SamplerBuilder;
 pub use self::texture::capturer::{
     Capturer as TextureCapturer, Rgba8AsyncMapping, Snapshot as TextureSnapshot,

--- a/src/wgpu/mod.rs
+++ b/src/wgpu/mod.rs
@@ -15,6 +15,7 @@
 //! - The [WebGPU specification](https://gpuweb.github.io/gpuweb/).
 //! - WebGPU [on wikipedia](https://en.wikipedia.org/wiki/WebGPU).
 
+mod bind_group_builder;
 mod device_map;
 mod render_pipeline_builder;
 mod sampler_builder;
@@ -24,6 +25,7 @@ mod texture;
 //
 // We do this manually rather than a glob-re-export in order to rename `Texture` to `TextureHandle`
 // and have it show up in the documentation properly.
+pub use self::bind_group_builder::LayoutBuilder as BindGroupLayoutBuilder;
 pub use self::device_map::{
     ActiveAdapter, AdapterMap, AdapterMapKey, DeviceMap, DeviceMapKey, DeviceQueuePair,
 };

--- a/src/wgpu/mod.rs
+++ b/src/wgpu/mod.rs
@@ -135,3 +135,12 @@ pub fn resolve_texture(
     };
     let _render_pass = encoder.begin_render_pass(&render_pass_desc);
 }
+
+/// Shorthand for creating the pipeline layout from a slice of bind group layouts.
+pub fn create_pipeline_layout(
+    device: &wgpu::Device,
+    bind_group_layouts: &[&wgpu::BindGroupLayout],
+) -> wgpu::PipelineLayout {
+    let descriptor = wgpu::PipelineLayoutDescriptor { bind_group_layouts };
+    device.create_pipeline_layout(&descriptor)
+}

--- a/src/wgpu/mod.rs
+++ b/src/wgpu/mod.rs
@@ -25,7 +25,9 @@ mod texture;
 //
 // We do this manually rather than a glob-re-export in order to rename `Texture` to `TextureHandle`
 // and have it show up in the documentation properly.
-pub use self::bind_group_builder::LayoutBuilder as BindGroupLayoutBuilder;
+pub use self::bind_group_builder::{
+    Builder as BindGroupBuilder, LayoutBuilder as BindGroupLayoutBuilder,
+};
 pub use self::device_map::{
     ActiveAdapter, AdapterMap, AdapterMapKey, DeviceMap, DeviceMapKey, DeviceQueuePair,
 };

--- a/src/wgpu/render_pass.rs
+++ b/src/wgpu/render_pass.rs
@@ -1,0 +1,208 @@
+/// A builder type to simplify the process of creating a render pass descriptor.
+#[derive(Debug, Default)]
+pub struct Builder<'a> {
+    color_attachments: Vec<wgpu::RenderPassColorAttachmentDescriptor<'a>>,
+    depth_stencil_attachment:
+        Option<wgpu::RenderPassDepthStencilAttachmentDescriptor<&'a wgpu::TextureView>>,
+}
+
+/// A builder type to simplify the process of creating a render pass descriptor.
+#[derive(Debug)]
+pub struct ColorAttachmentDescriptorBuilder<'a> {
+    descriptor: wgpu::RenderPassColorAttachmentDescriptor<'a>,
+}
+
+/// A builder type to simplify the process of creating a render pass descriptor.
+#[derive(Debug)]
+pub struct DepthStencilAttachmentDescriptorBuilder<'a> {
+    descriptor: wgpu::RenderPassDepthStencilAttachmentDescriptor<&'a wgpu::TextureView>,
+}
+
+impl<'a> ColorAttachmentDescriptorBuilder<'a> {
+    pub const DEFAULT_LOAD_OP: wgpu::LoadOp = wgpu::LoadOp::Clear;
+    pub const DEFAULT_STORE_OP: wgpu::StoreOp = wgpu::StoreOp::Store;
+    pub const DEFAULT_CLEAR_COLOR: wgpu::Color = wgpu::Color::TRANSPARENT;
+
+    /// Begin building a new render pass color attachment descriptor.
+    fn new(attachment: &'a wgpu::TextureView) -> Self {
+        ColorAttachmentDescriptorBuilder {
+            descriptor: wgpu::RenderPassColorAttachmentDescriptor {
+                attachment,
+                resolve_target: None,
+                load_op: Self::DEFAULT_LOAD_OP,
+                store_op: Self::DEFAULT_STORE_OP,
+                clear_color: Self::DEFAULT_CLEAR_COLOR,
+            },
+        }
+    }
+
+    /// Specify the resolve target for this render pass color attachment.
+    pub fn resolve_target(mut self, target: Option<&'a wgpu::TextureView>) -> Self {
+        self.descriptor.resolve_target = target;
+        self
+    }
+
+    /// The beginning-of-pass load operation for this color attachment.
+    pub fn load_op(mut self, load_op: wgpu::LoadOp) -> Self {
+        self.descriptor.load_op = load_op;
+        self
+    }
+
+    /// The end-of-pass store operation for this color attachment.
+    pub fn store_op(mut self, store_op: wgpu::StoreOp) -> Self {
+        self.descriptor.store_op = store_op;
+        self
+    }
+
+    /// The color that will be assigned to every pixel of this attachment when cleared.
+    pub fn clear_color(mut self, color: wgpu::Color) -> Self {
+        self.descriptor.clear_color = color;
+        self
+    }
+}
+
+impl<'a> DepthStencilAttachmentDescriptorBuilder<'a> {
+    pub const DEFAULT_DEPTH_LOAD_OP: wgpu::LoadOp = wgpu::LoadOp::Clear;
+    pub const DEFAULT_DEPTH_STORE_OP: wgpu::StoreOp = wgpu::StoreOp::Store;
+    pub const DEFAULT_CLEAR_DEPTH: f32 = 1.0;
+    pub const DEFAULT_STENCIL_LOAD_OP: wgpu::LoadOp = wgpu::LoadOp::Clear;
+    pub const DEFAULT_STENCIL_STORE_OP: wgpu::StoreOp = wgpu::StoreOp::Store;
+    pub const DEFAULT_CLEAR_STENCIL: u32 = 0;
+
+    fn new(attachment: &'a wgpu::TextureView) -> Self {
+        DepthStencilAttachmentDescriptorBuilder {
+            descriptor: wgpu::RenderPassDepthStencilAttachmentDescriptor {
+                attachment,
+                depth_load_op: Self::DEFAULT_DEPTH_LOAD_OP,
+                depth_store_op: Self::DEFAULT_DEPTH_STORE_OP,
+                clear_depth: Self::DEFAULT_CLEAR_DEPTH,
+                stencil_load_op: Self::DEFAULT_STENCIL_LOAD_OP,
+                stencil_store_op: Self::DEFAULT_STENCIL_STORE_OP,
+                clear_stencil: Self::DEFAULT_CLEAR_STENCIL,
+            },
+        }
+    }
+
+    /// The beginning-of-pass load operation for this depth attachment.
+    pub fn depth_load_op(mut self, load_op: wgpu::LoadOp) -> Self {
+        self.descriptor.depth_load_op = load_op;
+        self
+    }
+
+    /// The end-of-pass store operation for this depth attachment.
+    pub fn depth_store_op(mut self, store_op: wgpu::StoreOp) -> Self {
+        self.descriptor.depth_store_op = store_op;
+        self
+    }
+
+    /// The value that will be assigned to every pixel of this depth attachment when cleared.
+    pub fn clear_depth(mut self, depth: f32) -> Self {
+        self.descriptor.clear_depth = depth;
+        self
+    }
+
+    /// The beginning-of-pass load operation for this stencil attachment.
+    pub fn stencil_load_op(mut self, load_op: wgpu::LoadOp) -> Self {
+        self.descriptor.stencil_load_op = load_op;
+        self
+    }
+
+    /// The end-of-pass store operation for this stencil attachment.
+    pub fn stencil_store_op(mut self, store_op: wgpu::StoreOp) -> Self {
+        self.descriptor.stencil_store_op = store_op;
+        self
+    }
+
+    /// The value that will be assigned to every pixel of this stencil attachment when cleared.
+    pub fn clear_stencil(mut self, stencil: u32) -> Self {
+        self.descriptor.clear_stencil = stencil;
+        self
+    }
+}
+
+impl<'a> Builder<'a> {
+    pub const DEFAULT_COLOR_LOAD_OP: wgpu::LoadOp =
+        ColorAttachmentDescriptorBuilder::DEFAULT_LOAD_OP;
+    pub const DEFAULT_COLOR_STORE_OP: wgpu::StoreOp =
+        ColorAttachmentDescriptorBuilder::DEFAULT_STORE_OP;
+    pub const DEFAULT_CLEAR_COLOR: wgpu::Color =
+        ColorAttachmentDescriptorBuilder::DEFAULT_CLEAR_COLOR;
+    pub const DEFAULT_DEPTH_LOAD_OP: wgpu::LoadOp =
+        DepthStencilAttachmentDescriptorBuilder::DEFAULT_DEPTH_LOAD_OP;
+    pub const DEFAULT_DEPTH_STORE_OP: wgpu::StoreOp =
+        DepthStencilAttachmentDescriptorBuilder::DEFAULT_DEPTH_STORE_OP;
+    pub const DEFAULT_CLEAR_DEPTH: f32 =
+        DepthStencilAttachmentDescriptorBuilder::DEFAULT_CLEAR_DEPTH;
+    pub const DEFAULT_STENCIL_LOAD_OP: wgpu::LoadOp =
+        DepthStencilAttachmentDescriptorBuilder::DEFAULT_STENCIL_LOAD_OP;
+    pub const DEFAULT_STENCIL_STORE_OP: wgpu::StoreOp =
+        DepthStencilAttachmentDescriptorBuilder::DEFAULT_STENCIL_STORE_OP;
+    pub const DEFAULT_CLEAR_STENCIL: u32 =
+        DepthStencilAttachmentDescriptorBuilder::DEFAULT_CLEAR_STENCIL;
+
+    /// Begin building a new render pass descriptor.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a single color attachment descriptor to the render pass descriptor.
+    ///
+    /// Call this multiple times in succession to add multiple color attachments.
+    pub fn color_attachment<F>(
+        mut self,
+        attachment: &'a wgpu::TextureView,
+        color_builder: F,
+    ) -> Self
+    where
+        F: FnOnce(ColorAttachmentDescriptorBuilder<'a>) -> ColorAttachmentDescriptorBuilder<'a>,
+    {
+        let builder = ColorAttachmentDescriptorBuilder::new(attachment);
+        let descriptor = color_builder(builder).descriptor;
+        self.color_attachments.push(descriptor);
+        self
+    }
+
+    /// Add a depth stencil attachment to the render pass.
+    ///
+    /// This should only be called once, as only a single depth stencil attachment is valid. Only
+    /// the attachment submitted last will be used.
+    pub fn depth_stencil_attachment<F>(
+        mut self,
+        attachment: &'a wgpu::TextureView,
+        depth_stencil_builder: F,
+    ) -> Self
+    where
+        F: FnOnce(
+            DepthStencilAttachmentDescriptorBuilder<'a>,
+        ) -> DepthStencilAttachmentDescriptorBuilder<'a>,
+    {
+        let builder = DepthStencilAttachmentDescriptorBuilder::new(attachment);
+        let descriptor = depth_stencil_builder(builder).descriptor;
+        self.depth_stencil_attachment = Some(descriptor);
+        self
+    }
+
+    /// Return the built color and depth attachments.
+    pub fn into_inner(
+        self,
+    ) -> (
+        Vec<wgpu::RenderPassColorAttachmentDescriptor<'a>>,
+        Option<wgpu::RenderPassDepthStencilAttachmentDescriptor<&'a wgpu::TextureView>>,
+    ) {
+        let Builder {
+            color_attachments,
+            depth_stencil_attachment,
+        } = self;
+        (color_attachments, depth_stencil_attachment)
+    }
+
+    /// Begin a render pass with the specified parameters on the given encoder.
+    pub fn begin(self, encoder: &mut wgpu::CommandEncoder) -> wgpu::RenderPass {
+        let (color_attachments, depth_stencil_attachment) = self.into_inner();
+        let descriptor = wgpu::RenderPassDescriptor {
+            color_attachments: &color_attachments,
+            depth_stencil_attachment,
+        };
+        encoder.begin_render_pass(&descriptor)
+    }
+}

--- a/src/wgpu/render_pipeline_builder.rs
+++ b/src/wgpu/render_pipeline_builder.rs
@@ -1,0 +1,514 @@
+//! Items aimed at easing the contruction of a render pipeline.
+//!
+//! Creating a `RenderPipeline` tends to involve a lot of boilerplate that we don't always want to
+//! have to consider when writing graphics code. Here we define a set of helpers that allow us to
+//! simplify the process and fall back to a set of reasonable defaults.
+
+/// A trait required to be implemented by vertices to provide a simpler render pipeline API.
+pub trait VertexDescriptor {
+    /// The stride, in bytes, between elements of this buffer.
+    const STRIDE: wgpu::BufferAddress;
+    /// A description of each of the vertex's attributes.
+    const ATTRIBUTES: &'static [wgpu::VertexAttributeDescriptor];
+}
+
+#[derive(Debug)]
+enum Layout<'a> {
+    Descriptor(wgpu::PipelineLayoutDescriptor<'a>),
+    Created(&'a wgpu::PipelineLayout),
+}
+
+/// Types that may be directly converted into a pipeline layout descriptor.
+pub trait IntoPipelineLayoutDescriptor<'a> {
+    /// Convert the type into a pipeline layout descriptor.
+    fn into_pipeline_layout_descriptor(self) -> wgpu::PipelineLayoutDescriptor<'a>;
+}
+
+/// A builder type to help simplify the construction of a **RenderPipeline**.
+///
+/// We've attempted to provide a suite of reasonable defaults in the case that none are provided.
+#[derive(Debug)]
+pub struct RenderPipelineBuilder<'a> {
+    layout: Layout<'a>,
+    vs_mod: &'a wgpu::ShaderModule,
+    fs_mod: Option<&'a wgpu::ShaderModule>,
+    vs_entry_point: &'a str,
+    fs_entry_point: &'a str,
+    rasterization_state: Option<wgpu::RasterizationStateDescriptor>,
+    primitive_topology: wgpu::PrimitiveTopology,
+    color_state: Option<wgpu::ColorStateDescriptor>,
+    color_states: &'a [wgpu::ColorStateDescriptor],
+    depth_stencil_state: Option<wgpu::DepthStencilStateDescriptor>,
+    index_format: wgpu::IndexFormat,
+    vertex_buffers: Vec<wgpu::VertexBufferDescriptor<'static>>,
+    sample_count: u32,
+    sample_mask: u32,
+    alpha_to_coverage_enabled: bool,
+}
+
+/// Construct a vertex buffer descriptor from the given vertex type and step mode.
+pub fn vertex_buffer_descriptor_from_type<T>(
+    step_mode: wgpu::InputStepMode,
+) -> wgpu::VertexBufferDescriptor<'static>
+where
+    T: VertexDescriptor,
+{
+    wgpu::VertexBufferDescriptor {
+        stride: T::STRIDE,
+        step_mode,
+        attributes: T::ATTRIBUTES,
+    }
+}
+
+impl<'a> RenderPipelineBuilder<'a> {
+    // The default entry point used for shaders when unspecified.
+    pub const DEFAULT_SHADER_ENTRY_POINT: &'static str = "main";
+
+    // Rasterization state defaults for the case where the user has submitted a fragment shader.
+    pub const DEFAULT_FRONT_FACE: wgpu::FrontFace = wgpu::FrontFace::Ccw;
+    pub const DEFAULT_CULL_MODE: wgpu::CullMode = wgpu::CullMode::None;
+    pub const DEFAULT_DEPTH_BIAS: i32 = 0;
+    pub const DEFAULT_DEPTH_BIAS_SLOPE_SCALE: f32 = 0.0;
+    pub const DEFAULT_DEPTH_BIAS_CLAMP: f32 = 0.0;
+    pub const DEFAULT_RASTERIZATION_STATE: wgpu::RasterizationStateDescriptor =
+        wgpu::RasterizationStateDescriptor {
+            front_face: Self::DEFAULT_FRONT_FACE,
+            cull_mode: Self::DEFAULT_CULL_MODE,
+            depth_bias: Self::DEFAULT_DEPTH_BIAS,
+            depth_bias_slope_scale: Self::DEFAULT_DEPTH_BIAS_SLOPE_SCALE,
+            depth_bias_clamp: Self::DEFAULT_DEPTH_BIAS_CLAMP,
+        };
+
+    // Primitive topology.
+    pub const DEFAULT_PRIMITIVE_TOPOLOGY: wgpu::PrimitiveTopology =
+        wgpu::PrimitiveTopology::TriangleList;
+
+    // Color state defaults.
+    pub const DEFAULT_COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Unorm;
+    pub const DEFAULT_COLOR_BLEND: wgpu::BlendDescriptor = wgpu::BlendDescriptor {
+        src_factor: wgpu::BlendFactor::SrcAlpha,
+        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+        operation: wgpu::BlendOperation::Add,
+    };
+    pub const DEFAULT_ALPHA_BLEND: wgpu::BlendDescriptor = wgpu::BlendDescriptor {
+        src_factor: wgpu::BlendFactor::One,
+        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+        operation: wgpu::BlendOperation::Add,
+    };
+    pub const DEFAULT_COLOR_WRITE: wgpu::ColorWrite = wgpu::ColorWrite::ALL;
+    pub const DEFAULT_COLOR_STATE: wgpu::ColorStateDescriptor = wgpu::ColorStateDescriptor {
+        format: Self::DEFAULT_COLOR_FORMAT,
+        color_blend: Self::DEFAULT_COLOR_BLEND,
+        alpha_blend: Self::DEFAULT_ALPHA_BLEND,
+        write_mask: Self::DEFAULT_COLOR_WRITE,
+    };
+
+    // Depth state defaults.
+    pub const DEFAULT_DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+    pub const DEFAULT_DEPTH_WRITE_ENABLED: bool = true;
+    pub const DEFAULT_DEPTH_COMPARE: wgpu::CompareFunction = wgpu::CompareFunction::LessEqual;
+    pub const DEFAULT_STENCIL_FRONT: wgpu::StencilStateFaceDescriptor =
+        wgpu::StencilStateFaceDescriptor::IGNORE;
+    pub const DEFAULT_STENCIL_BACK: wgpu::StencilStateFaceDescriptor =
+        wgpu::StencilStateFaceDescriptor::IGNORE;
+    pub const DEFAULT_STENCIL_READ_MASK: u32 = 0;
+    pub const DEFAULT_STENCIL_WRITE_MASK: u32 = 0;
+    pub const DEFAULT_DEPTH_STENCIL_STATE: wgpu::DepthStencilStateDescriptor =
+        wgpu::DepthStencilStateDescriptor {
+            format: Self::DEFAULT_DEPTH_FORMAT,
+            depth_write_enabled: Self::DEFAULT_DEPTH_WRITE_ENABLED,
+            depth_compare: Self::DEFAULT_DEPTH_COMPARE,
+            stencil_front: Self::DEFAULT_STENCIL_FRONT,
+            stencil_back: Self::DEFAULT_STENCIL_BACK,
+            stencil_read_mask: Self::DEFAULT_STENCIL_READ_MASK,
+            stencil_write_mask: Self::DEFAULT_STENCIL_WRITE_MASK,
+        };
+
+    // Vertex buffer defaults.
+    pub const DEFAULT_INDEX_FORMAT: wgpu::IndexFormat = wgpu::IndexFormat::Uint32;
+    // No MSAA by default.
+    pub const DEFAULT_SAMPLE_COUNT: u32 = 1;
+    pub const DEFAULT_SAMPLE_MASK: u32 = !0;
+    pub const DEFAULT_ALPHA_TO_COVERAGE_ENABLED: bool = false;
+
+    // Constructors
+
+    /// Begin building the render pipeline for the given pipeline layout and the vertex shader
+    /// module.
+    pub fn from_layout(layout: &'a wgpu::PipelineLayout, vs_mod: &'a wgpu::ShaderModule) -> Self {
+        let layout = Layout::Created(layout);
+        Self::new_inner(layout, vs_mod)
+    }
+
+    /// Begin building the render pipeline for a pipeline with the given layout descriptor and the
+    /// vertex shader module.
+    pub fn from_layout_descriptor<T>(layout_desc: T, vs_mod: &'a wgpu::ShaderModule) -> Self
+    where
+        T: IntoPipelineLayoutDescriptor<'a>,
+    {
+        let desc = layout_desc.into_pipeline_layout_descriptor();
+        let layout = Layout::Descriptor(desc);
+        Self::new_inner(layout, vs_mod)
+    }
+
+    // Shared between constructors.
+    fn new_inner(layout: Layout<'a>, vs_mod: &'a wgpu::ShaderModule) -> Self {
+        RenderPipelineBuilder {
+            layout,
+            vs_mod,
+            fs_mod: None,
+            vs_entry_point: Self::DEFAULT_SHADER_ENTRY_POINT,
+            fs_entry_point: Self::DEFAULT_SHADER_ENTRY_POINT,
+            rasterization_state: None,
+            color_state: None,
+            color_states: &[],
+            primitive_topology: Self::DEFAULT_PRIMITIVE_TOPOLOGY,
+            depth_stencil_state: None,
+            index_format: Self::DEFAULT_INDEX_FORMAT,
+            vertex_buffers: vec![],
+            sample_count: Self::DEFAULT_SAMPLE_COUNT,
+            sample_mask: Self::DEFAULT_SAMPLE_MASK,
+            alpha_to_coverage_enabled: Self::DEFAULT_ALPHA_TO_COVERAGE_ENABLED,
+        }
+    }
+
+    // Builders
+
+    pub fn vertex_entry_point(mut self, entry_point: &'a str) -> Self {
+        self.vs_entry_point = entry_point;
+        self
+    }
+
+    pub fn fragment_entry_point(mut self, entry_point: &'a str) -> Self {
+        self.fs_entry_point = entry_point;
+        self
+    }
+
+    /// Specify a fragment shader for the render pipeline.
+    pub fn fragment_shader(mut self, fs_mod: &'a wgpu::ShaderModule) -> Self {
+        self.fs_mod = Some(fs_mod);
+        self
+    }
+
+    // Rasterization state.
+
+    /// Specify the full rasterization state.
+    pub fn rasterization_state(mut self, state: wgpu::RasterizationStateDescriptor) -> Self {
+        self.rasterization_state = Some(state);
+        self
+    }
+
+    pub fn front_face(mut self, front_face: wgpu::FrontFace) -> Self {
+        let state = self
+            .rasterization_state
+            .get_or_insert(Self::DEFAULT_RASTERIZATION_STATE);
+        state.front_face = front_face;
+        self
+    }
+
+    pub fn cull_mode(mut self, cull_mode: wgpu::CullMode) -> Self {
+        let state = self
+            .rasterization_state
+            .get_or_insert(Self::DEFAULT_RASTERIZATION_STATE);
+        state.cull_mode = cull_mode;
+        self
+    }
+
+    pub fn depth_bias(mut self, bias: i32) -> Self {
+        let state = self
+            .rasterization_state
+            .get_or_insert(Self::DEFAULT_RASTERIZATION_STATE);
+        state.depth_bias = bias;
+        self
+    }
+
+    pub fn depth_bias_slope_scale(mut self, scale: f32) -> Self {
+        let state = self
+            .rasterization_state
+            .get_or_insert(Self::DEFAULT_RASTERIZATION_STATE);
+        state.depth_bias_slope_scale = scale;
+        self
+    }
+
+    pub fn depth_bias_clamp(mut self, clamp: f32) -> Self {
+        let state = self
+            .rasterization_state
+            .get_or_insert(Self::DEFAULT_RASTERIZATION_STATE);
+        state.depth_bias_clamp = clamp;
+        self
+    }
+
+    // Primitive topology.
+
+    /// Specify the primitive topology.
+    ///
+    /// This represents the way vertices will be read from the **VertexBuffer**.
+    pub fn primitive_topology(mut self, topology: wgpu::PrimitiveTopology) -> Self {
+        self.primitive_topology = topology;
+        self
+    }
+
+    // Color state.
+
+    /// Specify the full color state for drawing to the output attachment.
+    ///
+    /// If you have multiple output attachments, see the `color_states` method.
+    pub fn color_state(mut self, state: wgpu::ColorStateDescriptor) -> Self {
+        self.color_state = Some(state);
+        self
+    }
+
+    pub fn color_format(mut self, format: wgpu::TextureFormat) -> Self {
+        let state = self.color_state.get_or_insert(Self::DEFAULT_COLOR_STATE);
+        state.format = format;
+        self
+    }
+
+    pub fn color_blend(mut self, blend: wgpu::BlendDescriptor) -> Self {
+        let state = self.color_state.get_or_insert(Self::DEFAULT_COLOR_STATE);
+        state.color_blend = blend;
+        self
+    }
+
+    pub fn alpha_blend(mut self, blend: wgpu::BlendDescriptor) -> Self {
+        let state = self.color_state.get_or_insert(Self::DEFAULT_COLOR_STATE);
+        state.alpha_blend = blend;
+        self
+    }
+
+    pub fn write_mask(mut self, mask: wgpu::ColorWrite) -> Self {
+        let state = self.color_state.get_or_insert(Self::DEFAULT_COLOR_STATE);
+        state.write_mask = mask;
+        self
+    }
+
+    // Depth / Stencil state
+
+    pub fn depth_stencil_state(mut self, state: wgpu::DepthStencilStateDescriptor) -> Self {
+        self.depth_stencil_state = Some(state);
+        self
+    }
+
+    pub fn depth_format(mut self, format: wgpu::TextureFormat) -> Self {
+        let state = self
+            .depth_stencil_state
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+        state.format = format;
+        self
+    }
+
+    pub fn depth_write_enabled(mut self, enabled: bool) -> Self {
+        let state = self
+            .depth_stencil_state
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+        state.depth_write_enabled = enabled;
+        self
+    }
+
+    pub fn depth_compare(mut self, compare: wgpu::CompareFunction) -> Self {
+        let state = self
+            .depth_stencil_state
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+        state.depth_compare = compare;
+        self
+    }
+
+    pub fn stencil_front(mut self, stencil: wgpu::StencilStateFaceDescriptor) -> Self {
+        let state = self
+            .depth_stencil_state
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+        state.stencil_front = stencil;
+        self
+    }
+
+    pub fn stencil_back(mut self, stencil: wgpu::StencilStateFaceDescriptor) -> Self {
+        let state = self
+            .depth_stencil_state
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+        state.stencil_back = stencil;
+        self
+    }
+
+    pub fn stencil_read_mask(mut self, mask: u32) -> Self {
+        let state = self
+            .depth_stencil_state
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+        state.stencil_read_mask = mask;
+        self
+    }
+
+    pub fn stencil_write_mask(mut self, mask: u32) -> Self {
+        let state = self
+            .depth_stencil_state
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+        state.stencil_write_mask = mask;
+        self
+    }
+
+    // Vertex buffer methods.
+
+    /// The format of the type used within the index buffer.
+    pub fn index_format(mut self, format: wgpu::IndexFormat) -> Self {
+        self.index_format = format;
+        self
+    }
+
+    /// Add a new vertex buffer descriptor to the render pipeline.
+    pub fn add_vertex_buffer_descriptor(
+        mut self,
+        d: wgpu::VertexBufferDescriptor<'static>,
+    ) -> Self {
+        self.vertex_buffers.push(d);
+        self
+    }
+
+    /// Short-hand for adding a descriptor to the render pipeline describing a buffer of vertices
+    /// of the given vertex type.
+    pub fn add_vertex_buffer<V>(self) -> Self
+    where
+        V: VertexDescriptor,
+    {
+        let step_mode = wgpu::InputStepMode::Vertex;
+        let descriptor = vertex_buffer_descriptor_from_type::<V>(step_mode);
+        self.add_vertex_buffer_descriptor(descriptor)
+    }
+
+    /// Short-hand for adding a descriptor to the render pipeline describing a buffer of instances
+    /// of the given vertex type.
+    pub fn add_instance_buffer<I>(self) -> Self
+    where
+        I: VertexDescriptor,
+    {
+        let step_mode = wgpu::InputStepMode::Instance;
+        let descriptor = vertex_buffer_descriptor_from_type::<I>(step_mode);
+        self.add_vertex_buffer_descriptor(descriptor)
+    }
+
+    /// The sample count of the output attachment.
+    pub fn sample_count(mut self, sample_count: u32) -> Self {
+        self.sample_count = sample_count;
+        self
+    }
+
+    // Finalising methods.
+
+    /// Build the render pipeline layout, its descriptor and ultimately the pipeline itself with
+    /// the specified parameters.
+    ///
+    /// **Panic!**s in the following occur:
+    ///
+    /// - A rasterization state field was specified but no fragment shader was given.
+    /// - A color state field was specified but no fragment shader was given.
+    pub fn build(self, device: &wgpu::Device) -> wgpu::RenderPipeline {
+        match self.layout {
+            Layout::Descriptor(ref desc) => {
+                let layout = device.create_pipeline_layout(desc);
+                build(self, &layout, device)
+            }
+            Layout::Created(layout) => build(self, layout, device),
+        }
+    }
+}
+
+impl<'a> IntoPipelineLayoutDescriptor<'a> for wgpu::PipelineLayoutDescriptor<'a> {
+    fn into_pipeline_layout_descriptor(self) -> wgpu::PipelineLayoutDescriptor<'a> {
+        self
+    }
+}
+
+impl<'a> IntoPipelineLayoutDescriptor<'a> for &'a [&'a wgpu::BindGroupLayout] {
+    fn into_pipeline_layout_descriptor(self) -> wgpu::PipelineLayoutDescriptor<'a> {
+        wgpu::PipelineLayoutDescriptor {
+            bind_group_layouts: self,
+        }
+    }
+}
+
+fn build(
+    builder: RenderPipelineBuilder,
+    layout: &wgpu::PipelineLayout,
+    device: &wgpu::Device,
+) -> wgpu::RenderPipeline {
+    let RenderPipelineBuilder {
+        layout: _layout,
+        vs_mod,
+        fs_mod,
+        vs_entry_point,
+        fs_entry_point,
+        rasterization_state,
+        primitive_topology,
+        color_state,
+        color_states,
+        depth_stencil_state,
+        index_format,
+        vertex_buffers,
+        sample_count,
+        sample_mask,
+        alpha_to_coverage_enabled,
+    } = builder;
+
+    let vertex_stage = wgpu::ProgrammableStageDescriptor {
+        module: &vs_mod,
+        entry_point: vs_entry_point,
+    };
+
+    let fragment_stage = fs_mod.map(|fs_mod| wgpu::ProgrammableStageDescriptor {
+        module: fs_mod,
+        entry_point: fs_entry_point,
+    });
+
+    let rasterization_state = match fragment_stage.is_some() {
+        true => {
+            Some(rasterization_state.unwrap_or(RenderPipelineBuilder::DEFAULT_RASTERIZATION_STATE))
+        }
+        false => {
+            if rasterization_state.is_some() {
+                panic!("specified rasterization state fields but no fragment shader");
+            } else {
+                None
+            }
+        }
+    };
+
+    let mut single_color_state = [RenderPipelineBuilder::DEFAULT_COLOR_STATE];
+    let color_states = match (fragment_stage.is_some(), color_states.is_empty()) {
+        (true, true) => {
+            if let Some(cs) = color_state {
+                single_color_state[0] = cs;
+            }
+            &single_color_state[..]
+        }
+        (true, false) => color_states,
+        (false, true) => panic!("specified color states but no fragment shader"),
+        (false, false) => match color_state.is_some() {
+            true => panic!("specified color state fields but no fragment shader"),
+            false => &[],
+        },
+    };
+
+    let vertex_buffers: Vec<_> = vertex_buffers
+        .into_iter()
+        .map(|desc| wgpu::VertexBufferDescriptor {
+            stride: desc.stride,
+            step_mode: desc.step_mode,
+            attributes: desc.attributes,
+        })
+        .collect();
+
+    let pipeline_desc = wgpu::RenderPipelineDescriptor {
+        layout,
+        vertex_stage,
+        fragment_stage,
+        rasterization_state,
+        primitive_topology,
+        color_states,
+        depth_stencil_state,
+        index_format,
+        vertex_buffers: &vertex_buffers[..],
+        sample_count,
+        sample_mask,
+        alpha_to_coverage_enabled,
+    };
+
+    device.create_render_pipeline(&pipeline_desc)
+}

--- a/src/wgpu/texture/reshaper/mod.rs
+++ b/src/wgpu/texture/reshaper/mod.rs
@@ -186,7 +186,6 @@ fn bind_group_layout(device: &wgpu::Device, src_sample_count: u32) -> wgpu::Bind
     }
     builder.build(device)
 }
-
 fn bind_group(
     device: &wgpu::Device,
     layout: &wgpu::BindGroupLayout,
@@ -194,30 +193,13 @@ fn bind_group(
     sampler: &wgpu::Sampler,
     uniform_buffer: Option<&wgpu::Buffer>,
 ) -> wgpu::BindGroup {
-    let texture_binding = wgpu::Binding {
-        binding: 0,
-        resource: wgpu::BindingResource::TextureView(&texture),
-    };
-    let sampler_binding = wgpu::Binding {
-        binding: 1,
-        resource: wgpu::BindingResource::Sampler(&sampler),
-    };
-    let uniforms_binding = uniform_buffer.map(|buffer| wgpu::Binding {
-        binding: 2,
-        resource: wgpu::BindingResource::Buffer {
-            buffer,
-            range: 0..std::mem::size_of::<Uniforms>() as wgpu::BufferAddress,
-        },
-    });
-    let bindings = match uniforms_binding {
-        None => vec![texture_binding, sampler_binding],
-        Some(uniforms_binding) => vec![texture_binding, sampler_binding, uniforms_binding],
-    };
-    let desc = wgpu::BindGroupDescriptor {
-        layout,
-        bindings: &bindings,
-    };
-    device.create_bind_group(&desc)
+    let mut builder = wgpu::BindGroupBuilder::new()
+        .texture_view(texture)
+        .sampler(sampler);
+    if let Some(buffer) = uniform_buffer {
+        builder = builder.buffer::<Uniforms>(buffer, 0..1);
+    }
+    builder.build(device, layout)
 }
 
 fn pipeline_layout(

--- a/src/wgpu/texture/reshaper/mod.rs
+++ b/src/wgpu/texture/reshaper/mod.rs
@@ -119,23 +119,14 @@ impl Reshaper {
         dst_texture: &wgpu::TextureView,
         encoder: &mut wgpu::CommandEncoder,
     ) {
-        let vertex_range = 0..VERTICES.len() as u32;
-        let instance_range = 0..1;
-
-        let render_pass_desc = wgpu::RenderPassDescriptor {
-            color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
-                attachment: dst_texture,
-                resolve_target: None,
-                load_op: wgpu::LoadOp::Clear,
-                store_op: wgpu::StoreOp::Store,
-                clear_color: wgpu::Color::TRANSPARENT,
-            }],
-            depth_stencil_attachment: None,
-        };
-        let mut render_pass = encoder.begin_render_pass(&render_pass_desc);
+        let mut render_pass = wgpu::RenderPassBuilder::new()
+            .color_attachment(dst_texture, |color| color)
+            .begin(encoder);
         render_pass.set_pipeline(&self.render_pipeline);
         render_pass.set_vertex_buffers(0, &[(&self.vertex_buffer, 0)]);
         render_pass.set_bind_group(0, &self.bind_group, &[]);
+        let vertex_range = 0..VERTICES.len() as u32;
+        let instance_range = 0..1;
         render_pass.draw(vertex_range, instance_range);
     }
 }


### PR DESCRIPTION
The process of creating the bind group, render pipeline and their layouts can be quite tedious and explicit. This is great for reducing the chance of errors, but is perhaps not so ergonomic for the creative coding workflow where we'd like to throw together new pipelines quickly and easily.

The aim for these new types is to provide this quick-and-easy API by falling back to reasonable defaults in the case that some parameter has not been specified. All defaults have been exposed as constants on the associated builder types.