### PR TITLE
Automate publishing nannou repositories if version is changed

### DIFF
--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -94,6 +94,45 @@ jobs:
         command: check
         args: --examples --verbose
 
+  cargo-publish:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    env:
+      CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Update apt
+      run: sudo apt update
+    - name: Install alsa dev tools
+      run: sudo apt-get install libasound2-dev
+    - name: Install libxcb dev tools
+      run: sudo apt-get install libxcb-composite0-dev
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Cargo publish nannou
+      continue-on-error: true
+      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou/Cargo.toml
+    - name: Cargo publish nannou_audio
+      continue-on-error: true
+      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_audio/Cargo.toml
+    # TODO: Add this once `nannou_isf` is ready.
+    # - name: Cargo publish nannou_isf
+    #   continue-on-error: true
+    #   run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_isf/Cargo.toml
+    - name: Cargo publish nannou_laser
+      continue-on-error: true
+      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_laser/Cargo.toml
+    - name: Cargo publish nannou_osc
+      continue-on-error: true
+      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_osc/Cargo.toml
+    - name: Cargo publish nannou_timeline
+      continue-on-error: true
+      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_timeline/Cargo.toml
+
   guide-build-book:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This adds a workflow that will automatically try to publish the `nannou`
and `nannou_*` crates every time a commit is pushed to `master`.

The idea is that we can now run `cargo run -p set_version -- X.Y.Z`,
commit the version update and push to the repo and the github action
will automatically publish all versions that have been incremented.

Another nice benefit is that contributors can now open their own PRs to
update crate versions. Maintainers are only required to merge, and no
longer need to manually run `cargo publish` locally.

This workflow may need a little tweaking over the next couple of
releases as its difficult to test until it comes time to make a release.