### PR TITLE
Add function wgpu::shader_from_spirv_bytes()

### DIFF
--- a/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
+++ b/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
@@ -41,9 +41,7 @@ fn model(app: &App) -> Model {
     let device = window.swap_chain_device();
 
     // Create the compute shader module.
-    let cs = include_bytes!("shaders/comp.spv");
-    let cs_spirv = wgpu::read_spirv(std::io::Cursor::new(&cs[..])).unwrap();
-    let cs_mod = device.create_shader_module(&cs_spirv);
+    let cs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/comp.spv"));
 
     // Create the buffer that will store the result of our compute operation.
     let oscillator_buffer_size =

--- a/examples/wgpu/wgpu_image/wgpu_image.rs
+++ b/examples/wgpu/wgpu_image/wgpu_image.rs
@@ -62,14 +62,8 @@ fn model(app: &App) -> Model {
     let format = Frame::TEXTURE_FORMAT;
     let msaa_samples = window.msaa_samples();
 
-    let vs = include_bytes!("shaders/vert.spv");
-    let vs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&vs[..])).expect("failed to read hard-coded SPIRV");
-    let vs_mod = device.create_shader_module(&vs_spirv);
-    let fs = include_bytes!("shaders/frag.spv");
-    let fs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&fs[..])).expect("failed to read hard-coded SPIRV");
-    let fs_mod = device.create_shader_module(&fs_spirv);
+    let vs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/vert.spv"));
+    let fs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag.spv"));
 
     // Load the image as a texture.
     let texture = wgpu::Texture::from_image(&window, &image);

--- a/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
+++ b/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
@@ -86,14 +86,8 @@ fn model(app: &App) -> Model {
     let format = Frame::TEXTURE_FORMAT;
     let msaa_samples = window.msaa_samples();
 
-    let vs = include_bytes!("shaders/vert.spv");
-    let vs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&vs[..])).expect("failed to read hard-coded SPIRV");
-    let vs_mod = device.create_shader_module(&vs_spirv);
-    let fs = include_bytes!("shaders/frag.spv");
-    let fs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&fs[..])).expect("failed to read hard-coded SPIRV");
-    let fs_mod = device.create_shader_module(&fs_spirv);
+    let vs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/vert.spv"));
+    let fs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag.spv"));
 
     let texture_array = {
         // The wgpu device queue used to load the image data.

--- a/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
+++ b/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
@@ -77,14 +77,8 @@ fn model(app: &App) -> Model {
     let (win_w, win_h) = window.inner_size_pixels();
 
     // Load shader modules.
-    let vs = include_bytes!("shaders/vert.spv");
-    let vs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&vs[..])).expect("failed to read hard-coded SPIRV");
-    let vs_mod = device.create_shader_module(&vs_spirv);
-    let fs = include_bytes!("shaders/frag.spv");
-    let fs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&fs[..])).expect("failed to read hard-coded SPIRV");
-    let fs_mod = device.create_shader_module(&fs_spirv);
+    let vs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/vert.spv"));
+    let fs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag.spv"));
 
     // Create the vertex, normal and index buffers.
     let vertex_buffer = device

--- a/examples/wgpu/wgpu_teapot_camera/wgpu_teapot_camera.rs
+++ b/examples/wgpu/wgpu_teapot_camera/wgpu_teapot_camera.rs
@@ -119,14 +119,8 @@ fn model(app: &App) -> Model {
     let msaa_samples = window.msaa_samples();
     let (win_w, win_h) = window.inner_size_pixels();
 
-    let vs = include_bytes!("shaders/vert.spv");
-    let vs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&vs[..])).expect("failed to read hard-coded SPIRV");
-    let vs_mod = device.create_shader_module(&vs_spirv);
-    let fs = include_bytes!("shaders/frag.spv");
-    let fs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&fs[..])).expect("failed to read hard-coded SPIRV");
-    let fs_mod = device.create_shader_module(&fs_spirv);
+    let vs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/vert.spv"));
+    let fs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag.spv"));
 
     let vertex_buffer = device
         .create_buffer_mapped(data::VERTICES.len(), wgpu::BufferUsage::VERTEX)

--- a/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
+++ b/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
@@ -58,14 +58,8 @@ fn model(app: &App) -> Model {
     let sample_count = window.msaa_samples();
 
     // Load shader modules.
-    let vs = include_bytes!("shaders/vert.spv");
-    let vs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&vs[..])).expect("failed to read hard-coded SPIRV");
-    let vs_mod = device.create_shader_module(&vs_spirv);
-    let fs = include_bytes!("shaders/frag.spv");
-    let fs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&fs[..])).expect("failed to read hard-coded SPIRV");
-    let fs_mod = device.create_shader_module(&fs_spirv);
+    let vs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/vert.spv"));
+    let fs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag.spv"));
 
     // Create the vertex buffer.
     let vertex_buffer = device

--- a/examples/wgpu/wgpu_triangle_raw_frame/wgpu_triangle_raw_frame.rs
+++ b/examples/wgpu/wgpu_triangle_raw_frame/wgpu_triangle_raw_frame.rs
@@ -54,14 +54,8 @@ fn model(app: &App) -> Model {
     // NOTE: We are drawing to the swap chain format, rather than the `Frame::TEXTURE_FORMAT`.
     let format = window.swap_chain_descriptor().format;
 
-    let vs = include_bytes!("shaders/vert.spv");
-    let vs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&vs[..])).expect("failed to read hard-coded SPIRV");
-    let vs_mod = device.create_shader_module(&vs_spirv);
-    let fs = include_bytes!("shaders/frag.spv");
-    let fs_spirv =
-        wgpu::read_spirv(std::io::Cursor::new(&fs[..])).expect("failed to read hard-coded SPIRV");
-    let fs_mod = device.create_shader_module(&fs_spirv);
+    let vs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/vert.spv"));
+    let fs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag.spv"));
 
     let vertex_buffer = device
         .create_buffer_mapped(VERTICES.len(), wgpu::BufferUsage::VERTEX)

--- a/nannou/src/draw/renderer/mod.rs
+++ b/nannou/src/draw/renderer/mod.rs
@@ -412,14 +412,8 @@ impl Renderer {
         );
 
         // Load shader modules.
-        let vs = include_bytes!("shaders/vert.spv");
-        let vs_spirv = wgpu::read_spirv(std::io::Cursor::new(&vs[..]))
-            .expect("failed to read hard-coded SPIRV");
-        let vs_mod = device.create_shader_module(&vs_spirv);
-        let fs = include_bytes!("shaders/frag.spv");
-        let fs_spirv = wgpu::read_spirv(std::io::Cursor::new(&fs[..]))
-            .expect("failed to read hard-coded SPIRV");
-        let fs_mod = device.create_shader_module(&fs_spirv);
+        let vs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/vert.spv"));
+        let fs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag.spv"));
 
         // Create the glyph cache texture.
         let text_sampler = wgpu::SamplerBuilder::new().build(device);

--- a/nannou/src/wgpu/mod.rs
+++ b/nannou/src/wgpu/mod.rs
@@ -75,6 +75,12 @@ pub use wgpu::{
     VertexFormat,
 };
 
+pub fn shader_from_spirv_bytes(device: &wgpu::Device, bytes: &[u8]) -> wgpu::ShaderModule {
+    let cursor = std::io::Cursor::new(bytes);
+    let vs_spirv = wgpu::read_spirv(cursor).expect("failed to read hard-coded SPIRV");
+    device.create_shader_module(&vs_spirv)
+}
+
 /// The default set of options used to request a `wgpu::Adapter` when creating windows.
 pub const DEFAULT_ADAPTER_REQUEST_OPTIONS: RequestAdapterOptions = RequestAdapterOptions {
     power_preference: PowerPreference::HighPerformance,

--- a/nannou/src/wgpu/texture/reshaper/mod.rs
+++ b/nannou/src/wgpu/texture/reshaper/mod.rs
@@ -40,21 +40,15 @@ impl Reshaper {
         dst_format: wgpu::TextureFormat,
     ) -> Self {
         // Load shader modules.
-        let vs = include_bytes!("shaders/vert.spv");
-        let vs_spirv = wgpu::read_spirv(std::io::Cursor::new(&vs[..]))
-            .expect("failed to read hard-coded SPIRV");
-        let vs_mod = device.create_shader_module(&vs_spirv);
-        let fs = match src_sample_count {
-            1 => &include_bytes!("shaders/frag.spv")[..],
-            2 => &include_bytes!("shaders/frag_msaa2.spv")[..],
-            4 => &include_bytes!("shaders/frag_msaa4.spv")[..],
-            8 => &include_bytes!("shaders/frag_msaa8.spv")[..],
-            16 => &include_bytes!("shaders/frag_msaa16.spv")[..],
-            _ => &include_bytes!("shaders/frag_msaa.spv")[..],
+        let vs_mod = wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/vert.spv"));
+        let fs_mod = match src_sample_count {
+            1 => wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag.spv")),
+            2 => wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag_msaa2.spv")),
+            4 => wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag_msaa4.spv")),
+            8 => wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag_msaa8.spv")),
+            16 => wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag_msaa16.spv")),
+            _ => wgpu::shader_from_spirv_bytes(device, include_bytes!("shaders/frag_msaa.spv")),
         };
-        let fs_spirv =
-            wgpu::read_spirv(std::io::Cursor::new(fs)).expect("failed to read hard-coded SPIRV");
-        let fs_mod = device.create_shader_module(&fs_spirv);
 
         // Create the sampler for sampling from the source texture.
         let sampler = wgpu::SamplerBuilder::new().build(device);


### PR DESCRIPTION
wgpu::shader_from_spirv_bytes() reduces the amount of code required for loading shaders.