### PR TITLE
Example 1-5 Vector Magnitude: fix rect alignment

### DIFF
--- a/nature_of_code/chp_01_vectors/1_5_vector_magnitude.rs
+++ b/nature_of_code/chp_01_vectors/1_5_vector_magnitude.rs
@@ -12,6 +12,8 @@ fn main() {
 fn view(app: &App, frame: Frame) {
     // Begin drawing
     let draw = app.draw();
+    let win = app.window_rect();
+
     draw.background().color(WHITE);
 
     let mut mouse = vec2(app.mouse.x, app.mouse.y);
@@ -20,10 +22,8 @@ fn view(app: &App, frame: Frame) {
 
     let m = mouse.magnitude();
 
-    draw.rect()
-        .xy(app.window_rect().top_left())
-        .w_h(m, 10.0)
-        .color(BLACK);
+    let r = Rect::from_w_h(m, 10.0).top_left_of(win);
+    draw.rect().xy(r.xy()).wh(r.wh()).color(BLACK);
 
     draw.line().weight(2.0).color(BLACK).points(center, mouse);
 


### PR DESCRIPTION
Rect should be aligned to top left of win. The old example drew half of the rect outside of win rect bounds.