### PR TITLE
Fix orientation of the teapot y axis in wgpu_instancing example

### DIFF
--- a/examples/wgpu/wgpu_instancing/wgpu_instancing.rs
+++ b/examples/wgpu/wgpu_instancing/wgpu_instancing.rs
@@ -333,14 +333,12 @@ fn view(app: &App, model: &Model, frame: Frame) {
 
 fn create_uniforms(world_rotation: f32, [w, h]: [u32; 2]) -> Uniforms {
     let world_rotation = Matrix3::from_angle_y(Rad(world_rotation as f32));
-    // note: this teapot was meant for OpenGL where the origin is at the lower left instead the
-    // origin is at the upper left in Vulkan, so we reverse the Y axis
     let aspect_ratio = w as f32 / h as f32;
     let proj = cgmath::perspective(Rad(std::f32::consts::FRAC_PI_2), aspect_ratio, 0.01, 100.0);
     let view = Matrix4::look_at(
         Point3::new(0.3, 0.3, 1.0),
         Point3::new(0.0, 0.0, 0.0),
-        Vector3::new(0.0, -1.0, 0.0),
+        Vector3::new(0.0, 1.0, 0.0),
     );
 
     let world_scale = Matrix4::from_scale(0.015);


### PR DESCRIPTION
As noted in #596, this fixes the y axis for the wgpu_instancing example. Let me know if I missed something and I'll pick it up!