### PR TITLE
Fix comments for the generation of SPIR-V files in wgpu examples

### DIFF
--- a/examples/wgpu/wgpu_compute_shader/shaders/shader.comp
+++ b/examples/wgpu/wgpu_compute_shader/shaders/shader.comp
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// and update `vert.spv`. You can do so using `glslangValidator` with the
 // following command: `glslangValidator -V -o comp.spv shader.comp`
+// and update `comp.spv`. You can do so using `glslangValidator` with the
 
 #version 450
 

--- a/examples/wgpu/wgpu_compute_shader/shaders/shader.comp
+++ b/examples/wgpu/wgpu_compute_shader/shaders/shader.comp
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// following command: `glslangValidator -V -o comp.spv shader.comp`
 // and update `comp.spv`. You can do so using `glslangValidator` with the
+// following command: `glslangValidator -V shader.comp`
 
 #version 450
 

--- a/examples/wgpu/wgpu_image/shaders/shader.frag
+++ b/examples/wgpu/wgpu_image/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// and update `vert.spv`. You can do so using `glslangValidator` with the
 // following command: `glslangValidator -V -o frag.spv shader.frag`
+// and update `frag.spv`. You can do so using `glslangValidator` with the
 
 #version 450
 

--- a/examples/wgpu/wgpu_image/shaders/shader.frag
+++ b/examples/wgpu/wgpu_image/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// following command: `glslangValidator -V -o frag.spv shader.frag`
 // and update `frag.spv`. You can do so using `glslangValidator` with the
+// following command: `glslangValidator -V shader.frag`
 
 #version 450
 

--- a/examples/wgpu/wgpu_image/shaders/shader.vert
+++ b/examples/wgpu/wgpu_image/shaders/shader.vert
@@ -2,7 +2,7 @@
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
 // and update `vert.spv`. You can do so using `glslangValidator` with the
-// following command: `glslangValidator -V -o vert.spv shader.vert`
+// following command: `glslangValidator -V shader.vert`
 
 #version 450
 

--- a/examples/wgpu/wgpu_image_sequence/shaders/shader.frag
+++ b/examples/wgpu/wgpu_image_sequence/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// and update `vert.spv`. You can do so using `glslangValidator` with the
 // following command: `glslangValidator -V -o frag.spv shader.frag`
+// and update `frag.spv`. You can do so using `glslangValidator` with the
 
 #version 450
 

--- a/examples/wgpu/wgpu_image_sequence/shaders/shader.frag
+++ b/examples/wgpu/wgpu_image_sequence/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// following command: `glslangValidator -V -o frag.spv shader.frag`
 // and update `frag.spv`. You can do so using `glslangValidator` with the
+// following command: `glslangValidator -V shader.frag`
 
 #version 450
 

--- a/examples/wgpu/wgpu_image_sequence/shaders/shader.vert
+++ b/examples/wgpu/wgpu_image_sequence/shaders/shader.vert
@@ -2,7 +2,7 @@
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
 // and update `vert.spv`. You can do so using `glslangValidator` with the
-// following command: `glslangValidator -V -o vert.spv shader.vert`
+// following command: `glslangValidator -V shader.vert`
 
 #version 450
 

--- a/examples/wgpu/wgpu_teapot/shaders/shader.frag
+++ b/examples/wgpu/wgpu_teapot/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// and update `vert.spv`. You can do so using `glslangValidator` with the
 // following command: `glslangValidator -V -o frag.spv shader.frag`
+// and update `frag.spv`. You can do so using `glslangValidator` with the
 
 #version 450
 

--- a/examples/wgpu/wgpu_teapot/shaders/shader.frag
+++ b/examples/wgpu/wgpu_teapot/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// following command: `glslangValidator -V -o frag.spv shader.frag`
 // and update `frag.spv`. You can do so using `glslangValidator` with the
+// following command: `glslangValidator -V shader.frag`
 
 #version 450
 

--- a/examples/wgpu/wgpu_teapot/shaders/shader.vert
+++ b/examples/wgpu/wgpu_teapot/shaders/shader.vert
@@ -2,7 +2,7 @@
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
 // and update `vert.spv`. You can do so using `glslangValidator` with the
-// following command: `glslangValidator -V -o vert.spv shader.vert`
+// following command: `glslangValidator -V shader.vert`
 
 #version 450
 

--- a/examples/wgpu/wgpu_teapot_camera/shaders/shader.frag
+++ b/examples/wgpu/wgpu_teapot_camera/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// and update `vert.spv`. You can do so using `glslangValidator` with the
 // following command: `glslangValidator -V -o frag.spv shader.frag`
+// and update `frag.spv`. You can do so using `glslangValidator` with the
 
 #version 450
 

--- a/examples/wgpu/wgpu_teapot_camera/shaders/shader.frag
+++ b/examples/wgpu/wgpu_teapot_camera/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// following command: `glslangValidator -V -o frag.spv shader.frag`
 // and update `frag.spv`. You can do so using `glslangValidator` with the
+// following command: `glslangValidator -V shader.frag`
 
 #version 450
 

--- a/examples/wgpu/wgpu_teapot_camera/shaders/shader.vert
+++ b/examples/wgpu/wgpu_teapot_camera/shaders/shader.vert
@@ -2,7 +2,7 @@
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
 // and update `vert.spv`. You can do so using `glslangValidator` with the
-// following command: `glslangValidator -V -o vert.spv shader.vert`
+// following command: `glslangValidator -V shader.vert`
 
 #version 450
 

--- a/examples/wgpu/wgpu_triangle/shaders/shader.frag
+++ b/examples/wgpu/wgpu_triangle/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// and update `vert.spv`. You can do so using `glslangValidator` with the
 // following command: `glslangValidator -V -o frag.spv shader.frag`
+// and update `frag.spv`. You can do so using `glslangValidator` with the
 
 #version 450
 

--- a/examples/wgpu/wgpu_triangle/shaders/shader.frag
+++ b/examples/wgpu/wgpu_triangle/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// following command: `glslangValidator -V -o frag.spv shader.frag`
 // and update `frag.spv`. You can do so using `glslangValidator` with the
+// following command: `glslangValidator -V shader.frag`
 
 #version 450
 

--- a/examples/wgpu/wgpu_triangle/shaders/shader.vert
+++ b/examples/wgpu/wgpu_triangle/shaders/shader.vert
@@ -2,7 +2,7 @@
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
 // and update `vert.spv`. You can do so using `glslangValidator` with the
-// following command: `glslangValidator -V -o vert.spv shader.vert`
+// following command: `glslangValidator -V shader.vert`
 
 #version 450
 

--- a/examples/wgpu/wgpu_triangle_raw_frame/shaders/shader.frag
+++ b/examples/wgpu/wgpu_triangle_raw_frame/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// and update `vert.spv`. You can do so using `glslangValidator` with the
 // following command: `glslangValidator -V -o frag.spv shader.frag`
+// and update `shader.spv`. You can do so using `glslangValidator` with the
 
 #version 450
 

--- a/examples/wgpu/wgpu_triangle_raw_frame/shaders/shader.frag
+++ b/examples/wgpu/wgpu_triangle_raw_frame/shaders/shader.frag
@@ -1,8 +1,8 @@
 // NOTE: This shader requires being manually compiled to SPIR-V in order to
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
-// following command: `glslangValidator -V -o frag.spv shader.frag`
 // and update `shader.spv`. You can do so using `glslangValidator` with the
+// following command: `glslangValidator -V shader.frag`
 
 #version 450
 

--- a/examples/wgpu/wgpu_triangle_raw_frame/shaders/shader.vert
+++ b/examples/wgpu/wgpu_triangle_raw_frame/shaders/shader.vert
@@ -2,7 +2,7 @@
 // avoid having downstream users require building shaderc and compiling the
 // shader themselves. If you update this shader, be sure to also re-compile it
 // and update `vert.spv`. You can do so using `glslangValidator` with the
-// following command: `glslangValidator -V -o vert.spv shader.vert`
+// following command: `glslangValidator -V shader.vert`
 
 #version 450
 


### PR DESCRIPTION
Fix names of the generated SPIR-V files in the comments (which were all invariably `vert.spv`) and remove the `-o ...` argument since it corresponds to the default pattern for the name of the generated file.
