### PR TITLE
fix test for angle_between (testing github actions)

### DIFF
--- a/nannou/src/geom/vector.rs
+++ b/nannou/src/geom/vector.rs
@@ -1404,10 +1404,10 @@ impl<S> Vector2<S> {
     /// # fn main() {
     /// let a = vec2(-1.0, 1.0);
     /// let b = vec2(1.0, 1.0);
-    /// assert_eq!(a.angle_between(b), 0.0);
-    /// assert_eq!(b.angle_between(a), PI);
-    /// assert_eq!(a.angle_between(b), (b - a).angle());
-    /// assert_eq!(b.angle_between(a), (a - b).angle());
+    /// assert_eq!(a.angle_between(b), PI/2.0);
+    /// assert_eq!(b.angle_between(a), PI/2.0);
+    /// assert_eq!(a.angle_between(a), 0.0);
+    /// assert_eq!(b.angle_between(b), 0.0);
     /// # }
     /// ```
     pub fn angle_between(self, other: Self) -> S


### PR DESCRIPTION
I noticed that `cargo test --doc` in the `src/nannou/` gave me an error (due to float rounding issues). I was wondering whether this should be caught or not by github actions.

This PR changes the doctest for angle_between, which should cause a doc test failure given the current implementation. This PR is just meant to test whether github actions is correctly catching doctest issues, or whether the rounding issue I saw is somehow specific to my local machine.

edit: weird, guess it's just my machine that computes `vec2(-1.0, 0.0).angle()` as more-off from `PI` than everyone else? maybe it's osx vs linux? maybe one day i will understand these mysteries