### PR TITLE
Remove some unnecessary dependencies from `nannou_laser`

### DIFF
--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -14,11 +14,9 @@ name = "nannou_laser"
 crate-type = ["rlib", "staticlib", "cdylib"]
 
 [dependencies]
-derive_more = "0.14"
-failure = "0.1"
-hashbrown = "0.2"
 ether-dream = "0.2"
 petgraph = "0.4"
+thiserror = "1"
 
 [features]
 ffi = []

--- a/nannou_laser/src/stream/frame/opt.rs
+++ b/nannou_laser/src/stream/frame/opt.rs
@@ -2,9 +2,9 @@
 
 use crate::lerp::Lerp;
 use crate::point::{Point, Position, RawPoint};
-use hashbrown::{HashMap, HashSet};
 use petgraph::visit::EdgeRef;
 use petgraph::Undirected;
+use std::collections::{HashMap, HashSet};
 
 /// Represents a line segment over which the laser scanner will travel.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -255,7 +255,7 @@ pub fn point_graph_to_euler_graph(pg: &PointGraph) -> EulerGraph {
     let ccs = petgraph::algo::kosaraju_scc(pg);
 
     // The indices of the connected components whose nodes all have an even degree.
-    let euler_components: hashbrown::HashSet<_> = ccs
+    let euler_components: HashSet<_> = ccs
         .iter()
         .enumerate()
         .filter(|(_, cc)| cc.iter().all(|&n| pg.edges(n).count() % 2 == 0))
@@ -804,7 +804,7 @@ mod test {
     };
     use super::{EulerGraph, PointGraph, SegmentKind};
     use crate::point::{Point, Position};
-    use hashbrown::HashSet;
+    use std::collections::HashSet;
 
     fn graph_eq<N, E, Ty, Ix>(
         a: &petgraph::Graph<N, E, Ty, Ix>,

--- a/nannou_laser/src/stream/raw.rs
+++ b/nannou_laser/src/stream/raw.rs
@@ -1,11 +1,10 @@
 use crate::util::{clamp, map_range};
 use crate::{DetectedDac, RawPoint};
-use derive_more::From;
-use failure::Fail;
 use std::io;
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{self, AtomicBool};
 use std::sync::{mpsc, Arc, Mutex};
+use thiserror::Error;
 
 /// The function that will be called when a `Buffer` of points is requested.
 pub trait RenderFn<M>: Fn(&mut M, &mut Buffer) {}
@@ -63,54 +62,51 @@ type StateUpdate = Box<dyn FnMut(&mut State) + 'static + Send>;
 pub type ModelUpdate<M> = Box<dyn FnMut(&mut M) + 'static + Send>;
 
 /// Errors that may occur while running a laser stream.
-#[derive(Debug, Fail, From)]
+#[derive(Debug, Error)]
 pub enum RawStreamError {
-    #[fail(display = "an Ether Dream DAC stream error occurred: {}", err)]
+    #[error("an Ether Dream DAC stream error occurred: {err}")]
     EtherDreamStream {
-        #[fail(cause)]
+        #[from]
         err: EtherDreamStreamError,
     },
 }
 
 /// Errors that may occur while creating a node crate.
-#[derive(Debug, Fail, From)]
+#[derive(Debug, Error)]
 pub enum EtherDreamStreamError {
-    #[fail(display = "laser DAC detection failed: {}", err)]
+    #[error("laser DAC detection failed: {err}")]
     FailedToDetectDacs {
-        #[fail(cause)]
+        #[from]
         err: io::Error,
     },
-    #[fail(display = "failed to connect the DAC stream: {}", err)]
+    #[error("failed to connect the DAC stream: {err}")]
     FailedToConnectStream {
-        #[fail(cause)]
+        #[source]
         err: ether_dream::dac::stream::CommunicationError,
     },
-    #[fail(display = "failed to prepare the DAC stream: {}", err)]
+    #[error("failed to prepare the DAC stream: {err}")]
     FailedToPrepareStream {
-        #[fail(cause)]
+        #[source]
         err: ether_dream::dac::stream::CommunicationError,
     },
-    #[fail(display = "failed to begin the DAC stream: {}", err)]
+    #[error("failed to begin the DAC stream: {err}")]
     FailedToBeginStream {
-        #[fail(cause)]
+        #[source]
         err: ether_dream::dac::stream::CommunicationError,
     },
-    #[fail(display = "failed to submit data over the DAC stream: {}", err)]
+    #[error("failed to submit data over the DAC stream: {err}")]
     FailedToSubmitData {
-        #[fail(cause)]
+        #[source]
         err: ether_dream::dac::stream::CommunicationError,
     },
-    #[fail(
-        display = "failed to submit point rate change over the DAC stream: {}",
-        err
-    )]
+    #[error("failed to submit point rate change over the DAC stream: {err}")]
     FailedToSubmitPointRate {
-        #[fail(cause)]
+        #[source]
         err: ether_dream::dac::stream::CommunicationError,
     },
-    #[fail(display = "failed to submit stop command to the DAC stream: {}", err)]
+    #[error("failed to submit stop command to the DAC stream: {err}")]
     FailedToStopStream {
-        #[fail(cause)]
+        #[source]
         err: ether_dream::dac::stream::CommunicationError,
     },
 }


### PR DESCRIPTION
This PR removes `nannou_laser`'s dependency on the `failure` and
`derive_more` crates in favour of the more minimal, library-friendly
`thiserror` crate.

Also removes the `hashbrown` dependency in favour of using the `std`
hash collections as I believe the `hashbrown` optimisations have since
been applied to `std`.

This removes the need for about ~15 upstream crates.

Closes #520.