### PR TITLE
Support for stream error handling to nannou_laser

### DIFF
--- a/nannou_laser/src/ffi.rs
+++ b/nannou_laser/src/ffi.rs
@@ -111,6 +111,32 @@ pub enum Result {
     DetectDacFailed,
     BuildStreamFailed,
     DetectDacsAsyncFailed,
+    CloseStreamFailed,
+    NullPointer,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct StreamError {
+    inner: *const StreamErrorInner,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum StreamErrorKind {
+    EtherDreamFailedToDetectDacs,
+    EtherDreamFailedToConnectStream,
+    EtherDreamFailedToPrepareStream,
+    EtherDreamFailedToBeginStream,
+    EtherDreamFailedToSubmitData,
+    EtherDreamFailedToSubmitPointRate,
+    EtherDreamFailedToStopStream,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct StreamErrorAction {
+    inner: *mut StreamErrorActionInner,
 }
 
 /// A set of stream configuration parameters unique to `Frame` streams.
@@ -161,8 +187,17 @@ struct DetectDacsAsyncInner {
     last_error: Arc<Mutex<Option<CString>>>,
 }
 
-struct FrameStreamModel(*mut raw::c_void, FrameRenderCallback, RawRenderCallback);
-struct RawStreamModel(*mut raw::c_void, RawRenderCallback);
+struct StreamErrorInner(*const crate::StreamError);
+
+struct StreamErrorActionInner(*mut crate::StreamErrorAction);
+
+struct FrameStreamModel(
+    *mut raw::c_void,
+    FrameRenderCallback,
+    RawRenderCallback,
+    StreamErrorCallback,
+);
+struct RawStreamModel(*mut raw::c_void, RawRenderCallback, StreamErrorCallback);
 
 unsafe impl Send for FrameStreamModel {}
 unsafe impl Send for RawStreamModel {}
@@ -170,12 +205,10 @@ unsafe impl Send for RawStreamModel {}
 struct FrameStreamInner(crate::FrameStream<FrameStreamModel>);
 struct RawStreamInner(crate::RawStream<RawStreamModel>);
 
-/// Cast to `extern fn(*mut raw::c_void, *mut Frame)` internally.
-//pub type FrameRenderCallback = *const raw::c_void;
 pub type FrameRenderCallback = extern "C" fn(*mut raw::c_void, *mut Frame);
-/// Cast to `extern fn(*mut raw::c_void, *mut Buffer)` internally.
-//pub type RawRenderCallback = *const raw::c_void;
 pub type RawRenderCallback = extern "C" fn(*mut raw::c_void, *mut Buffer);
+pub type StreamErrorCallback =
+    extern "C" fn(*mut raw::c_void, *const StreamError, *mut StreamErrorAction);
 
 /// Given some uninitialized pointer to an `Api` struct, fill it with a new Api instance.
 #[no_mangle]
@@ -200,9 +233,7 @@ pub unsafe extern "C" fn detect_dacs_async(
     let duration = if timeout_secs == 0.0 {
         None
     } else {
-        let secs = timeout_secs as u64;
-        let nanos = ((timeout_secs - secs as raw::c_float) * 1_000_000_000.0) as u32;
-        Some(std::time::Duration::new(secs, nanos))
+        Some(duration_from_secs_f32(timeout_secs))
     };
     let boxed_detect_dacs_inner = match detect_dacs_async_inner(&api.inner, duration) {
         Ok(detector) => Box::new(detector),
@@ -309,15 +340,45 @@ pub unsafe extern "C" fn new_frame_stream(
     callback_data: *mut raw::c_void,
     frame_render_callback: FrameRenderCallback,
     process_raw_callback: RawRenderCallback,
+    stream_error_callback: StreamErrorCallback,
 ) -> Result {
     let api: &mut ApiInner = &mut (*(*api).inner);
-    let model = FrameStreamModel(callback_data, frame_render_callback, process_raw_callback);
+    let model = FrameStreamModel(
+        callback_data,
+        frame_render_callback,
+        process_raw_callback,
+        stream_error_callback,
+    );
 
     fn render_fn(model: &mut FrameStreamModel, frame: &mut crate::stream::frame::Frame) {
-        let FrameStreamModel(callback_data_ptr, frame_render_callback, _) = *model;
+        let FrameStreamModel(callback_data_ptr, frame_render_callback, _, _) = *model;
         let mut inner = FrameInner(frame);
         let mut frame = Frame { inner: &mut inner };
         frame_render_callback(callback_data_ptr, &mut frame);
+    }
+
+    fn process_raw_fn(model: &mut FrameStreamModel, buffer: &mut crate::stream::raw::Buffer) {
+        let FrameStreamModel(callback_data_ptr, _, process_raw_callback, _) = *model;
+        let mut inner = BufferInner(buffer);
+        let mut buffer = Buffer { inner: &mut inner };
+        process_raw_callback(callback_data_ptr, &mut buffer);
+    }
+
+    fn stream_error_fn(
+        model: &mut FrameStreamModel,
+        err: &crate::stream::raw::StreamError,
+        action: &mut crate::stream::raw::StreamErrorAction,
+    ) {
+        let FrameStreamModel(callback_data_ptr, _, _, stream_error_callback) = *model;
+        let mut inner = StreamErrorActionInner(action);
+        let mut action = StreamErrorAction {
+            inner: &mut inner as *mut _,
+        };
+        let inner = StreamErrorInner(err);
+        let err = StreamError {
+            inner: &inner as *const _,
+        };
+        stream_error_callback(callback_data_ptr, &err, &mut action);
     }
 
     let mut builder = api
@@ -325,16 +386,9 @@ pub unsafe extern "C" fn new_frame_stream(
         .new_frame_stream(model, render_fn)
         .point_hz((*config).stream_conf.point_hz as _)
         .latency_points((*config).stream_conf.latency_points as _)
-        .frame_hz((*config).frame_hz as _);
-
-    fn process_raw_fn(model: &mut FrameStreamModel, buffer: &mut crate::stream::raw::Buffer) {
-        let FrameStreamModel(callback_data_ptr, _, process_raw_callback) = *model;
-        let mut inner = BufferInner(buffer);
-        let mut buffer = Buffer { inner: &mut inner };
-        process_raw_callback(callback_data_ptr, &mut buffer);
-    }
-
-    builder = builder.process_raw(process_raw_fn);
+        .frame_hz((*config).frame_hz as _)
+        .process_raw(process_raw_fn)
+        .stream_error(stream_error_fn);
 
     if (*config).stream_conf.detected_dac != std::ptr::null() {
         let ffi_dac = (*(*config).stream_conf.detected_dac).clone();
@@ -365,22 +419,41 @@ pub unsafe extern "C" fn new_raw_stream(
     config: *const StreamConfig,
     callback_data: *mut raw::c_void,
     process_raw_callback: RawRenderCallback,
+    stream_error_callback: StreamErrorCallback,
 ) -> Result {
     let api: &mut ApiInner = &mut (*(*api).inner);
-    let model = RawStreamModel(callback_data, process_raw_callback);
+    let model = RawStreamModel(callback_data, process_raw_callback, stream_error_callback);
 
     fn render_fn(model: &mut RawStreamModel, buffer: &mut crate::stream::raw::Buffer) {
-        let RawStreamModel(callback_data_ptr, raw_render_callback) = *model;
+        let RawStreamModel(callback_data_ptr, raw_render_callback, _) = *model;
         let mut inner = BufferInner(buffer);
         let mut buffer = Buffer { inner: &mut inner };
         raw_render_callback(callback_data_ptr, &mut buffer);
+    }
+
+    fn stream_error_fn(
+        model: &mut RawStreamModel,
+        err: &crate::stream::raw::StreamError,
+        action: &mut crate::stream::raw::StreamErrorAction,
+    ) {
+        let RawStreamModel(callback_data_ptr, _, stream_error_callback) = *model;
+        let mut inner = StreamErrorActionInner(action);
+        let mut action = StreamErrorAction {
+            inner: &mut inner as *mut _,
+        };
+        let inner = StreamErrorInner(err);
+        let err = StreamError {
+            inner: &inner as *const _,
+        };
+        stream_error_callback(callback_data_ptr, &err, &mut action);
     }
 
     let mut builder = api
         .inner
         .new_raw_stream(model, render_fn)
         .point_hz((*config).point_hz as _)
-        .latency_points((*config).latency_points as _);
+        .latency_points((*config).latency_points as _)
+        .stream_error(stream_error_fn);
 
     if (*config).detected_dac != std::ptr::null() {
         let ffi_dac = (*(*config).detected_dac).clone();
@@ -511,6 +584,46 @@ pub unsafe extern "C" fn frame_stream_set_frame_hz(
     (*stream.inner).0.set_frame_hz(frame_hz).is_ok()
 }
 
+/// Returns whether or not the communication thread has closed.
+///
+/// A stream may be closed if an error has occurred and the stream error callback indicated to
+/// close the thread. A stream might also be closed if another `close` was called on another handle
+/// to the stream.
+///
+/// In this case, the `Stream` should be closed or dropped and a new one should be created to
+/// replace it.
+#[no_mangle]
+pub unsafe extern "C" fn frame_stream_is_closed(stream: *const FrameStream) -> bool {
+    let stream: &FrameStream = &*stream;
+    (*stream.inner).0.is_closed()
+}
+
+/// Close the TCP communication thread and wait for the thread to join.
+///
+/// This consumes and drops the `Stream`, returning the result produced by joining the thread.
+///
+/// This method will block until the associated thread has been joined.
+#[no_mangle]
+pub unsafe extern "C" fn frame_stream_close(api: *mut Api, stream: FrameStream) -> Result {
+    if stream.inner != std::ptr::null_mut() {
+        match Box::from_raw(stream.inner).0.close() {
+            Some(Ok(Ok(()))) => Result::Success,
+            Some(Ok(Err(err))) => {
+                (*(*api).inner).last_error = Some(err_to_cstring(&err));
+                return Result::CloseStreamFailed;
+            }
+            Some(Err(_err)) => {
+                let string = format!("failed to join stream thread");
+                (*(*api).inner).last_error = Some(string_to_cstring(string));
+                return Result::CloseStreamFailed;
+            }
+            None => Result::Success,
+        }
+    } else {
+        Result::NullPointer
+    }
+}
+
 /// Update the rate at which the DAC should process points per second.
 ///
 /// This value should be no greater than the detected DAC's `max_point_hz`.
@@ -539,6 +652,46 @@ pub unsafe extern "C" fn raw_stream_set_latency_points(
 ) -> bool {
     let stream: &RawStream = &*stream;
     (*stream.inner).0.set_latency_points(points).is_ok()
+}
+
+/// Returns whether or not the communication thread has closed.
+///
+/// A stream may be closed if an error has occurred and the stream error callback indicated to
+/// close the thread. A stream might also be closed if another `close` was called on another handle
+/// to the stream.
+///
+/// In this case, the `Stream` should be closed or dropped and a new one should be created to
+/// replace it.
+#[no_mangle]
+pub unsafe extern "C" fn raw_stream_is_closed(stream: *const RawStream) -> bool {
+    let stream: &RawStream = &*stream;
+    (*stream.inner).0.is_closed()
+}
+
+/// Close the TCP communication thread and wait for the thread to join.
+///
+/// This consumes and drops the `Stream`, returning the result produced by joining the thread.
+///
+/// This method will block until the associated thread has been joined.
+#[no_mangle]
+pub unsafe extern "C" fn raw_stream_close(api: *mut Api, stream: RawStream) -> Result {
+    if stream.inner != std::ptr::null_mut() {
+        match Box::from_raw(stream.inner).0.close() {
+            Some(Ok(Ok(()))) => Result::Success,
+            Some(Ok(Err(err))) => {
+                (*(*api).inner).last_error = Some(err_to_cstring(&err));
+                return Result::CloseStreamFailed;
+            }
+            Some(Err(_err)) => {
+                let string = format!("failed to join stream thread");
+                (*(*api).inner).last_error = Some(string_to_cstring(string));
+                return Result::CloseStreamFailed;
+            }
+            None => Result::Success,
+        }
+    } else {
+        Result::NullPointer
+    }
 }
 
 /// Add a sequence of consecutive points separated by blank space.
@@ -652,6 +805,64 @@ pub unsafe extern "C" fn detect_dacs_async_last_error(
     s
 }
 
+/// Retrieve the kind of the stream error.
+#[no_mangle]
+pub unsafe extern "C" fn stream_error_kind(err: *const StreamError) -> StreamErrorKind {
+    let err: &crate::StreamError = &*(*(*err).inner).0;
+    stream_error_to_kind(err)
+}
+
+/// Retrieve the number of attempts from the stream error.
+///
+/// If the error is `EtherDreamFailedToConnectStream`, this refers to the consecutive number of
+/// failed attempts to establish a TCP connection with the DAC.
+///
+/// If the error is `EtherDreamFailedToDetectDac`, this refers to the consecutive number of failed
+/// attempts to detect the requested DAC.
+#[no_mangle]
+pub unsafe extern "C" fn stream_error_attempts(err: *const StreamError) -> u32 {
+    let err: &crate::StreamError = &*(*(*err).inner).0;
+    stream_error_to_attempts(err)
+}
+
+/// Set the error action to reattempt the TCP stream connection.
+///
+/// This action attempts to reconnect to the specified DAC in the case that one was provided, or
+/// any DAC in the case that `None` was provided.
+#[no_mangle]
+pub unsafe extern "C" fn stream_error_action_set_reattempt_connect(action: *mut StreamErrorAction) {
+    let target = crate::StreamErrorAction::ReattemptConnect;
+    stream_error_action_set(action, target);
+}
+
+/// Set the error action to redetect the DAC.
+///
+/// This action attempts to re-detect the same DAC in the case that one was specified, or any DAC in the
+/// case that `None` was provided.
+///
+/// This can be useful in the case where the DAC has dropped from the network and may have
+/// re-appeared broadcasting from a different IP address.
+#[no_mangle]
+pub unsafe extern "C" fn stream_error_action_set_redetect_dacs(
+    action: *mut StreamErrorAction,
+    timeout_secs: f32,
+) {
+    let timeout = if timeout_secs < 0.0 {
+        None
+    } else {
+        Some(duration_from_secs_f32(timeout_secs))
+    };
+    let target = crate::StreamErrorAction::RedetectDac { timeout };
+    stream_error_action_set(action, target);
+}
+
+/// Set the error action to close the TCP communication thread.
+#[no_mangle]
+pub unsafe extern "C" fn stream_error_action_set_close_thread(action: *mut StreamErrorAction) {
+    let target = crate::StreamErrorAction::CloseThread;
+    stream_error_action_set(action, target);
+}
+
 /// Begin asynchronous DAC detection.
 ///
 /// The given timeout corresponds to the duration of time since the last DAC broadcast was received
@@ -690,6 +901,20 @@ fn detect_dacs_async_inner(
         dacs,
         last_error,
     })
+}
+
+unsafe fn stream_error_action_set(
+    action: *mut StreamErrorAction,
+    target: crate::StreamErrorAction,
+) {
+    let action: &mut crate::StreamErrorAction = &mut *(*(*action).inner).0;
+    *action = target;
+}
+
+fn duration_from_secs_f32(secs: f32) -> Duration {
+    let whole_secs = secs as u64;
+    let nanos = ((secs - whole_secs as raw::c_float) * 1_000_000_000.0) as u32;
+    std::time::Duration::new(whole_secs, nanos)
 }
 
 fn err_to_cstring(err: &dyn fmt::Display) -> CString {
@@ -769,5 +994,45 @@ fn detected_dac_from_ffi(ffi_dac: DetectedDac) -> crate::DetectedDac {
             broadcast,
             source_addr,
         }
+    }
+}
+
+fn stream_error_to_kind(err: &crate::StreamError) -> StreamErrorKind {
+    use crate::stream::raw::EtherDreamStreamError;
+    match *err {
+        crate::StreamError::EtherDreamStream { ref err } => match *err {
+            EtherDreamStreamError::FailedToDetectDacs { .. } => {
+                StreamErrorKind::EtherDreamFailedToDetectDacs
+            }
+            EtherDreamStreamError::FailedToConnectStream { .. } => {
+                StreamErrorKind::EtherDreamFailedToConnectStream
+            }
+            EtherDreamStreamError::FailedToPrepareStream { .. } => {
+                StreamErrorKind::EtherDreamFailedToPrepareStream
+            }
+            EtherDreamStreamError::FailedToBeginStream { .. } => {
+                StreamErrorKind::EtherDreamFailedToBeginStream
+            }
+            EtherDreamStreamError::FailedToSubmitData { .. } => {
+                StreamErrorKind::EtherDreamFailedToSubmitData
+            }
+            EtherDreamStreamError::FailedToSubmitPointRate { .. } => {
+                StreamErrorKind::EtherDreamFailedToSubmitPointRate
+            }
+            EtherDreamStreamError::FailedToStopStream { .. } => {
+                StreamErrorKind::EtherDreamFailedToStopStream
+            }
+        },
+    }
+}
+
+fn stream_error_to_attempts(err: &crate::StreamError) -> u32 {
+    use crate::stream::raw::EtherDreamStreamError;
+    match *err {
+        crate::StreamError::EtherDreamStream { ref err } => match *err {
+            EtherDreamStreamError::FailedToDetectDacs { attempts, .. }
+            | EtherDreamStreamError::FailedToConnectStream { attempts, .. } => attempts,
+            _ => 0,
+        },
     }
 }

--- a/nannou_laser/src/lib.rs
+++ b/nannou_laser/src/lib.rs
@@ -15,8 +15,8 @@ pub use lerp::Lerp;
 pub use point::{Point, RawPoint};
 pub use stream::frame::Frame;
 pub use stream::frame::Stream as FrameStream;
-pub use stream::raw::Buffer;
 pub use stream::raw::Stream as RawStream;
+pub use stream::raw::{Buffer, StreamError, StreamErrorAction};
 
 use std::io;
 use std::sync::Arc;
@@ -88,12 +88,14 @@ impl Api {
         let frame_hz = None;
         let interpolation_conf = Default::default();
         let process_raw = stream::frame::default_process_raw_fn;
+        let stream_error = stream::raw::default_stream_error_fn;
         stream::frame::Builder {
             api_inner,
             builder,
             model,
             render,
             process_raw,
+            stream_error,
             frame_hz,
             interpolation_conf,
         }
@@ -109,11 +111,13 @@ impl Api {
     {
         let api_inner = self.inner.clone();
         let builder = Default::default();
+        let stream_error = stream::raw::default_stream_error_fn;
         stream::raw::Builder {
             api_inner,
             builder,
             model,
             render,
+            stream_error,
         }
     }
 }

--- a/nannou_laser/src/stream/frame/mod.rs
+++ b/nannou_laser/src/stream/frame/mod.rs
@@ -4,6 +4,7 @@ use crate::{Point, RawPoint};
 use std::io;
 use std::ops::{Deref, DerefMut};
 use std::sync::{mpsc, Arc, Mutex};
+use std::time::Duration;
 
 pub mod opt;
 
@@ -136,6 +137,15 @@ impl<M, F, R, E> Builder<M, F, R, E> {
     /// The DAC with which the stream should be established.
     pub fn detected_dac(mut self, dac: crate::DetectedDac) -> Self {
         self.builder.dac = Some(dac);
+        self
+    }
+
+    /// The duration before TCP connection or communication attempts will time out.
+    ///
+    /// If this value is `None` (the default case), no timeout will be applied and the stream will
+    /// wait forever.
+    pub fn tcp_timeout(mut self, tcp_timeout: Option<Duration>) -> Self {
+        self.builder.tcp_timeout = tcp_timeout;
         self
     }
 

--- a/nannou_laser/src/stream/mod.rs
+++ b/nannou_laser/src/stream/mod.rs
@@ -21,6 +21,10 @@ pub struct Builder {
     /// Each time the laser indicates its "fullness", the raw stream will request enough points
     /// from the render function to fill the DAC buffer up to `latency_points`.
     pub latency_points: Option<u32>,
+    /// The duration before TCP connection or communication attempts will time out.
+    ///
+    /// If this value is `None`, no timeout will be applied and the stream will wait forever.
+    pub tcp_timeout: Option<std::time::Duration>,
 }
 
 /// Given a DAC point rate and a desired frame rate, determine how many points to generate per

--- a/nannou_laser/src/stream/raw.rs
+++ b/nannou_laser/src/stream/raw.rs
@@ -666,13 +666,11 @@ where
     let ip = src_addr.ip().clone();
     let result = match tcp_timeout {
         None => ether_dream::dac::stream::connect(&broadcast, ip),
-        Some(timeout) => {
-            ether_dream::dac::stream::connect_timeout(&broadcast, ip, timeout)
-                .and_then(|stream| {
-                    stream.set_timeout(Some(timeout))?;
-                    Ok(stream)
-                })
-        }
+        Some(timeout) => ether_dream::dac::stream::connect_timeout(&broadcast, ip, timeout)
+            .and_then(|stream| {
+                stream.set_timeout(Some(timeout))?;
+                Ok(stream)
+            }),
     };
     let mut stream = match result {
         Ok(stream) => stream,


### PR DESCRIPTION
This adds the ability to add a stream error callback function to both
the raw and frame stream types during building.

An action can be specified to take in response to the error. Options
include attempting to re-detect the DAC, reconnect to the TCP stream and
closing the stream thread.

Methods have also been added to the stream types to allow for checking
whether or not the stream has been closed, and for closing the stream
manually and checking the result.

The `ffi` module has been updated to provide access to this new
functionality.