### PR TITLE
Fix "redraw event in non-redraw phase"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ threadpool = "1"
 toml = "0.5"
 walkdir = "2"
 wgpu = "0.4"
-winit = "0.21"
+winit = "0.22"
 
 [dev-dependencies]
 audrey = "0.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1391,8 +1391,8 @@ where
     }
 
     // Update the modifier keys within the app if necessary.
-    if let winit::event::Event::DeviceEvent { event, .. } = winit_event {
-        if let winit::event::DeviceEvent::ModifiersChanged(new_mods) = event {
+    if let winit::event::Event::WindowEvent { event, .. } = winit_event {
+        if let winit::event::WindowEvent::ModifiersChanged(new_mods) = event {
             app.keys.mods = new_mods.clone();
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -287,6 +287,10 @@ impl WindowEvent {
                 None => return None,
             },
 
+            winit::event::WindowEvent::ModifiersChanged(_) => {
+                return None;
+            },
+
             winit::event::WindowEvent::AxisMotion { .. }
             | winit::event::WindowEvent::ReceivedCharacter(_)
             | winit::event::WindowEvent::ThemeChanged(_)


### PR DESCRIPTION
This PR fixes "redraw event in non-redraw phase" on window resize/move by updating to winit 0.22. See [winit #1382](https://github.com/rust-windowing/winit/issues/1382).