### PR TITLE
Publish version 0.15

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,12 +17,12 @@ edition = "2018"
 audrey = "0.2"
 futures = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
-nannou = { version ="0.14.1", path = "../nannou" }
-nannou_audio = { version ="0.14.0", path = "../nannou_audio" }
+nannou = { version ="0.15.0", path = "../nannou" }
+nannou_audio = { version ="0.15.0", path = "../nannou_audio" }
 nannou_isf = { version ="0.1.0", path = "../nannou_isf" }
-nannou_laser = { version ="0.14.1", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
-nannou_osc = { version ="0.14.0", path = "../nannou_osc" }
-nannou_timeline = { version ="0.14.0", features = ["serde1"], path =  "../nannou_timeline" }
+nannou_laser = { version ="0.15.0", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
+nannou_osc = { version ="0.15.0", path = "../nannou_osc" }
+nannou_timeline = { version ="0.15.0", features = ["serde1"], path =  "../nannou_timeline" }
 pitch_calc = { version = "0.12", features = ["serde"] }
 time_calc = { version= "0.13", features = ["serde"] }
 walkdir = "2"

--- a/generative_design/Cargo.toml
+++ b/generative_design/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-nannou = { version ="0.14.1", path = "../nannou" }
+nannou = { version ="0.15.0", path = "../nannou" }
 usvg = "0.4"
 wikipedia = "0.3"
 

--- a/guide/book_tests/Cargo.toml
+++ b/guide/book_tests/Cargo.toml
@@ -16,6 +16,6 @@ skeptic = { git = "https://github.com/mitchmindtree/rust-skeptic", branch = "1.4
 # https://github.com/budziq/rust-skeptic/pull/121
 skeptic = { git = "https://github.com/mitchmindtree/rust-skeptic", branch = "1.45-extern" }
 #skeptic = "0.13"
-nannou = { version ="0.14.0", path = "../../nannou" }
-nannou_osc = { version ="0.14.0", path = "../../nannou_osc" }
+nannou = { version ="0.15.0", path = "../../nannou" }
+nannou_osc = { version ="0.15.0", path = "../../nannou_osc" }
 

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -7,6 +7,12 @@ back to the origins.
 
 # Unreleased
 
+*There are no unreleased changes yet.*
+
+---
+
+# Version 0.15.0 (2020-10-04)
+
 **Update to WGPU 0.5**
 
 For the most part, these changes will affect users of the `nannou::wgpu` module,

--- a/guide/src/contributing.md
+++ b/guide/src/contributing.md
@@ -3,10 +3,10 @@
 Considering contributing to nannou? Awesome! Hopefully this section can guide
 you in the right direction.
 
-- [**About the Codebase**](./about-the-codebase.md)
-- [**PR Checklist**](./pr-checklist.md)
-- [**PR Reviews**](./pr-reviews.md)
-- [**Publish New Versions**](./publish-new-versions.md)
+- [**About the Codebase**](./contributing/about-the-codebase.md)
+- [**PR Checklist**](./contributing/pr-checklist.md)
+- [**PR Reviews**](./contributing/pr-reviews.md)
+- [**Publishing New Versions**](./contributing/publishing-new-versions.md)
 
 ## Still have questions?
 

--- a/guide/src/getting_started/create_a_project.md
+++ b/guide/src/getting_started/create_a_project.md
@@ -29,9 +29,9 @@ create a new project with just a few small steps:
    version = "0.1.0"
    authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
    edition = "2018"
-   
+
    [dependencies]
-   nannou = "0.14"
+   nannou = "0.15"
    ```
 
    Note that there is a chance the nannou version above might be out of date.

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version ="0.14.1"
+version ="0.15.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"

--- a/nannou_audio/Cargo.toml
+++ b/nannou_audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_audio"
-version ="0.14.0"
+version ="0.15.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The audio API for Nannou, the creative coding framework."
 readme = "README.md"

--- a/nannou_isf/Cargo.toml
+++ b/nannou_isf/Cargo.toml
@@ -4,12 +4,10 @@ version ="0.1.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 isf = { git = "https://github.com/nannou-org/isf", branch = "master" }
-nannou = { version ="0.14.0", path = "../nannou" }
+nannou = { version ="0.15.0", path = "../nannou" }
 thiserror = "1"
 threadpool = "1"
 walkdir = "2"

--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_laser"
-version ="0.14.3"
+version ="0.15.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 edition = "2018"

--- a/nannou_new/Cargo.toml
+++ b/nannou_new/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_new"
-version ="0.14.0"
+version ="0.15.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A tool for easily starting Nannou projects."
 readme = "README.md"

--- a/nannou_osc/Cargo.toml
+++ b/nannou_osc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_osc"
-version ="0.14.0"
+version ="0.15.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The OSC API for Nannou, the creative coding framework."
 readme = "README.md"

--- a/nannou_package/Cargo.toml
+++ b/nannou_package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_package"
-version ="0.14.0"
+version ="0.15.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The build packaging tool for the Nannou Creative Coding Framework."
 readme = "README.md"

--- a/nannou_timeline/Cargo.toml
+++ b/nannou_timeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_timeline"
-version ="0.14.0"
+version ="0.15.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A timeline widget, compatible with all conrod GUI projects."
 readme = "README.md"
@@ -27,6 +27,6 @@ serde1 = [
 ]
 
 [dev-dependencies]
-nannou = { version ="0.14.0", path = "../nannou" }
+nannou = { version ="0.15.0", path = "../nannou" }
 rand = "0.3.12"
 serde_json = "1.0"

--- a/nature_of_code/Cargo.toml
+++ b/nature_of_code/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-nannou = { version ="0.14.1", path = "../nannou" }
+nannou = { version ="0.15.0", path = "../nannou" }
 
 # Chapter 1 Vectors
 [[example]]


### PR DESCRIPTION
See the changelog below for an overview of the changes included in this
version.

For the most part, this is an update for wgpu 0.5. @alekspickle
already has a WIP for wgpu 0.6 at #655! I'm more than happy to publish a
new version again as soon as that lands, but figured this one is already
well overdue :)

Also, find out how you can get new nannou versions published quicker in
the new Contributing chapter of the guide [here](https://guide.nannou.cc/contributing/publishing-new-versions.html)).