### PR TITLE
Port CPAL's record_wav example to nannou

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -34,6 +34,9 @@ path = "audio/simple_audio.rs"
 [[example]]
 name = "simple_audio_file"
 path = "audio/simple_audio_file.rs"
+[[example]]
+name = "record_wav"
+path = "audio/record_wav.rs"
 
 # Communication
 [[example]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,6 +26,7 @@ nannou_timeline = { version ="0.14.0", features = ["serde1"], path =  "../nannou
 pitch_calc = { version = "0.12", features = ["serde"] }
 time_calc = { version= "0.13", features = ["serde"] }
 walkdir = "2"
+hound = "3.4.0"
 
 # Audio
 [[example]]

--- a/examples/audio/record_wav.rs
+++ b/examples/audio/record_wav.rs
@@ -1,4 +1,4 @@
-//! Records a WAV file (roughly 3 seconds long) using the default input device and config.
+//! Records a WAV file using the default input device and default input format.
 //!
 //! The input data is recorded to "$CARGO_MANIFEST_DIR/recorded.wav".
 use nannou::prelude::*;
@@ -33,13 +33,8 @@ fn model(app: &App) -> Model {
     // Initialise the audio host so we can spawn an audio stream.
     let audio_host = audio::Host::new();
 
-    // Get specs from device config.
-    let spec = hound::WavSpec {
-        channels: 1,
-        sample_rate: 44100,
-        bits_per_sample: 32,
-        sample_format: hound::SampleFormat::Float,
-    };
+    // Create a writer
+    let spec = get_spec(&audio_host);
     let writer = hound::WavWriter::create("recorded.wav", spec).unwrap();
     let capture_model = CaptureModel { writer };
 
@@ -55,24 +50,59 @@ fn model(app: &App) -> Model {
 // A function that captures the audio from the buffer and
 // writes it into the the WavWriter.
 fn capture_fn(audio: &mut CaptureModel, buffer: &Buffer) {
-    // when the program ends, writer is dropped and
-    // when writer is dropped, it writes data to disk.
+    // When the program ends, writer is dropped and data gets written to the disk.
     for frame in buffer.frames() {
-        audio
-            .writer
-            .write_sample(frame[0] as f32)
-            .expect("error while writing");
+        for sample in frame {
+            audio
+                .writer
+                .write_sample(*sample)
+                .expect("error while writing the sample");
+        }
     }
 }
 
 fn key_pressed(_app: &App, model: &mut Model, key: Key) {
     match key {
-        Key::R => {}
-        Key::P => {}
+        Key::Space => {
+            if model.stream.is_paused() {
+                model.stream.play().unwrap();
+            } else if model.stream.is_playing() {
+                model.stream.pause().unwrap();
+            }
+        }
         _ => {}
     }
 }
 
-fn view(_app: &App, _model: &Model, frame: Frame) {
+fn view(app: &App, model: &Model, frame: Frame) {
     frame.clear(DIMGRAY);
+
+    if model.stream.is_playing() && app.elapsed_frames() % 30 < 20 {
+        let draw = app.draw();
+        draw.ellipse().w_h(100.0, 100.0).color(RED);
+
+        draw.to_frame(app, &frame).unwrap();
+    }
+}
+
+// Get specification from default device format.
+fn get_spec(audio_host: &nannou_audio::Host) -> hound::WavSpec {
+    let default_input_format = audio_host
+        .default_input_device()
+        .unwrap()
+        .default_input_format()
+        .unwrap();
+
+    let (bits_per_sample, sample_format) = match default_input_format.data_type {
+        audio::cpal::SampleFormat::I16 => (16, hound::SampleFormat::Int),
+        audio::cpal::SampleFormat::U16 => (16, hound::SampleFormat::Int),
+        audio::cpal::SampleFormat::F32 => (32, hound::SampleFormat::Float),
+    };
+
+    hound::WavSpec {
+        channels: default_input_format.channels,
+        sample_rate: default_input_format.sample_rate.0,
+        bits_per_sample,
+        sample_format,
+    }
 }

--- a/examples/audio/record_wav.rs
+++ b/examples/audio/record_wav.rs
@@ -1,0 +1,62 @@
+//! Records a WAV file (roughly 3 seconds long) using the default input device and config.
+//!
+//! The input data is recorded to "$CARGO_MANIFEST_DIR/recorded.wav".
+use nannou::prelude::*;
+use nannou_audio as audio;
+use nannou_audio::Buffer;
+
+fn main() {
+    nannou::app(model).run();
+}
+
+struct Model {
+    stream: audio::Stream<CaptureModel>,
+}
+
+struct CaptureModel {
+    frames: Vec<f32>,
+}
+
+fn model(app: &App) -> Model {
+    app.new_window()
+        .key_pressed(key_pressed)
+        .view(view)
+        .build()
+        .unwrap();
+
+    let audio_host = audio::Host::new();
+
+    let model = CaptureModel {
+        frames: vec![],
+    };
+
+    let stream = audio_host
+        .new_input_stream(model)
+        .capture(capture_fn)
+        .build()
+        .unwrap();
+
+    Model { stream }
+}
+
+fn capture_fn(audio: &mut CaptureModel, buffer: &Buffer) {
+    for frame in buffer.frames() {
+        audio.frames.push(frame[0]);
+    }
+}
+
+fn key_pressed(_app: &App, model: &mut Model, key: Key) {
+    match key {
+        Key::R => {
+
+        },
+        Key::P => {
+
+        },
+        _ => {}
+    }
+}
+
+fn view(_app: &App, _model: &Model, frame: Frame) {
+    frame.clear(DIMGRAY);
+}


### PR DESCRIPTION
The example shows how to create an input stream, record audio and write it to disk in .wav format. Because of nannou's interactive nature, I couldn't help but add a record indicator and basic controls to play and pause the stream. Related to issue #435 