### PR TITLE
fix implementation of angle_between

### DIFF
--- a/nannou/src/geom/vector.rs
+++ b/nannou/src/geom/vector.rs
@@ -1402,19 +1402,21 @@ impl<S> Vector2<S> {
     /// ```
     /// # use nannou::prelude::*;
     /// # fn main() {
-    /// let a = vec2(-1.0, 1.0);
-    /// let b = vec2(1.0, 1.0);
-    /// assert_eq!(a.angle_between(b), 0.0);
-    /// assert_eq!(b.angle_between(a), PI);
-    /// assert_eq!(a.angle_between(b), (b - a).angle());
-    /// assert_eq!(b.angle_between(a), (a - b).angle());
+    /// let right = vec2(1.0, 0.0);
+    /// let upright = vec2(1.0, 1.0);
+    /// let up = vec2(0.0, 1.0);
+    /// let bot = vec2(0.0, -1.0);
+    /// assert_eq!(right.angle_between(up), PI/2.0);
+    /// assert_eq!(up.angle_between(right), -PI/2.0);
+    /// assert_eq!(right.angle_between(upright), PI/4.0);
+    /// assert_eq!(right.angle_between(bot), -PI/2.0);
     /// # }
     /// ```
     pub fn angle_between(self, other: Self) -> S
     where
         S: BaseFloat,
     {
-        (other - self).angle()
+        other.angle() - self.angle()
     }
 
     /// Rotate the vector around the origin (0.0, 0.0) by the given radians.


### PR DESCRIPTION
I don't think the current implementation of `(other - self).angle()` is correct. The angle between (1, 0) and (0, 1) should be PI, but this function gives 0.

I think `other.angle() - self.angle()` is what was meant.

Also fwiw, I took a look at the implementations in [Processing](https://github.com/processing/processing/blob/8e86389c7e017d0e4d61f81fb942c25e3ed348c7/core/src/processing/core/PVector.java#L987) and [p5.js](https://github.com/processing/p5.js/blob/1.0.0/src/math/p5.Vector.js#L1293). They both use the dot product / product of magnitudes formula, which i guess uses less trig operations and might be a faster? Maybe benchmarking this can be a separate issue though.

(Another note is that they both do clamping due to floating point issues, which I don't _think_ the difference-of-angles approach has? But probably also worthwhile testing this more thoroughly...)