### PR TITLE
Correct typos in Generative Design example comments

### DIFF
--- a/generative_design/data_trees/m_5_1_01.rs
+++ b/generative_design/data_trees/m_5_1_01.rs
@@ -21,7 +21,7 @@
  * simple example of a recursive function
  *
  * KEYS
- * 1-9                 : recursion level
+ * 0-9                 : recursion level
  * s                   : save png
  */
 use nannou::prelude::*;

--- a/generative_design/dynamic_data_structure/m_6_1_02.rs
+++ b/generative_design/dynamic_data_structure/m_6_1_02.rs
@@ -22,7 +22,7 @@
  * two nodes and a spring
  *
  * MOUSE
- * click, drag   : postion of one of the nodes
+ * click, drag   : position of one of the nodes
  *
  * KEYS
  * s             : save png

--- a/generative_design/dynamic_data_structure/m_6_1_03.rs
+++ b/generative_design/dynamic_data_structure/m_6_1_03.rs
@@ -23,7 +23,6 @@
  * KEYS
  * r             : reset positions
  * s             : save png
- * p             : save pdf
  */
 use nannou::prelude::*;
 

--- a/generative_design/image/p_4_3_2_01.rs
+++ b/generative_design/image/p_4_3_2_01.rs
@@ -21,8 +21,8 @@
  * pixel mapping. each pixel is translated into a new element (letter)
  *
  * KEYS
- * 1                 : toogle font size mode (dynamic/static)
- * 2                 : toogle font color mode (color/b&w)
+ * 1                 : toggle font size mode (dynamic/static)
+ * 2                 : toggle font color mode (color/b&w)
  * arrow up/down     : maximal fontsize +/-
  * arrow right/left  : minimal fontsize +/-
  * s                 : save png

--- a/generative_design/oscillation_figures/m_2_3_01.rs
+++ b/generative_design/oscillation_figures/m_2_3_01.rs
@@ -21,7 +21,7 @@
  * draws an amplitude modulated oscillator
  *
  * KEYS
- * i                 : toggle draw info signal
+ * a                 : toggle draw info signal
  * c                 : toggle draw carrier signal
  * 1/2               : info signal frequency -/+
  * arrow left/right  : info signal phi -/+

--- a/generative_design/random_and_noise/m_1_2_01.rs
+++ b/generative_design/random_and_noise/m_1_2_01.rs
@@ -19,7 +19,7 @@
 
 /**
  * order vs random!
- * how to interpolate beetween a free composition (random) and a circle shape (order)
+ * how to interpolate between a free composition (random) and a circle shape (order)
  *
  * MOUSE
  * position x          : fade between random and circle shape

--- a/generative_design/shape/p_2_0_02.rs
+++ b/generative_design/shape/p_2_0_02.rs
@@ -18,7 +18,7 @@
 // limitations under the License.
 
 /**
- * drawing with a changing shape by draging the mouse.
+ * drawing with a changing shape by dragging the mouse.
  *
  * MOUSE
  * position x          : length

--- a/generative_design/shape/p_2_0_03.rs
+++ b/generative_design/shape/p_2_0_03.rs
@@ -18,7 +18,7 @@
 // limitations under the License.
 
 /**
- * drawing with a changing shape by draging the mouse.
+ * drawing with a changing shape by dragging the mouse.
  *
  * MOUSE
  * position x          : length

--- a/generative_design/shape/p_2_2_1_01.rs
+++ b/generative_design/shape/p_2_2_1_01.rs
@@ -24,7 +24,7 @@
  * position x          : drawing speed
  *
  * KEYS
- * DEL/BACKSPACE       : clear display
+ * r                   : clear display
  * s                   : save png
  */
 use nannou::prelude::*;

--- a/generative_design/shape/p_2_2_3_01.rs
+++ b/generative_design/shape/p_2_2_3_01.rs
@@ -18,7 +18,7 @@
 // limitations under the License.
 
 /**
- * form mophing process by connected random agents
+ * form morphing process by connected random agents
  *
  * MOUSE
  * click               : start a new circe

--- a/generative_design/shape/p_2_2_5_01.rs
+++ b/generative_design/shape/p_2_2_5_01.rs
@@ -18,7 +18,7 @@
 // limitations under the License.
 
 /**
- * pack as many cirlces as possible together
+ * pack as many circles as possible together
  *
  * MOUSE
  * press + position x/y : move area of interest

--- a/generative_design/shape/p_2_3_1_01.rs
+++ b/generative_design/shape/p_2_3_1_01.rs
@@ -26,10 +26,10 @@
  * KEYS
  * 1-4                 : switch default colors
  * delete/backspace    : clear screen
- * d                   : reverse direction and mirrow angle
+ * d                   : reverse direction and mirror angle
  * space               : new random color
- * arrow left          : rotaion speed -
- * arrow right         : rotaion speed +
+ * arrow left          : rotation speed -
+ * arrow right         : rotation speed +
  * arrow up            : line length +
  * arrow down          : line length -
  * s                   : save png


### PR DESCRIPTION
Just a handful of typos I noticed when going through the examples.

Several examples mention using the backspace button, but the functionality does not appear to work (only the delete button)... it was unclear if the code should be fixed or the comments updated. Just for posterity... they were:
- p_4_1_2_01.rs
- p_4_1_2_02.rs
- m_1_5_03.rs
- m_1_5_04.rs
- p_2_2_3_01.rs
- p_2_2_6_01.rs
- p_2_3_1_01.rs
- p_2_3_3_01.rs