### PR TITLE
Update ether-dream version for nannou_laser

### DIFF
--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -14,7 +14,7 @@ name = "nannou_laser"
 crate-type = ["rlib", "staticlib", "cdylib"]
 
 [dependencies]
-ether-dream = "0.2"
+ether-dream = "~0.2.5"
 ilda-idtf = { version = "0.1", optional = true }
 lasy = "0.3"
 thiserror = "1"


### PR DESCRIPTION
Upon trying to build, I encountered
```
   Compiling nannou_laser v0.14.1 (/home/leaf/prog/nannou/nannou_laser)
error[E0425]: cannot find function `connect_timeout` in module `ether_dream::dac::stream`
   --> nannou_laser/src/stream/raw.rs:669:52
    |
669 |         Some(timeout) => ether_dream::dac::stream::connect_timeout(&broadcast, ip, timeout)
    |                                                    ^^^^^^^^^^^^^^^ not found in `ether_dream::dac::stream`

error[E0599]: no method named `set_timeout` found for struct `ether_dream::RecvDacBroadcasts` in the current scope
  --> nannou_laser/src/dac.rs:80:29
   |
80 |         self.dac_broadcasts.set_timeout(duration)
   |                             ^^^^^^^^^^^ method not found in `ether_dream::RecvDacBroadcasts`

error[E0599]: no method named `set_nonblocking` found for struct `ether_dream::RecvDacBroadcasts` in the current scope
  --> nannou_laser/src/dac.rs:85:29
   |
85 |         self.dac_broadcasts.set_nonblocking(nonblocking)
   |                             ^^^^^^^^^^^^^^^ method not found in `ether_dream::RecvDacBroadcasts`

```

Of the functions, `set_timeout` is the newer one and depends on `ether-dream` v0.2.5, so I opted to specify that as a minimum version in `nannou_laser`'s manifest.