### PR TITLE
set minimum interval for request_redraw calls

### DIFF
--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -15,6 +15,7 @@ use std::any::Any;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 use std::{env, fmt};
 use winit::dpi::LogicalSize;
 
@@ -252,6 +253,8 @@ pub(crate) struct TrackedState {
     pub(crate) scale_factor: f64,
     // Updated on `Resized`.
     pub(crate) physical_size: winit::dpi::PhysicalSize<u32>,
+    // Updated on `RedrawRequested`.
+    pub(crate) last_redraw_requested: Instant,
 }
 
 /// A swap_chain and its images associated with a single window.
@@ -846,6 +849,7 @@ impl<'app> Builder<'app> {
         let tracked_state = TrackedState {
             scale_factor: window.scale_factor(),
             physical_size: win_physical_size,
+            last_redraw_requested: Instant::now(),
         };
 
         let window = Window {


### PR DESCRIPTION
This PR adds a minimum time duration between `window.window.request_redraw()` attempts.

On OS X, when a window is entirely covered by other windows, [window.window.request_redraw](https://docs.rs/winit/0.20.0-alpha2/winit/window/struct.Window.html#method.request_redraw) makes a blocking call but does not actually perform the redraw. This results in apply_update/request_redraw being called every 3-10µs, which has two side effects:

- rust fully consumes a single core of the cpu
- the gpu is hammered with `request_redraw`s, causing whichever program is in the foreground to experience severe visual lag

This PR prevents superfluous redraw requests. It does _not_ attempt to short-circuit any `apply_update` calls past that. I'm not familiar enough with this project to know the side effects that would have.