### PR TITLE
fixes m_1_3_02 and m_1_3_03 generative examples

### DIFF
--- a/generative_design/random_and_noise/m_1_3_02.rs
+++ b/generative_design/random_and_noise/m_1_3_02.rs
@@ -81,7 +81,7 @@ fn view(app: &App, model: &Model, frame: Frame) {
         &flat_samples.as_slice(),
     );
 
-    let draw = app.draw();        
+    let draw = app.draw();
     draw.texture(&model.texture);
 
     // Write to the window frame.


### PR DESCRIPTION
As reported in issue #609 the two generative examples m_1_3_02 and m_1_3_03 only produce a black window. 

I've done some digging today and have noticed that there seems to be an issue with sampling from a `Rgba16Float` texture in WPGU. Updating these examples textures so they now instead use `.format(wgpu::TextureFormat::Rgba8Unorm)` fixes this issue and the examples draw as expected. 

closes #609 