### PR TITLE
change doc comments for lrgt fn to reflect tuple order

### DIFF
--- a/nannou/src/geom/rect.rs
+++ b/nannou/src/geom/rect.rs
@@ -286,7 +286,7 @@ where
         [self.x(), self.bottom()].into()
     }
 
-    /// The edges of the **Rect** in a tuple (top, bottom, left, right).
+    /// The edges of the **Rect** in a tuple (left, right, bottom, top).
     pub fn l_r_b_t(&self) -> (S, S, S, S) {
         (self.left(), self.right(), self.bottom(), self.top())
     }


### PR DESCRIPTION
Just a minor change to the doc comments for the rect l_r_b_t function, so that it reflects the actual order of the tuple. I think this should resolve any ambiguities or confusion regarding the order of edges that get returned.