### PR TITLE
Depend on `nannou` by both version and path in `nannou_timeline`

### DIFF
--- a/nannou_timeline/Cargo.toml
+++ b/nannou_timeline/Cargo.toml
@@ -27,6 +27,6 @@ serde1 = [
 ]
 
 [dev-dependencies]
-nannou = "0.13"
+nannou = { version = "0.13", path = "../nannou" }
 rand = "0.3.12"
 serde_json = "1.0"


### PR DESCRIPTION
This makes it a little easier to ensure that `nannou_timeline` on master
also builds with `nannou` on master. Also acts as a nice version bump
check when publishing new crate versions.