### PR TITLE
fixes broken nannou slack invite link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ address before we can recommend using them just yet!
 
 - [Website](https://www.nannou.cc/)
 - [Guide](https://www.guide.nannou.cc/)
-- [Slack](https://nannou.slack.com)
+- [Slack](https://communityinviter.com/apps/nannou/nannou-slack)
 - [Support nannou!](https://opencollective.com/nannou)


### PR DESCRIPTION
the current link only works for people that have already been invited to the channel. This updates the link so users can then request and invite to be sent to them in order to join the slack channel.