### PR TITLE
Add nonblocking LASER DAC detection. Polish `nannou_laser::ffi`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
     - Move `run_all_examples.rs` test into a new `scripts/` directory. Add
       ability to run examples of specific packages in the workspace.
     - Move `nature_of_code` examples
+- Add non-blocking LASER DAC detection via `Api::detect_dacs_async`.
+- Add nicer socket address and error handling to `nannou_laser::ffi`.
 
 # Version 0.13.1 (2020-03-05)
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,7 +21,7 @@ hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 nannou = { version = "0.13", path = "../nannou" }
 nannou_audio = { version = "0.2", path = "../nannou_audio" }
 nannou_isf = { version = "0.1", path = "../nannou_isf" }
-nannou_laser = { version = "0.3", path = "../nannou_laser" }
+nannou_laser = { version = "0.3", features = ["ffi"], path = "../nannou_laser" }
 nannou_osc = { version = "0.1", path = "../nannou_osc" }
 nannou_timeline = { version = "0.2", features = ["serde1"], path =  "../nannou_timeline" }
 pitch_calc = { version = "0.12", features = ["serde"] }

--- a/examples/laser/laser_ffi.rs
+++ b/examples/laser/laser_ffi.rs
@@ -19,16 +19,22 @@ fn main() {
     unsafe {
         // Create the API.
         println!("Initialising API...");
-        let mut api = std::ptr::null_mut();
-        nannou_laser::ffi::api_new(&mut api);
+        let mut api = std::mem::MaybeUninit::<nannou_laser::ffi::Api>::uninit();
+        nannou_laser::ffi::api_new(api.as_mut_ptr());
+        let mut api = api.assume_init();
 
         // Asynchronously detect DACs.
         println!("Initialising asynchronous DAC detector...");
-        let mut detect_dacs_async = std::ptr::null_mut();
+        let mut detect_dacs_async =
+            std::mem::MaybeUninit::<nannou_laser::ffi::DetectDacsAsync>::uninit();
         let timeout_secs = 1.0;
-        let res = nannou_laser::ffi::detect_dacs_async(api, timeout_secs, &mut detect_dacs_async);
+        let res = nannou_laser::ffi::detect_dacs_async(
+            &mut api,
+            timeout_secs,
+            detect_dacs_async.as_mut_ptr(),
+        );
         if res as u32 != 0 {
-            let err_cstr = std::ffi::CStr::from_ptr(nannou_laser::ffi::api_last_error(api));
+            let err_cstr = std::ffi::CStr::from_ptr(nannou_laser::ffi::api_last_error(&api));
             eprintln!(
                 "failed to initialise asynchronous DAC detection: {:?}",
                 err_cstr
@@ -36,6 +42,7 @@ fn main() {
             nannou_laser::ffi::api_drop(api);
             return;
         }
+        let mut detect_dacs_async = detect_dacs_async.assume_init();
 
         println!("Waiting for some DACs to be discovered...");
         std::thread::sleep(std::time::Duration::from_secs(2));
@@ -43,7 +50,7 @@ fn main() {
         // Check for discovered, available DACs.
         let mut dacs = std::ptr::null_mut();
         let mut len = 0;
-        nannou_laser::ffi::available_dacs(detect_dacs_async, &mut dacs, &mut len);
+        nannou_laser::ffi::available_dacs(&mut detect_dacs_async, &mut dacs, &mut len);
         if len > 0 {
             println!("The following DACs are available:");
             let slice = std::slice::from_raw_parts(dacs, len as usize);
@@ -55,7 +62,7 @@ fn main() {
         }
 
         // Check to see if an error occurred during detection.
-        let last_error = nannou_laser::ffi::detect_dacs_async_last_error(detect_dacs_async);
+        let last_error = nannou_laser::ffi::detect_dacs_async_last_error(&detect_dacs_async);
         if last_error != std::ptr::null() {
             let err_cstr = std::ffi::CStr::from_ptr(last_error);
             eprintln!("an error occurred during detection: {:?}", err_cstr);
@@ -67,9 +74,9 @@ fn main() {
         // Synchronous DAC detection.
         println!("Detecting DAC...");
         let mut dac = std::mem::MaybeUninit::<nannou_laser::ffi::DetectedDac>::uninit();
-        let res = nannou_laser::ffi::detect_dac(api, dac.as_mut_ptr());
+        let res = nannou_laser::ffi::detect_dac(&mut api, dac.as_mut_ptr());
         if res as u32 != 0 {
-            let err_cstr = std::ffi::CStr::from_ptr(nannou_laser::ffi::api_last_error(api));
+            let err_cstr = std::ffi::CStr::from_ptr(nannou_laser::ffi::api_last_error(&api));
             eprintln!("failed to detect DAC: {:?}", err_cstr);
             nannou_laser::ffi::api_drop(api);
             return;
@@ -88,16 +95,17 @@ fn main() {
         let frame_stream_conf = frame_stream_conf.assume_init();
         let callback_data: *mut CallbackData =
             Box::into_raw(Box::new(CallbackData { pattern: RECTANGLE }));
-        let mut frame_stream = std::ptr::null_mut();
+        let mut frame_stream = std::mem::MaybeUninit::<nannou_laser::ffi::FrameStream>::uninit();
         println!("Spawning new frame stream...");
         nannou_laser::ffi::new_frame_stream(
-            api,
-            &mut frame_stream,
+            &mut api,
+            frame_stream.as_mut_ptr(),
             &frame_stream_conf,
             callback_data as *mut std::os::raw::c_void,
             frame_render_callback,
             process_raw_callback,
         );
+        let frame_stream = frame_stream.assume_init();
 
         // Run through each pattern for 1 second.
         for pattern in 0..TOTAL_PATTERNS {
@@ -117,15 +125,16 @@ fn main() {
         let stream_conf = stream_conf.assume_init();
         let callback_data: *mut CallbackData =
             Box::into_raw(Box::new(CallbackData { pattern: RECTANGLE }));
-        let mut raw_stream = std::ptr::null_mut();
+        let mut raw_stream = std::mem::MaybeUninit::<nannou_laser::ffi::RawStream>::uninit();
         println!("Spawning a raw stream...");
         nannou_laser::ffi::new_raw_stream(
-            api,
-            &mut raw_stream,
+            &mut api,
+            raw_stream.as_mut_ptr(),
             &stream_conf,
             callback_data as *mut std::os::raw::c_void,
             raw_render_callback,
         );
+        let raw_stream = raw_stream.assume_init();
 
         std::thread::sleep(std::time::Duration::from_secs(1));
 

--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -19,3 +19,6 @@ failure = "0.1"
 hashbrown = "0.2"
 ether-dream = "0.2"
 petgraph = "0.4"
+
+[features]
+ffi = []

--- a/nannou_laser/cbindgen.toml
+++ b/nannou_laser/cbindgen.toml
@@ -1,0 +1,3 @@
+[parse]
+parse_deps = true
+include = ["ether-dream"]

--- a/nannou_laser/src/dac.rs
+++ b/nannou_laser/src/dac.rs
@@ -1,0 +1,194 @@
+//! Items related to DACs and DAC detection.
+
+use std::io;
+use std::sync::atomic::{self, AtomicBool};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Callback functions that may be passed to the `detect_dacs_async` function.
+pub trait DetectedDacCallback: FnMut(io::Result<DetectedDac>) {}
+impl<F> DetectedDacCallback for F where F: FnMut(io::Result<DetectedDac>) {}
+
+/// A persistent, unique identifier associated with a DAC (like a MAC address).
+///
+/// It should be possible to use this to uniquely identify the same DAC on different occasions.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Id {
+    EtherDream { mac_address: [u8; 6] },
+}
+
+/// An available DAC detected on the system.
+#[derive(Clone, Debug)]
+pub enum DetectedDac {
+    /// An ether dream laser DAC discovered via the ether dream protocol broadcast message.
+    EtherDream {
+        broadcast: ether_dream::protocol::DacBroadcast,
+        source_addr: std::net::SocketAddr,
+    },
+}
+
+/// An iterator yielding laser DACs available on the system as they are discovered.
+pub struct DetectDacs {
+    pub(crate) dac_broadcasts: ether_dream::RecvDacBroadcasts,
+}
+
+/// Messages that driver forward the DAC detector thread.
+enum DetectorThreadMsg {
+    /// A message indicating to stop detection and close the thread immediately.
+    Close,
+    /// A message emitted from a timer to step forward and check for DACs again.
+    Tick,
+}
+
+/// A handle to a non-blocking DAC detection thread.
+pub struct DetectDacsAsync {
+    msg_tx: mpsc::Sender<DetectorThreadMsg>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl DetectedDac {
+    /// The maximum point rate allowed by the DAC.
+    pub fn max_point_hz(&self) -> u32 {
+        match self {
+            DetectedDac::EtherDream { ref broadcast, .. } => broadcast.max_point_rate as _,
+        }
+    }
+
+    /// The number of points that can be stored within the buffer.
+    pub fn buffer_capacity(&self) -> u32 {
+        match self {
+            DetectedDac::EtherDream { ref broadcast, .. } => broadcast.buffer_capacity as _,
+        }
+    }
+
+    /// A persistent, unique identifier associated with the DAC (like a MAC address).
+    ///
+    /// It should be possible to use this to uniquely identify the same DAC on different occasions.
+    pub fn id(&self) -> Id {
+        match self {
+            DetectedDac::EtherDream { ref broadcast, .. } => Id::EtherDream {
+                mac_address: broadcast.mac_address,
+            },
+        }
+    }
+}
+
+impl DetectDacs {
+    /// Specify a duration for the detection to wait before timing out.
+    pub fn set_timeout(&self, duration: Option<std::time::Duration>) -> io::Result<()> {
+        self.dac_broadcasts.set_timeout(duration)
+    }
+
+    /// Specify whether or not retrieving the next DAC should block.
+    pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        self.dac_broadcasts.set_nonblocking(nonblocking)
+    }
+}
+
+impl DetectDacsAsync {
+    /// Close the DAC detection thread.
+    pub fn close(mut self) {
+        self.close_inner()
+    }
+
+    /// Private close implementation shared between `Drop` and `close`.
+    fn close_inner(&mut self) {
+        if let Some(thread) = self.thread.take() {
+            if self.msg_tx.send(DetectorThreadMsg::Close).is_ok() {
+                thread.join().ok();
+            }
+        }
+    }
+}
+
+impl Iterator for DetectDacs {
+    type Item = io::Result<DetectedDac>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let res = self.dac_broadcasts.next()?;
+        match res {
+            Err(err) => Some(Err(err)),
+            Ok((broadcast, source_addr)) => Some(Ok(DetectedDac::EtherDream {
+                broadcast,
+                source_addr,
+            })),
+        }
+    }
+}
+
+impl Drop for DetectDacsAsync {
+    fn drop(&mut self) {
+        self.close_inner();
+    }
+}
+
+/// An iterator yielding DACs available on the system as they are discovered.
+pub(crate) fn detect_dacs() -> io::Result<DetectDacs> {
+    let dac_broadcasts = ether_dream::recv_dac_broadcasts()?;
+    Ok(DetectDacs { dac_broadcasts })
+}
+
+/// Spawn a thread for DAC detection.
+///
+/// Calls the given `callback` with broadcasts as they are received.
+pub(crate) fn detect_dacs_async<F>(
+    timeout: Option<Duration>,
+    callback: F,
+) -> io::Result<DetectDacsAsync>
+where
+    F: 'static + DetectedDacCallback + Send,
+{
+    detect_dacs_async_inner(timeout, Box::new(callback) as Box<_>)
+}
+
+/// Inner implementation of `detect_dacs_async` removing static dispatch indirection.
+fn detect_dacs_async_inner(
+    timeout: Option<Duration>,
+    mut callback: Box<dyn 'static + DetectedDacCallback + Send>,
+) -> io::Result<DetectDacsAsync> {
+    let mut detect_dacs = detect_dacs()?;
+    detect_dacs.set_nonblocking(true)?;
+    let (msg_tx, msg_rx) = mpsc::channel();
+    let msg_tx2 = msg_tx.clone();
+    let thread = std::thread::Builder::new()
+        .name("nannou_laser-dac-detection".to_string())
+        .spawn(move || {
+            // For closing the timer thread.
+            let is_closed = Arc::new(AtomicBool::new(false));
+
+            // Start the timer.
+            let is_closed2 = is_closed.clone();
+            std::thread::spawn(move || {
+                let tick_interval = timeout.unwrap_or(std::time::Duration::from_secs(1));
+                while !is_closed2.load(atomic::Ordering::Relaxed) {
+                    std::thread::sleep(tick_interval);
+                    if msg_tx2.send(DetectorThreadMsg::Tick).is_err() {
+                        break;
+                    }
+                }
+            });
+
+            // Loop until we receive a close.
+            for msg in msg_rx {
+                if let DetectorThreadMsg::Close = msg {
+                    is_closed.store(true, atomic::Ordering::Relaxed);
+                    break;
+                }
+                if let Some(res) = detect_dacs.next() {
+                    if let Err(ref e) = res {
+                        match e.kind() {
+                            io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock => continue,
+                            _ => (),
+                        }
+                    }
+                    callback(res);
+                }
+            }
+        })
+        .expect("failed to spawn DAC detection thread");
+
+    Ok(DetectDacsAsync {
+        msg_tx,
+        thread: Some(thread),
+    })
+}

--- a/nannou_laser/src/lib.rs
+++ b/nannou_laser/src/lib.rs
@@ -3,6 +3,7 @@
 pub extern crate ether_dream;
 
 pub mod dac;
+#[cfg(feature = "ffi")]
 pub mod ffi;
 pub mod lerp;
 pub mod point;


### PR DESCRIPTION
This greatly simplifies the process of detecting laser DACs
asynchronously, particularly for languages other than Rust where thread
safety is like the wild west.