### PR TITLE
Re-export `widget_ids!` macro from `nannou::ui`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 
 [dev-dependencies]
 audrey = "0.2"
-conrod_core = "0.70"
 futures = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 nannou = { version ="0.14.1", path = "../nannou" }

--- a/examples/ui/simple_ui.rs
+++ b/examples/ui/simple_ui.rs
@@ -15,12 +15,14 @@ struct Model {
     position: Point2,
 }
 
-struct Ids {
-    resolution: widget::Id,
-    scale: widget::Id,
-    rotation: widget::Id,
-    random_color: widget::Id,
-    position: widget::Id,
+widget_ids! {
+    struct Ids {
+        resolution,
+        scale,
+        rotation,
+        random_color,
+        position,
+    }
 }
 
 fn model(app: &App) -> Model {
@@ -31,13 +33,7 @@ fn model(app: &App) -> Model {
     let mut ui = app.new_ui().build().unwrap();
 
     // Generate some ids for our widgets.
-    let ids = Ids {
-        resolution: ui.generate_widget_id(),
-        scale: ui.generate_widget_id(),
-        rotation: ui.generate_widget_id(),
-        random_color: ui.generate_widget_id(),
-        position: ui.generate_widget_id(),
-    };
+    let ids = Ids::new(ui.widget_id_generator());
 
     // Init our variables
     let resolution = 6;

--- a/examples/ui/timeline_demo.rs
+++ b/examples/ui/timeline_demo.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate conrod_core;
-
 use nannou::prelude::*;
 use nannou::ui::prelude::*;
 use nannou_timeline as timeline;
@@ -42,7 +39,7 @@ struct TimelineData {
 }
 
 // Create all of our unique `WidgetId`s with the `widget_ids!` macro.
-conrod_core::widget_ids! {
+widget_ids! {
     struct Ids {
         window,
         ruler,

--- a/nannou/src/ui.rs
+++ b/nannou/src/ui.rs
@@ -5,6 +5,7 @@
 pub use self::conrod_core::event::Input;
 pub use self::conrod_core::{
     color, cursor, event, graph, image, input, position, scroll, text, theme, utils, widget,
+    widget_ids,
 };
 pub use self::conrod_core::{
     Borderable, Bordering, Color, Colorable, Dimensions, FontSize, Labelable, Point, Positionable,
@@ -23,7 +24,7 @@ pub mod prelude {
         Bordering, Dimensions, FontSize, Input, Point, Range, Rect, Scalar, Theme, Ui, UiCell,
     };
     // Modules.
-    pub use super::{color, image, position, text, widget};
+    pub use super::{color, image, position, text, widget, widget_ids};
 }
 
 use self::conrod_core::text::rt::gpu_cache::CacheWriteErr;


### PR DESCRIPTION
This long overdue re-export simplifies the process of generating widget
IDs for nannou GUIs. The ui examples have been updated to demonstrate
how to take advantage of the macro.