### PR TITLE
Small guide fixes

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -1,4 +1,4 @@
-# the nannou guide [![Build Status](https://travis-ci.org/nannou-org/guide.svg?branch=master)](https://travis-ci.org/nannou-org/guide)
+# the nannou guide
 
 The one-stop-shop for everything someone might want to know about nannou!
 
@@ -8,8 +8,8 @@ The easiest way to build, render and read the book is as follows:
 
 - Clone the repo.
   ```bash
-  git clone https://github.com/nannou-org/guide
-  cd guide
+  git clone https://github.com/nannou-org/nannou
+  cd nannou/guide
   ```
 - Install the [Rust markdown book](https://github.com/rust-lang-nursery/mdBook) tool.
   ```

--- a/guide/src/why_nannou.md
+++ b/guide/src/why_nannou.md
@@ -124,4 +124,4 @@ Further reading:
 * [Please read: Rust license changing (very slightly)](https://mail.mozilla.org/pipermail/rust-dev/2012-November/002664.html)
 * [Rationale of Apache dual licensing](https://internals.rust-lang.org/t/rationale-of-apache-dual-licensing/8952)
 * [Against what does the Apache 2.0 patent clause protect?](https://opensource.stackexchange.com/questions/1881/against-what-does-the-apache-2-0-patent-clause-protect)
-* [GPLv2 Combination Exception for the Apache 2 License]https://blog.gerv.net/2016/09/gplv2-combination-exception-for-the-apache-2-license/)
+* [GPLv2 Combination Exception for the Apache 2 License](https://blog.gerv.net/2016/09/gplv2-combination-exception-for-the-apache-2-license/)


### PR DESCRIPTION
This removes the Travis CI badge for the previous standalone guide repo. I didn't see a guide-specific workflow in the actions (https://github.com/nannou-org/nannou/actions). Lemme know if the guide readme should use the overall badge, or maybe there should be a guide-specific workflow?