### PR TITLE
Update lasy dependency of nannou_laser. Publish nannou_laser 0.14.2.

### DIFF
--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -73,11 +73,23 @@ changelog entry
 
 ---
 
-# Version 0.14.1 (2020-05-06)
+### `nannou_laser` 0.14.2 (2020-05-15)
+
+- Update `lasy` to 0.4. Adds better support for points and improved euler
+  circuit interpolation.
+
+---
+
+### `nannou_laser` 0.14.1 (2020-05-06)
+
+- Add `ilda-idtf` feature to `nannou_laser`.
+
+---
+
+### `nannou` 0.14.1 (2020-05-06)
 
 - Fix bug where `draw::Renderer` was initialised with an incorrect scale factor.
 - Fix `Vector::angle_between` implementation.
-- Add `ilda-idtf` feature to `nannou_laser`.
 
 ---
 

--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_laser"
-version ="0.14.1"
+version ="0.14.2"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 edition = "2018"
@@ -16,7 +16,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 [dependencies]
 ether-dream = "~0.2.5"
 ilda-idtf = { version = "0.1", optional = true }
-lasy = "0.3"
+lasy = "0.4"
 thiserror = "1"
 
 [features]


### PR DESCRIPTION
See changelog diff for details.