### PR TITLE
[nannou_laser] Add support for toggling draw path reordering

### DIFF
--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -73,6 +73,12 @@ changelog entry
 
 ---
 
+### `nannou_laser` 0.14.3 (2020-05-19)
+
+- Add support for enabling/disabling draw path reordering.
+
+---
+
 ### `nannou_laser` 0.14.2 (2020-05-15)
 
 - Update `lasy` to 0.4. Adds better support for points and improved euler

--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_laser"
-version ="0.14.2"
+version ="0.14.3"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 edition = "2018"
@@ -16,7 +16,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 [dependencies]
 ether-dream = "~0.2.5"
 ilda-idtf = { version = "0.1", optional = true }
-lasy = "0.4"
+lasy = "0.4.1"
 thiserror = "1"
 
 [features]

--- a/nannou_laser/src/lib.rs
+++ b/nannou_laser/src/lib.rs
@@ -88,6 +88,7 @@ impl Api {
         let frame_hz = None;
         let interpolation_conf = Default::default();
         let enable_optimisations = stream::DEFAULT_ENABLE_OPTIMISATIONS;
+        let enable_draw_reorder = stream::DEFAULT_ENABLE_DRAW_REORDER;
         let process_raw = stream::frame::default_process_raw_fn;
         let stream_error = stream::raw::default_stream_error_fn;
         stream::frame::Builder {
@@ -100,6 +101,7 @@ impl Api {
             frame_hz,
             interpolation_conf,
             enable_optimisations,
+            enable_draw_reorder,
         }
     }
 

--- a/nannou_laser/src/stream/mod.rs
+++ b/nannou_laser/src/stream/mod.rs
@@ -10,6 +10,9 @@ pub const DEFAULT_FRAME_HZ: u32 = 60;
 /// Enable optimisations by default.
 pub const DEFAULT_ENABLE_OPTIMISATIONS: bool = true;
 
+/// Enable draw path reordering by default.
+pub const DEFAULT_ENABLE_DRAW_REORDER: bool = true;
+
 /// Builder parameters shared between the `raw` and `frame` signals.
 #[derive(Clone, Debug, Default)]
 pub struct Builder {


### PR DESCRIPTION
This allows for enabling/disabling draw path reordering for frames
submitted to the LASER frame stream. See the docs for the new
`enable_draw_reorder` methods for more details.