### PR TITLE
Correct small mistake in coordinate_degrees functions documentation

### DIFF
--- a/nannou/src/draw/drawing.rs
+++ b/nannou/src/draw/drawing.rs
@@ -442,7 +442,7 @@ where
         self.map_ty(|ty| SetOrientation::z_radians(ty, z))
     }
 
-    /// Specify the orientation around the *x* axis as an absolute value in radians.
+    /// Specify the orientation around the *x* axis as an absolute value in degrees.
     pub fn x_degrees(self, x: S) -> Self
     where
         S: BaseFloat,
@@ -450,7 +450,7 @@ where
         self.map_ty(|ty| SetOrientation::x_degrees(ty, x))
     }
 
-    /// Specify the orientation around the *y* axis as an absolute value in radians.
+    /// Specify the orientation around the *y* axis as an absolute value in degrees.
     pub fn y_degrees(self, y: S) -> Self
     where
         S: BaseFloat,
@@ -458,7 +458,7 @@ where
         self.map_ty(|ty| SetOrientation::y_degrees(ty, y))
     }
 
-    /// Specify the orientation around the *z* axis as an absolute value in radians.
+    /// Specify the orientation around the *z* axis as an absolute value in degrees.
     pub fn z_degrees(self, z: S) -> Self
     where
         S: BaseFloat,


### PR DESCRIPTION
Correct documentation for {x,y,z}_degrees functions to say "in degrees" instead of "in radians", which is incorrect.