### PR TITLE
Add a `draw.arrow()` API. Include a new `draw_arrow.rs` example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -48,6 +48,9 @@ path = "communication/osc_sender.rs"
 name = "draw"
 path = "draw/draw.rs"
 [[example]]
+name = "draw_arrow"
+path = "draw/draw_arrow.rs"
+[[example]]
 name = "draw_blend"
 path = "draw/draw_blend.rs"
 [[example]]

--- a/examples/draw/draw_arrow.rs
+++ b/examples/draw/draw_arrow.rs
@@ -1,0 +1,26 @@
+use nannou::prelude::*;
+
+fn main() {
+    nannou::sketch(view).run()
+}
+
+fn view(app: &App, frame: Frame) {
+    let draw = app.draw();
+    let r = app.window_rect();
+    draw.background().color(BLACK);
+
+    for r in r.subdivisions_iter() {
+        for r in r.subdivisions_iter() {
+            for r in r.subdivisions_iter() {
+                let side = r.w().min(r.h());
+                let start = r.xy();
+                let start_to_mouse = app.mouse.position() - start;
+                let target_mag = start_to_mouse.magnitude().min(side * 0.5);
+                let end = start + start_to_mouse.with_magnitude(target_mag);
+                draw.arrow().weight(5.0).points(start, end);
+            }
+        }
+    }
+
+    draw.to_frame(app, &frame).unwrap();
+}

--- a/nannou/src/draw/mod.rs
+++ b/nannou/src/draw/mod.rs
@@ -541,6 +541,11 @@ where
         self.a(Default::default())
     }
 
+    /// Begin drawing an **Arrow**.
+    pub fn arrow(&self) -> Drawing<primitive::Arrow<S>, S> {
+        self.a(Default::default())
+    }
+
     /// Begin drawing a **Quad**.
     pub fn quad(&self) -> Drawing<primitive::Quad<S>, S> {
         self.a(Default::default())

--- a/nannou/src/draw/primitive/arrow.rs
+++ b/nannou/src/draw/primitive/arrow.rs
@@ -1,0 +1,269 @@
+use crate::color::LinSrgba;
+use crate::draw::primitive::path;
+use crate::draw::primitive::Line;
+use crate::draw::primitive::Primitive;
+use crate::draw::properties::spatial::{orientation, position};
+use crate::draw::properties::{ColorScalar, SetColor, SetOrientation, SetPosition, SetStroke};
+use crate::draw::{self, Drawing};
+use crate::geom::{self, pt2, vec2, Point2};
+use crate::math::{BaseFloat, Zero};
+use lyon::tessellation::StrokeOptions;
+
+/// A path containing only two points - a start and end.
+///
+/// A triangle is drawn on the end to indicate direction.
+#[derive(Clone, Debug)]
+pub struct Arrow<S = geom::scalar::Default> {
+    line: Line<S>,
+    head_length: Option<S>,
+    head_width: Option<S>,
+}
+
+/// The drawing context for a line.
+pub type DrawingArrow<'a, S = geom::scalar::Default> = Drawing<'a, Arrow<S>, S>;
+
+impl<S> Arrow<S> {
+    /// Short-hand for the `stroke_weight` method.
+    pub fn weight(self, weight: f32) -> Self {
+        self.map_line(|l| l.weight(weight))
+    }
+
+    /// Short-hand for the `stroke_tolerance` method.
+    pub fn tolerance(self, tolerance: f32) -> Self {
+        self.map_line(|l| l.tolerance(tolerance))
+    }
+
+    /// Specify the start point of the arrow.
+    pub fn start(self, start: Point2<S>) -> Self {
+        self.map_line(|l| l.start(start))
+    }
+
+    /// Specify the end point of the arrow.
+    pub fn end(self, end: Point2<S>) -> Self {
+        self.map_line(|l| l.end(end))
+    }
+
+    /// Specify the start and end points of the arrow.
+    pub fn points(self, start: Point2<S>, end: Point2<S>) -> Self {
+        self.map_line(|l| l.points(start, end))
+    }
+
+    /// The length of the arrow head.
+    ///
+    /// By default, this is equal to `weight * 4.0`.
+    ///
+    /// This value will be clamped to the length of the line itself.
+    pub fn head_length(mut self, length: S) -> Self {
+        self.head_length = Some(length);
+        self
+    }
+
+    /// The width of the arrow head.
+    ///
+    /// By default, this is equal to `weight * 2.0`.
+    pub fn head_width(mut self, width: S) -> Self {
+        self.head_width = Some(width);
+        self
+    }
+
+    // Map the inner `PathStroke<S>` using the given function.
+    fn map_line<F>(self, map: F) -> Self
+    where
+        F: FnOnce(Line<S>) -> Line<S>,
+    {
+        let Arrow {
+            line,
+            head_length,
+            head_width,
+        } = self;
+        let line = map(line);
+        Arrow {
+            line,
+            head_length,
+            head_width,
+        }
+    }
+}
+
+impl<'a, S> DrawingArrow<'a, S>
+where
+    S: BaseFloat,
+{
+    /// Short-hand for the `stroke_weight` method.
+    pub fn weight(self, weight: f32) -> Self {
+        self.map_ty(|ty| ty.weight(weight))
+    }
+
+    /// Short-hand for the `stroke_tolerance` method.
+    pub fn tolerance(self, tolerance: f32) -> Self {
+        self.map_ty(|ty| ty.tolerance(tolerance))
+    }
+
+    /// Specify the start point of the arrow.
+    pub fn start(self, start: Point2<S>) -> Self {
+        self.map_ty(|ty| ty.start(start))
+    }
+
+    /// Specify the end point of the arrow.
+    pub fn end(self, end: Point2<S>) -> Self {
+        self.map_ty(|ty| ty.end(end))
+    }
+
+    /// Specify the start and end points of the arrow.
+    pub fn points(self, start: Point2<S>, end: Point2<S>) -> Self {
+        self.map_ty(|ty| ty.points(start, end))
+    }
+
+    /// The length of the arrow head.
+    ///
+    /// By default, this is equal to `weight * 4.0`.
+    ///
+    /// This value will be clamped to the length of the line itself.
+    pub fn head_length(self, length: S) -> Self {
+        self.map_ty(|ty| ty.head_length(length))
+    }
+
+    /// The width of the arrow head.
+    ///
+    /// By default, this is equal to `weight * 2.0`.
+    pub fn head_width(self, width: S) -> Self {
+        self.map_ty(|ty| ty.head_width(width))
+    }
+}
+
+impl<S> SetStroke for Arrow<S> {
+    fn stroke_options_mut(&mut self) -> &mut StrokeOptions {
+        SetStroke::stroke_options_mut(&mut self.line)
+    }
+}
+
+impl<S> SetOrientation<S> for Arrow<S> {
+    fn properties(&mut self) -> &mut orientation::Properties<S> {
+        SetOrientation::properties(&mut self.line)
+    }
+}
+
+impl<S> SetPosition<S> for Arrow<S> {
+    fn properties(&mut self) -> &mut position::Properties<S> {
+        SetPosition::properties(&mut self.line)
+    }
+}
+
+impl<S> SetColor<ColorScalar> for Arrow<S> {
+    fn rgba_mut(&mut self) -> &mut Option<LinSrgba> {
+        SetColor::rgba_mut(&mut self.line)
+    }
+}
+
+impl<S> From<Arrow<S>> for Primitive<S> {
+    fn from(prim: Arrow<S>) -> Self {
+        Primitive::Arrow(prim)
+    }
+}
+
+impl<S> Into<Option<Arrow<S>>> for Primitive<S> {
+    fn into(self) -> Option<Arrow<S>> {
+        match self {
+            Primitive::Arrow(prim) => Some(prim),
+            _ => None,
+        }
+    }
+}
+
+impl draw::renderer::RenderPrimitive for Arrow<f32> {
+    fn render_primitive(
+        self,
+        mut ctxt: draw::renderer::RenderContext,
+        mesh: &mut draw::Mesh,
+    ) -> draw::renderer::PrimitiveRender {
+        let Arrow {
+            line,
+            head_length,
+            head_width,
+        } = self;
+        let start = line.start.unwrap_or(pt2(0.0, 0.0));
+        let end = line.end.unwrap_or(pt2(0.0, 0.0));
+        if start == end {
+            return draw::renderer::PrimitiveRender::default();
+        }
+
+        // Calculate the arrow head points.
+        let line_w_2 = line.path.opts.line_width * 2.0;
+        let line_w_4 = line_w_2 * 2.0;
+        let head_width = head_width.unwrap_or(line_w_2);
+        let head_length = head_length.unwrap_or(line_w_4);
+        let line_dir = end - start;
+        let line_dir_mag = line_dir.magnitude();
+        let tri_len = head_length.min(line_dir_mag);
+        let tri_dir_norm = line_dir.with_magnitude(tri_len);
+        let tri_start = end - tri_dir_norm;
+        let tri_end = end;
+        let line_start = start;
+        let line_end = tri_start;
+        let tri_a = tri_end;
+        let tri_w_dir = vec2(-tri_dir_norm.y, tri_dir_norm.x).with_magnitude(head_width);
+        let tri_b = tri_start + tri_w_dir;
+        let tri_c = tri_start - tri_w_dir;
+        // The line should only be drawn if there is space after drawing the triangle.
+        let draw_line = line_dir_mag > tri_len;
+
+        // Determine the transform to apply to all points.
+        let global_transform = ctxt.transform;
+        let local_transform = line.path.position.transform() * line.path.orientation.transform();
+        let transform = global_transform * local_transform;
+
+        // Draw the tri.
+        let tri_points = [tri_a, tri_b, tri_c];
+        let tri_points = tri_points.iter().cloned().map(Into::into);
+        let close_tri = true;
+        let tri_events = lyon::path::iterator::FromPolyline::new(close_tri, tri_points);
+        path::render_path_events(
+            tri_events,
+            line.path.color,
+            transform,
+            path::Options::Fill(Default::default()),
+            &ctxt.theme,
+            &draw::theme::Primitive::Arrow,
+            &mut ctxt.fill_tessellator,
+            &mut ctxt.stroke_tessellator,
+            mesh,
+        );
+
+        // Draw the line.
+        if draw_line {
+            let line_points = [line_start, line_end];
+            let line_points = line_points.iter().cloned().map(Into::into);
+            let close_line = false;
+            let line_events = lyon::path::iterator::FromPolyline::new(close_line, line_points);
+            path::render_path_events(
+                line_events,
+                line.path.color,
+                transform,
+                path::Options::Stroke(line.path.opts),
+                &ctxt.theme,
+                &draw::theme::Primitive::Arrow,
+                &mut ctxt.fill_tessellator,
+                &mut ctxt.stroke_tessellator,
+                mesh,
+            );
+        }
+
+        draw::renderer::PrimitiveRender::default()
+    }
+}
+
+impl<S> Default for Arrow<S>
+where
+    S: Zero,
+{
+    fn default() -> Self {
+        let line = Default::default();
+        let head_length = Default::default();
+        let head_width = Default::default();
+        Arrow {
+            line,
+            head_length,
+            head_width,
+        }
+    }
+}

--- a/nannou/src/draw/primitive/line.rs
+++ b/nannou/src/draw/primitive/line.rs
@@ -14,9 +14,9 @@ use lyon::tessellation::StrokeOptions;
 /// `points(a, b)` methods.
 #[derive(Clone, Debug)]
 pub struct Line<S = geom::scalar::Default> {
-    path: PathStroke<S>,
-    start: Option<Point2<S>>,
-    end: Option<Point2<S>>,
+    pub path: PathStroke<S>,
+    pub start: Option<Point2<S>>,
+    pub end: Option<Point2<S>>,
 }
 
 /// The drawing context for a line.
@@ -139,6 +139,9 @@ impl draw::renderer::RenderPrimitive for Line<f32> {
         let Line { path, start, end } = self;
         let start = start.unwrap_or(pt2(0.0, 0.0));
         let end = end.unwrap_or(pt2(0.0, 0.0));
+        if start == end {
+            return draw::renderer::PrimitiveRender::default();
+        }
         let close = false;
         let points = [start, end];
         let points = points.iter().cloned().map(Into::into);

--- a/nannou/src/draw/primitive/mod.rs
+++ b/nannou/src/draw/primitive/mod.rs
@@ -1,3 +1,4 @@
+pub mod arrow;
 pub mod ellipse;
 pub mod line;
 pub mod mesh;
@@ -11,6 +12,7 @@ pub mod tri;
 
 use crate::geom;
 
+pub use self::arrow::Arrow;
 pub use self::ellipse::Ellipse;
 pub use self::line::Line;
 pub use self::mesh::Mesh;
@@ -29,6 +31,7 @@ pub use self::tri::Tri;
 /// before their respective **Drawing** types are dropped.
 #[derive(Clone, Debug)]
 pub enum Primitive<S = geom::scalar::Default> {
+    Arrow(Arrow<S>),
     Ellipse(Ellipse<S>),
     Line(Line<S>),
     MeshVertexless(mesh::Vertexless),

--- a/nannou/src/draw/primitive/polygon.rs
+++ b/nannou/src/draw/primitive/polygon.rs
@@ -53,12 +53,12 @@ pub struct PolygonInit<S = geom::scalar::Default> {
 /// The set of options shared by all polygon types.
 #[derive(Clone, Debug)]
 pub struct PolygonOptions<S = geom::scalar::Default> {
-    position: position::Properties<S>,
-    orientation: orientation::Properties<S>,
-    no_fill: bool,
-    stroke_color: Option<LinSrgba>,
-    color: Option<LinSrgba>,
-    stroke: Option<StrokeOptions>,
+    pub position: position::Properties<S>,
+    pub orientation: orientation::Properties<S>,
+    pub no_fill: bool,
+    pub stroke_color: Option<LinSrgba>,
+    pub color: Option<LinSrgba>,
+    pub stroke: Option<StrokeOptions>,
 }
 
 /// A polygon with vertices already submitted.

--- a/nannou/src/draw/renderer/mod.rs
+++ b/nannou/src/draw/renderer/mod.rs
@@ -169,6 +169,7 @@ impl Default for PrimitiveRender {
 impl RenderPrimitive for draw::Primitive {
     fn render_primitive(self, ctxt: RenderContext, mesh: &mut draw::Mesh) -> PrimitiveRender {
         match self {
+            draw::Primitive::Arrow(prim) => prim.render_primitive(ctxt, mesh),
             draw::Primitive::Mesh(prim) => prim.render_primitive(ctxt, mesh),
             draw::Primitive::Path(prim) => prim.render_primitive(ctxt, mesh),
             draw::Primitive::Polygon(prim) => prim.render_primitive(ctxt, mesh),

--- a/nannou/src/draw/theme.rs
+++ b/nannou/src/draw/theme.rs
@@ -23,6 +23,7 @@ pub struct Color {
 /// These are used as keys into the **Theme**'s geometry primitive default values.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Primitive {
+    Arrow,
     Cuboid,
     Ellipse,
     Line,
@@ -68,14 +69,22 @@ impl Theme {
 
 impl Default for Theme {
     fn default() -> Self {
+        // TODO: This should be pub const.
+        let default_fill = Srgba::new(1.0, 1.0, 1.0, 1.0);
+        let default_stroke = Srgba::new(0.0, 0.0, 0.0, 1.0);
+
         let fill_color = Color {
-            default: Srgba::new(1.0, 1.0, 1.0, 1.0),
+            default: default_fill,
             primitive: Default::default(),
         };
-        let stroke_color = Color {
-            default: Srgba::new(0.0, 0.0, 0.0, 1.0),
+        let mut stroke_color = Color {
+            default: default_stroke,
             primitive: Default::default(),
         };
+        stroke_color
+            .primitive
+            .insert(Primitive::Arrow, default_fill);
+
         Theme {
             fill_color,
             stroke_color,


### PR DESCRIPTION
The new API is almost identical to `draw.line()`, except that you can
also specify the `.head_length(l)` and `.head_width(w)` if you wish. By
default, these are equal to `weight * 4.0` and `weight * 2.0`
respectively.

This might be particularly useful for things like vector field
visualisations or for debugging.