### PR TITLE
Some documentation fixes

### DIFF
--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -6,8 +6,6 @@
 //! - [**App**](./struct.App.html) - provides a context and API for windowing, devices, etc.
 //! - [**Proxy**](./struct.Proxy.html) - a handle to an **App** that may be used from a non-main
 //!   thread.
-//! - [**Draw**](./struct.Draw.html) - a simple API for drawing graphics, accessible via
-//!   `app.draw()`.
 //! - [**LoopMode**](./enum.LoopMode.html) - describes the behaviour of the application event loop.
 
 use crate::draw;

--- a/nannou/src/color/mod.rs
+++ b/nannou/src/color/mod.rs
@@ -1,6 +1,7 @@
 //! Color items, including everything from rgb, hsb/l/v, lap, alpha, luma and more, provided by the
-//! palette crate. See [the palette docs](https://docs.rs/palette) for more details or see the
-//! [**named**](./named/index.html) module for a set of provided color constants.
+//! [palette crate](https://docs.rs/palette).
+//!
+//! See the [**named**](./named/index.html) module for a set of provided color constants.
 
 pub mod conv;
 

--- a/nannou/src/draw/mod.rs
+++ b/nannou/src/draw/mod.rs
@@ -1,5 +1,6 @@
-//! A simple API for drawing 2D and 3D graphics. See the [**Draw** type](./struct.Draw.html) for
-//! more details.
+//! A simple API for drawing 2D and 3D graphics.
+//!
+//! See the [**Draw** type](./struct.Draw.html) for more details.
 
 use crate::geom::{self, Point2};
 use crate::math::{deg_to_rad, turns_to_rad, BaseFloat, Matrix4, SquareMatrix};

--- a/nannou/src/ease.rs
+++ b/nannou/src/ease.rs
@@ -1,4 +1,4 @@
 //! A suite of common interpolation functions often referred to as "easing" and "tweening"
-//! functions. This API is provided by the [**pennereq** crate](https://docs.rs/pennereq).
+//! functions. This API is provided by the [pennereq crate](https://docs.rs/pennereq).
 
 pub use pennereq::*;

--- a/nannou/src/event.rs
+++ b/nannou/src/event.rs
@@ -1,9 +1,10 @@
 //! Application, event loop and window event definitions and implementations.
 //!
 //! - [**Event**](./enum.Event.html) - the default application event type.
-//! - [**winit::event::WindowEvent**](./struct.WindowEvent.html) - events related to a single window.
-//! - [**WindowEvent**](./struct.WindowEvent.html) - a stripped-back, simplified,
-//!   newcomer-friendly version of the **raw**, low-level winit event.
+//! - [**winit::event::WindowEvent**](https://docs.rs/winit/0.22.1/winit/event/enum.WindowEvent.html) -
+//!   events related to a single window.
+//! - [**WindowEvent**](./enum.WindowEvent.html) - a stripped-back, simplified, newcomer-friendly
+//!   version of the **raw**, low-level winit event.
 
 use crate::geom::{self, Point2, Vector2};
 use crate::window;

--- a/nannou/src/event.rs
+++ b/nannou/src/event.rs
@@ -1,6 +1,6 @@
 //! Application, event loop and window event definitions and implementations.
 //!
-//! - [**Event**](./enum.Event.html) - the defualt application event type.
+//! - [**Event**](./enum.Event.html) - the default application event type.
 //! - [**winit::event::WindowEvent**](./struct.WindowEvent.html) - events related to a single window.
 //! - [**WindowEvent**](./struct.WindowEvent.html) - a stripped-back, simplified,
 //!   newcomer-friendly version of the **raw**, low-level winit event.
@@ -40,8 +40,10 @@ pub struct Update {
 pub enum Event {
     /// A window-specific event has occurred for the window with the given Id.
     ///
-    /// This event is portrayed both in its "raw" form (the **winit::event::WindowEvent**) and its
-    /// simplified, new-user-friendly form **SimpleWindowEvent**.
+    /// The event is available as a **WindowEvent**, a more user-friendly form of
+    /// **winit::event::WindowEvent**. Once
+    /// [winit#1387](https://github.com/rust-windowing/winit/issues/1387) is fixed, its "raw" form
+    /// will also be available.
     WindowEvent {
         id: window::Id,
         simple: Option<WindowEvent>,
@@ -135,7 +137,7 @@ pub enum WindowEvent {
     /// A mouse wheel movement or touchpad scroll occurred.
     MouseWheel(MouseScrollDelta, TouchPhase),
 
-    /// The window was resized to the given dimensions.
+    /// The window was resized to the given dimensions (in DPI-agnostic points, not pixels).
     Resized(Vector2<geom::scalar::Default>),
 
     /// A file at the given path was hovered over the window.

--- a/nannou/src/event.rs
+++ b/nannou/src/event.rs
@@ -1,7 +1,7 @@
 //! Application, event loop and window event definitions and implementations.
 //!
 //! - [**Event**](./enum.Event.html) - the default application event type.
-//! - [**winit::event::WindowEvent**](https://docs.rs/winit/0.22.1/winit/event/enum.WindowEvent.html) -
+//! - [**winit::event::WindowEvent**](https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html) -
 //!   events related to a single window.
 //! - [**WindowEvent**](./enum.WindowEvent.html) - a stripped-back, simplified, newcomer-friendly
 //!   version of the **raw**, low-level winit event.

--- a/nannou/src/geom/range.rs
+++ b/nannou/src/geom/range.rs
@@ -343,7 +343,7 @@ where
 
     /// The Range that encompasses both self and the given Range.
     ///
-    /// The same as [**Range::max**](./struct.Range#method.max) but retains `self`'s original
+    /// The same as [**Range::max**](./struct.Range.html#method.max) but retains `self`'s original
     /// direction.
     ///
     /// # Examples

--- a/nannou/src/math.rs
+++ b/nannou/src/math.rs
@@ -18,7 +18,27 @@ pub use self::cgmath::{
 };
 use std::ops::Add;
 
-/// Map a value from a given range to a new given range.
+/// Maps a value from an input range to an output range.
+///
+/// Note that `map_range` doesn't clamp the output: if `val` is outside the input range, the mapped
+/// value will be outside the output range. (Use `clamp` to restrict the output, if desired.)
+///
+/// # Examples
+/// ```
+/// # use nannou::prelude::*;
+/// assert_eq!(map_range(128, 0, 255, 0.0, 1.0), 0.5019607843137255);
+/// ```
+/// ```
+/// # use nannou::prelude::*;
+/// assert_eq!(map_range(3, 0, 10, 0.0, 1.0), 0.3);
+/// ```
+/// ```
+/// # use nannou::prelude::*;
+/// // When the value is outside the input range, the result will be outside the output range.
+/// let result = map_range(15, 0, 10, 0.0, 1.0);
+/// assert_eq!(result, 1.5);
+/// assert_eq!(clamp(result, 0.0, 1.0), 1.0);
+/// ```
 pub fn map_range<X, Y>(val: X, in_min: X, in_max: X, out_min: Y, out_max: Y) -> Y
 where
     X: NumCast,

--- a/nannou/src/rand.rs
+++ b/nannou/src/rand.rs
@@ -1,6 +1,9 @@
 //! Items related to randomness and random number generators. Also provides some high-level helper
-//! functions including [**random_f32()**](./fn.random_f32.html), [**random_f64()**](./fn.random_f64.html)
-//! and [**random_range(min, max)**](./fn.random_range.html).
+//! functions.
+//!
+//! Helper functions include [**random_f32()**](./fn.random_f32.html),
+//! [**random_f64()**](./fn.random_f64.html) and [**random_range(min,
+//! max)**](./fn.random_range.html).
 
 pub use rand;
 
@@ -41,7 +44,7 @@ where
 /// Generates and returns a random ascii character.
 ///
 /// The ascii characters that can be generated are:
-///  
+///
 ///  ABCDEFGHIJKLMNOPQRSTUVWXYZ\
 /// abcdefghijklmnopqrstuvwxyz\
 /// 0123456789)(*&^%$#@!~.

--- a/nannou/src/rand.rs
+++ b/nannou/src/rand.rs
@@ -1,6 +1,6 @@
 //! Items related to randomness and random number generators. Also provides some high-level helper
 //! functions including [**random_f32()**](./fn.random_f32.html), [**random_f64()**](./fn.random_f64.html)
-//! and [**random_range(min, max)**](./fn.random_f32.html).
+//! and [**random_range(min, max)**](./fn.random_range.html).
 
 pub use rand;
 

--- a/nannou/src/state.rs
+++ b/nannou/src/state.rs
@@ -1,6 +1,5 @@
-//! Small tracked parts of the application state. Includes [**window**](mod.window.html),
-//! [**keys**](mod.keys.html), [**mouse**](mod.mouse.html), [**time**](mod.mouse.html) - each of
-//! which are stored in the **App**.
+//! Small tracked parts of the application state. Includes **window**, **keys**, **mouse**, and
+//! **time** - each of which are stored in the **App**.
 
 pub use self::keys::Keys;
 pub use self::mouse::Mouse;

--- a/nannou/src/ui.rs
+++ b/nannou/src/ui.rs
@@ -1,4 +1,6 @@
-//! The User Interface API. Instantiate a [**Ui**](struct.Ui.html) via `app.new_ui()`.
+//! The User Interface API.
+//!
+//! Instantiate a [**Ui**](struct.Ui.html) via `app.new_ui()`.
 
 pub use self::conrod_core::event::Input;
 pub use self::conrod_core::{

--- a/nannou/src/wgpu/texture/mod.rs
+++ b/nannou/src/wgpu/texture/mod.rs
@@ -167,7 +167,7 @@ impl Texture {
     ///
     /// This constructor should only be used in the case that you already have a texture handle and
     /// a descriptor but need a **Texture**. The preferred construction approach is to use the
-    /// [**TextureBuilder**](./struct.Builder.html).
+    /// [**TextureBuilder**](./struct.TextureBuilder.html).
     ///
     /// The `descriptor` must be the same used to create the texture.
     pub fn from_handle_and_descriptor(

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -1,5 +1,7 @@
-//! The nannou [**Window**](./struct.Window.html) API. Create a new window via `.app.new_window()`.
-//! This produces a [**Builder**](./struct.Builder.html) which can be used to build a window.
+//! The nannou Window API.
+//!
+//! Create a new window via `app.new_window()`. This produces a [**Builder**](./struct.Builder.html)
+//! which can be used to build a [**Window**](./struct.Window.html).
 
 use crate::event::{
     Key, MouseButton, MouseScrollDelta, TouchEvent, TouchPhase, TouchpadPressure, WindowEvent,

--- a/scripts/set_version/Cargo.toml
+++ b/scripts/set_version/Cargo.toml
@@ -6,7 +6,7 @@ description = "A small tool for setting a new version across all nannou crates."
 edition = "2018"
 
 [[bin]]
-name = "run_all_examples"
+name = "set_version"
 path = "main.rs"
 
 [dependencies]


### PR DESCRIPTION
Added some clarifications to things I was wondering about (e.g. `map_range` not clamping output, `Resized` values in points, etc.).

Also fixes some broken internal links I found. (Maybe one day rust-lang/rust#43466 will land! In the meantime, I wonder if we could do a manual check that links in the generated output are valid? Might look into this, if you think it's worthwhile.)