### PR TITLE
Fix wrong comment on examples/draw/draw_mesh.rs

### DIFF
--- a/examples/draw/draw_mesh.rs
+++ b/examples/draw/draw_mesh.rs
@@ -10,7 +10,7 @@ fn view(app: &App, frame: Frame) {
     let t = app.time;
     let draw = app.draw();
 
-    // Clear the background to blue.
+    // Clear the background to black.
     draw.background().color(BLACK);
 
     // Use the mouse position to affect the frequency and amplitude.


### PR DESCRIPTION
The comment stated "Clear the background to blue" where the function clearly painted the background black.