### PR TITLE
Fix broken links on the index page of tutorials

### DIFF
--- a/guide/src/tutorials.md
+++ b/guide/src/tutorials.md
@@ -23,18 +23,18 @@ Tutorials for learning the basics of Rust with nannou.
 
 A suite of tutorials for getting familiar with the Nannou environment.
 
-- [Anatomy of a nannou app](./tutorials/basics/anatomy-of-a-nannou-app.md)
-- [Drawing a sketch](./tutorials/basics/draw-a-sketch.md)
-- [Sketch vs App](./tutorials/basics/sketch-vs-app.md)
-- [Window Coordinates](./tutorials/basics/window-coordinates.md)
+- [Anatomy of a nannou app](/tutorials/basics/anatomy-of-a-nannou-app.md)
+- [Drawing a sketch](/tutorials/basics/draw-a-sketch.md)
+- [Sketch vs App](/tutorials/basics/sketch-vs-app.md)
+- [Window Coordinates](/tutorials/basics/window-coordinates.md)
 - Nannou events
 
 ## Drawing
 
 Working with Nannou's `Draw` API - a simple approach of coding graphics.
 
-- [Drawing 2D shapes](./tutorials/draw/drawing-2d-shapes.md)
-- [Animating a circle](./tutorials/draw/animating-a-circle.md)
+- [Drawing 2D shapes](/tutorials/draw/drawing-2d-shapes.md)
+- [Animating a circle](/tutorials/draw/animating-a-circle.md)
 - Drawing images
 - Drawing 3D shapes
 - Drawing meshes

--- a/guide/src/tutorials.md
+++ b/guide/src/tutorials.md
@@ -23,17 +23,17 @@ Tutorials for learning the basics of Rust with nannou.
 
 A suite of tutorials for getting familiar with the Nannou environment.
 
-- [Anatomy of a nannou app](/tutorials/basics/anatomy-of-a-nannou-app.md)
-- [Drawing a sketch](/tutorials/basics/draw-a-sketch.md)
-- [App vs. Sketch](/tutorials/basics/app-vs-sketch.md)
-- [Window Coordinates](/tutorials/basics/window-coordinates.md)
+- [Anatomy of a nannou app](./tutorials/basics/anatomy-of-a-nannou-app.md)
+- [Drawing a sketch](./tutorials/basics/draw-a-sketch.md)
+- [Sketch vs App](./tutorials/basics/sketch-vs-app.md)
+- [Window Coordinates](./tutorials/basics/window-coordinates.md)
 - Nannou events
 
 ## Drawing
 
 Working with Nannou's `Draw` API - a simple approach of coding graphics.
 
-- [Drawing 2D shapes](/tutorials/draw/2d-shapes.md)
+- [Drawing 2D shapes](./tutorials/draw/drawing-2d-shapes.md)
 - [Animating a circle](./tutorials/draw/animating-a-circle.md)
 - Drawing images
 - Drawing 3D shapes

--- a/guide/src/tutorials/draw/animating-a-circle.md
+++ b/guide/src/tutorials/draw/animating-a-circle.md
@@ -17,7 +17,7 @@ In this tutorial we will cover the basics of moving a shape around in the window
 
 Let's start by making a simple program which draws a circle in the center of the screen.
 
-We will be using the barebones app from [Anatomy of a nannou app](./tutorials/basics/anatomy-of-a-nannou-app.md) as a starting point for this.
+We will be using the barebones app from [Anatomy of a nannou app](/tutorials/basics/anatomy-of-a-nannou-app.md) as a starting point for this.
 
 Update the view function of your nannou-app to look like this:
 


### PR DESCRIPTION
It seems some of the links on this page won't work: https://guide.nannou.cc/tutorials.html

(Btw, the tutorials looks nicer than when I tried long ago! Thank you so much for your efforts.)