### PR TITLE
Add `ilda-idtf` feature to `nannou_laser`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,11 +21,12 @@ hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 nannou = { version ="0.14.0", path = "../nannou" }
 nannou_audio = { version ="0.14.0", path = "../nannou_audio" }
 nannou_isf = { version ="0.1.0", path = "../nannou_isf" }
-nannou_laser = { version ="0.14.0", features = ["ffi"], path = "../nannou_laser" }
+nannou_laser = { version ="0.14.0", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
 nannou_osc = { version ="0.14.0", path = "../nannou_osc" }
 nannou_timeline = { version ="0.14.0", features = ["serde1"], path =  "../nannou_timeline" }
 pitch_calc = { version = "0.12", features = ["serde"] }
 time_calc = { version= "0.13", features = ["serde"] }
+walkdir = "2"
 
 # Audio
 [[example]]
@@ -114,6 +115,9 @@ path = "laser/laser_frame_stream_gui.rs"
 [[example]]
 name = "laser_raw_stream"
 path = "laser/laser_raw_stream.rs"
+[[example]]
+name = "laser_ilda_idtf"
+path = "laser/laser_ilda_idtf.rs"
 
 # Nannou Basics
 [[example]]

--- a/examples/laser/laser_ilda_idtf.rs
+++ b/examples/laser/laser_ilda_idtf.rs
@@ -1,0 +1,119 @@
+//! An example of reading files of the ILDA Image Data Transfer Format and playing them back with
+//! nannou.
+//!
+//! Specify a directory containing `.ild` or `.ILD` files to play them with this example. E.g.
+//!
+//! ```
+//! cargo run --release -p examples --example laser_ilda_idtf -- /path/to/ilda/files
+//! ```
+
+use nannou::prelude::*;
+use nannou_laser as laser;
+use nannou_laser::ilda_idtf::BufFileFrameReader;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+fn main() {
+    nannou::app(model).run();
+}
+
+struct Model {
+    _laser_api: laser::Api,
+    _laser_stream: laser::FrameStream<Laser>,
+}
+
+struct Laser {
+    ilda_paths: Vec<PathBuf>,
+    current_path: usize,
+    last_change: Instant,
+    frame_reader: BufFileFrameReader,
+}
+
+fn model(app: &App) -> Model {
+    // Create a window to receive keyboard events.
+    app.new_window().view(view).build().unwrap();
+
+    // Test file directory from the command line.
+    let test_files = match std::env::args().nth(1) {
+        None => panic!("Please specify a directory with at least one '.ild' or '.ILD' file"),
+        Some(s) => PathBuf::from(s),
+    };
+
+    // Initialise the state that we want to live on the laser thread and spawn the stream.
+    let ilda_paths: Vec<_> = find_ilda_files(&test_files).collect();
+    if ilda_paths.is_empty() {
+        panic!(
+            "Could not find any '.ild' or '.ILD' files in {}",
+            test_files.display()
+        );
+    }
+    let current_path = 0;
+    let path = &ilda_paths[current_path];
+    let last_change = Instant::now();
+    let frame_reader = BufFileFrameReader::open(&path).unwrap();
+    let laser_model = Laser {
+        ilda_paths,
+        last_change,
+        current_path,
+        frame_reader,
+    };
+
+    // Initialise the LASER API and spawn the stream.
+    let _laser_api = laser::Api::new();
+    let laser_stream = _laser_api
+        .new_frame_stream(laser_model, laser)
+        .tcp_timeout(Some(Duration::from_secs(1)))
+        .build()
+        .unwrap();
+    laser_stream.set_point_hz(10_000).unwrap();
+    laser_stream.set_frame_hz(30).unwrap();
+
+    Model {
+        _laser_api,
+        _laser_stream: laser_stream,
+    }
+}
+
+fn view(_app: &App, _model: &Model, frame: Frame) {
+    frame.clear(DIMGRAY);
+}
+
+fn laser(laser: &mut Laser, frame: &mut laser::Frame) {
+    loop {
+        match laser.frame_reader.next() {
+            Ok(Some(points)) => {
+                frame.add_lines(points);
+                return;
+            }
+            Err(err) => {
+                let path = &laser.ilda_paths[laser.current_path];
+                eprintln!("error occurred while reading {}: {}", path.display(), err);
+                laser.last_change = Instant::now();
+                laser.current_path += 1;
+            }
+            Ok(None) => {
+                if laser.last_change.elapsed() > Duration::from_secs(2) {
+                    laser.last_change = Instant::now();
+                    laser.current_path += 1;
+                }
+            }
+        }
+        laser.current_path %= laser.ilda_paths.len();
+        let path = &laser.ilda_paths[laser.current_path];
+        println!("{}", path.display());
+        laser.frame_reader = BufFileFrameReader::open(&path).unwrap();
+    }
+}
+
+fn find_ilda_files(dir: &Path) -> impl Iterator<Item = PathBuf> {
+    walkdir::WalkDir::new(dir).into_iter().filter_map(|entry| {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let ext = path.extension().and_then(|s| s.to_str());
+        if ext == Some("ild") || ext == Some("ILD") {
+            Some(path.to_path_buf())
+        } else {
+            None
+        }
+    })
+}

--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 
 [dependencies]
 ether-dream = "0.2"
+ilda-idtf = { version = "0.1", optional = true }
 petgraph = "0.4"
 thiserror = "1"
 

--- a/nannou_laser/src/ilda_idtf.rs
+++ b/nannou_laser/src/ilda_idtf.rs
@@ -1,0 +1,206 @@
+//! Re-exports the `ilda-idtf` crate and extends it with a **FrameReader** API, simplifying the
+//! process of reading the ILDA IDTF format into frames of points that are compatible with the
+//! `nannou_laser` API.
+//!
+//! See the extensive, top-level `ilda-idtf` API docs [here](https://docs.rs/ilda-idtf).
+
+use crate::{point, Point};
+use std::io;
+use std::path::Path;
+
+#[doc(inline)]
+pub use ilda_idtf::*;
+
+/// A type that simplifies the process of reading laser frames from the ILDA IDTF format in a
+/// manner that is compatible with the `nannou_laser` stream APIs.
+pub struct FrameReader<R> {
+    reader: SectionReader<R>,
+    points: Vec<Point>,
+    palette: Vec<layout::Color>,
+}
+
+/// A `FrameReader` that reads from a buffered file.
+pub type BufFileFrameReader = FrameReader<io::BufReader<std::fs::File>>;
+
+impl<R> FrameReader<R>
+where
+    R: io::Read,
+{
+    /// Create a new `FrameReader` from the given ILDA IDTF format reader.
+    pub fn new(reader: R) -> Self {
+        Self::from_section_reader(SectionReader::new(reader))
+    }
+
+    /// Create a new `FrameReader` from the given `SectionReader`.
+    pub fn from_section_reader(reader: SectionReader<R>) -> Self {
+        let points = vec![];
+        let palette = DEFAULT_PALETTE.to_vec();
+        Self {
+            reader,
+            points,
+            palette,
+        }
+    }
+
+    /// Consumes the `FrameReader` and returns the inner `SectionReader`.
+    pub fn into_section_reader(self) -> SectionReader<R> {
+        self.reader
+    }
+
+    /// Produce the next frame as a list of points representing consecutive lines.
+    pub fn next(&mut self) -> io::Result<Option<&[Point]>> {
+        self.points.clear();
+        loop {
+            let FrameReader {
+                ref mut reader,
+                ref mut points,
+                ref mut palette,
+            } = *self;
+
+            // Read the next section.
+            let section = match reader.read_next()? {
+                None => return Ok(None),
+                Some(s) => s,
+            };
+
+            match section.reader {
+                // Update the color palette.
+                SubsectionReaderKind::ColorPalette(mut r) => {
+                    palette.clear();
+                    while let Some(new_palette) = r.read_next()? {
+                        palette.push(new_palette.color);
+                    }
+                    continue;
+                }
+
+                // Update the points.
+                SubsectionReaderKind::Coords3dIndexedColor(mut r) => {
+                    while let Some(p) = r.read_next()? {
+                        points.push(point_from_coords_3d_indexed_color(*p, palette));
+                    }
+                }
+                SubsectionReaderKind::Coords2dIndexedColor(mut r) => {
+                    while let Some(p) = r.read_next()? {
+                        points.push(point_from_coords_2d_indexed_color(*p, palette));
+                    }
+                }
+                SubsectionReaderKind::Coords3dTrueColor(mut r) => {
+                    while let Some(p) = r.read_next()? {
+                        points.push(point_from_coords_3d_true_color(*p));
+                    }
+                }
+                SubsectionReaderKind::Coords2dTrueColor(mut r) => {
+                    while let Some(p) = r.read_next()? {
+                        points.push(point_from_coords_2d_true_color(*p));
+                    }
+                }
+            }
+
+            return Ok(Some(&self.points[..]));
+        }
+    }
+}
+
+impl BufFileFrameReader {
+    /// Creates a new `FrameReader` from the file at the given path.
+    ///
+    /// Returns a `FrameReader` that performs buffered reads on the file at the given path.
+    pub fn open<P>(path: P) -> io::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        Ok(Self::from_section_reader(open(path)?))
+    }
+}
+
+impl<R> From<SectionReader<R>> for FrameReader<R>
+where
+    R: io::Read,
+{
+    fn from(r: SectionReader<R>) -> Self {
+        Self::from_section_reader(r)
+    }
+}
+
+impl<R> Into<SectionReader<R>> for FrameReader<R>
+where
+    R: io::Read,
+{
+    fn into(self) -> SectionReader<R> {
+        self.into_section_reader()
+    }
+}
+
+fn normalise_coord(c: i16) -> f32 {
+    c as f32 / std::i16::MAX as f32
+}
+
+fn normalise_color(c: u8) -> f32 {
+    c as f32 / std::u8::MAX as f32
+}
+
+fn coords3d_to_position(coords: layout::Coords3d) -> point::Position {
+    [
+        normalise_coord(coords.x.get()),
+        normalise_coord(coords.y.get()),
+    ]
+}
+
+fn coords2d_to_position(coords: layout::Coords2d) -> point::Position {
+    [
+        normalise_coord(coords.x.get()),
+        normalise_coord(coords.y.get()),
+    ]
+}
+
+fn rgb_from_ilda(c: layout::Color) -> point::Rgb {
+    [
+        normalise_color(c.red),
+        normalise_color(c.green),
+        normalise_color(c.blue),
+    ]
+}
+
+const BLACK: [f32; 3] = [0.0; 3];
+
+fn point_from_coords_3d_indexed_color(
+    p: layout::Coords3dIndexedColor,
+    palette: &[layout::Color],
+) -> Point {
+    let position = coords3d_to_position(p.coords);
+    let color = match p.status.is_blanking() {
+        true => BLACK,
+        false => rgb_from_ilda(palette[p.color_index as usize]),
+    };
+    Point::new(position, color)
+}
+
+fn point_from_coords_2d_indexed_color(
+    p: layout::Coords2dIndexedColor,
+    palette: &[layout::Color],
+) -> Point {
+    let position = coords2d_to_position(p.coords);
+    let color = match p.status.is_blanking() {
+        true => BLACK,
+        false => rgb_from_ilda(palette[p.color_index as usize]),
+    };
+    Point::new(position, color)
+}
+
+fn point_from_coords_3d_true_color(p: layout::Coords3dTrueColor) -> Point {
+    let position = coords3d_to_position(p.coords);
+    let color = match p.status.is_blanking() {
+        true => BLACK,
+        false => rgb_from_ilda(p.color),
+    };
+    Point::new(position, color)
+}
+
+fn point_from_coords_2d_true_color(p: layout::Coords2dTrueColor) -> Point {
+    let position = coords2d_to_position(p.coords);
+    let color = match p.status.is_blanking() {
+        true => BLACK,
+        false => rgb_from_ilda(p.color),
+    };
+    Point::new(position, color)
+}

--- a/nannou_laser/src/lib.rs
+++ b/nannou_laser/src/lib.rs
@@ -5,6 +5,8 @@ pub extern crate ether_dream;
 pub mod dac;
 #[cfg(feature = "ffi")]
 pub mod ffi;
+#[cfg(feature = "ilda-idtf")]
+pub mod ilda_idtf;
 pub mod lerp;
 pub mod point;
 pub mod stream;


### PR DESCRIPTION
Adds support for ILDA Image Data Transfer Format to `nannou_laser`
behind a `ilda-idtf` feature. This feature adds a `ilda_idtf` module and
which re-exports the `ilda-idtf` crate and extends it with a
`FrameReader`. `FrameReader` simplifies the process of reading ILDA IDTF
files into frames that are compatible with `nannou_laser`.

An example demonstrating the new API has been added under
`examples/laser/laser_ilda_idtf.rs`.