### PR TITLE
Temporary switch to `rust-skeptic` patch to fix CI for book tests

### DIFF
--- a/guide/book_tests/Cargo.toml
+++ b/guide/book_tests/Cargo.toml
@@ -6,10 +6,16 @@ edition = '2018'
 description = 'For testing the nannou-guide, while including the nannou dependencies.'
 
 [build-dependencies]
-skeptic = "0.13"
+# Temporarily use git dependency until budziq/rust-skeptic#121 is merged and published.
+# https://github.com/budziq/rust-skeptic/pull/121
+skeptic = { git = "https://github.com/mitchmindtree/rust-skeptic", branch = "1.45-extern" }
+#skeptic = "0.13"
 
 [dev-dependencies]
-skeptic = "0.13"
+# Temporarily use git dependency until budziq/rust-skeptic#121 is merged and published.
+# https://github.com/budziq/rust-skeptic/pull/121
+skeptic = { git = "https://github.com/mitchmindtree/rust-skeptic", branch = "1.45-extern" }
+#skeptic = "0.13"
 nannou = { version ="0.14.0", path = "../../nannou" }
 nannou_osc = { version ="0.14.0", path = "../../nannou_osc" }
 


### PR DESCRIPTION
A recent change to cargo has started causing tests generated by
`rust-skeptic` to fail. budziq/rust-skeptic#120. This has started
causing [issues with our CI](https://github.com/nannou-org/nannou/pull/636/checks?check_run_id=920796725).

This PR temporarily switches to a branch with a patch for this issue. We
should remove this once budziq/rust-skeptic#121 is merged and published.