### PR TITLE
Updating to wgpu 0.6 - follow-up attempt to #655

### DIFF
--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -15,9 +15,9 @@ default = ["notosans"]
 
 [dependencies]
 cgmath = { version = "0.17", features = ["serde"] }
-conrod_core = "0.70"
-conrod_wgpu = "0.70"
-conrod_winit = "0.70"
+conrod_core = "0.71"
+conrod_wgpu = "0.71"
+conrod_winit = "0.71"
 daggy = "0.6"
 find_folder = "0.3"
 futures = { version = "0.3", features = ["executor", "thread-pool"] }
@@ -35,5 +35,5 @@ serde_derive = "1"
 serde_json = "1"
 toml = "0.5"
 walkdir = "2"
-wgpu = "0.5"
-winit = "0.22"
+wgpu = "0.6"
+winit = "0.23"

--- a/nannou/src/draw/renderer/mod.rs
+++ b/nannou/src/draw/renderer/mod.rs
@@ -395,7 +395,7 @@ impl Renderer {
             .usage(wgpu::TextureUsage::SAMPLED | wgpu::TextureUsage::COPY_DST)
             .format(Self::GLYPH_CACHE_TEXTURE_FORMAT)
             .build(device);
-        let glyph_cache_texture_view = glyph_cache_texture.create_default_view();
+        let glyph_cache_texture_view = glyph_cache_texture.view().build();
 
         // Create the depth texture.
         let depth_texture =
@@ -413,7 +413,11 @@ impl Renderer {
         let uniforms = create_uniforms(output_attachment_size, output_scale_factor);
         let uniforms_bytes = uniforms_as_bytes(&uniforms);
         let usage = wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST;
-        let uniform_buffer = device.create_buffer_with_data(uniforms_bytes, usage);
+        let uniform_buffer = device.create_buffer_init(wgpu::util::BufferInitDescriptor {
+            label: Some("nannou_draw_uniform_buffer"),
+            contents: uniforms_bytes,
+            usage,
+        });
 
         // Bind group for uniforms.
         let uniform_bind_group_layout = create_uniform_bind_group_layout(device);
@@ -1013,7 +1017,7 @@ fn create_text_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout
             wgpu::ShaderStage::FRAGMENT,
             false,
             wgpu::TextureViewDimension::D2,
-            wgpu::texture_format_to_component_type(Renderer::GLYPH_CACHE_TEXTURE_FORMAT),
+            Renderer::GLYPH_CACHE_TEXTURE_FORMAT,
         )
         .build(device)
 }

--- a/nannou/src/frame/mod.rs
+++ b/nannou/src/frame/mod.rs
@@ -228,20 +228,19 @@ impl<'swap_chain> Frame<'swap_chain> {
     /// greater than `1`, a render pass will be automatically added after the `view` completes and
     /// before the texture is drawn to the swapchain.
     pub fn color_attachment_descriptor(&self) -> wgpu::RenderPassColorAttachmentDescriptor {
-        let load_op = wgpu::LoadOp::Load;
-        let store_op = wgpu::StoreOp::Store;
+        let load = wgpu::LoadOp::Load;
+        let store = true;
         let attachment = match self.render_data.intermediary_lin_srgba.msaa_texture {
             None => &self.render_data.intermediary_lin_srgba.texture_view,
             Some((_, ref msaa_texture_view)) => msaa_texture_view,
         };
         let resolve_target = None;
         let clear_color = wgpu::Color::TRANSPARENT;
+        let ops = wgpu::Operations { load, store };
         wgpu::RenderPassColorAttachmentDescriptor {
             attachment,
             resolve_target,
-            load_op,
-            store_op,
-            clear_color,
+            ops,
         }
     }
 

--- a/nannou/src/ui.rs
+++ b/nannou/src/ui.rs
@@ -524,7 +524,7 @@ pub fn encode_render_pass(
 }
 
 mod conrod_winit_conv {
-    conrod_winit::v021_conversion_fns!();
+    conrod_winit::v023_conversion_fns!();
 }
 
 /// Convert the given window event to a UI Input.

--- a/nannou/src/wgpu/bind_group_builder.rs
+++ b/nannou/src/wgpu/bind_group_builder.rs
@@ -31,7 +31,20 @@ impl LayoutBuilder {
 
     /// Add a uniform buffer binding to the layout.
     pub fn uniform_buffer(self, visibility: wgpu::ShaderStage, dynamic: bool) -> Self {
-        let ty = wgpu::BindingType::UniformBuffer { dynamic };
+        let min_binding_size = None;
+        let ty = wgpu::BindingType::UniformBuffer { dynamic, min_binding_size };
+        self.binding(visibility, ty)
+    }
+
+    /// Add a uniform buffer binding to the layout.
+    pub fn uniform_buffer_with_min_binding_size(
+        self,
+        visibility: wgpu::ShaderStage,
+        dynamic: bool,
+        min_binding_size: std::num::NonZeroU64,
+    ) -> Self {
+        let min_binding_size = Some(min_binding_size);
+        let ty = wgpu::BindingType::UniformBuffer { dynamic, min_binding_size };
         self.binding(visibility, ty)
     }
 
@@ -42,7 +55,21 @@ impl LayoutBuilder {
         dynamic: bool,
         readonly: bool,
     ) -> Self {
-        let ty = wgpu::BindingType::StorageBuffer { dynamic, readonly };
+        let min_binding_size = None;
+        let ty = wgpu::BindingType::StorageBuffer { dynamic, readonly, min_binding_size };
+        self.binding(visibility, ty)
+    }
+
+    /// Add a storage buffer binding to the layout.
+    pub fn storage_buffer_with_min_binding_size(
+        self,
+        visibility: wgpu::ShaderStage,
+        dynamic: bool,
+        readonly: bool,
+        min_binding_size: std::num::NonZeroU64,
+    ) -> Self {
+        let min_binding_size = Some(min_binding_size);
+        let ty = wgpu::BindingType::StorageBuffer { dynamic, readonly, min_binding_size };
         self.binding(visibility, ty)
     }
 
@@ -136,18 +163,21 @@ impl LayoutBuilder {
 
     /// Build the bind group layout from the specified parameters.
     pub fn build(self, device: &wgpu::Device) -> wgpu::BindGroupLayout {
-        let mut bindings = Vec::with_capacity(self.bindings.len());
+        let mut entries = Vec::with_capacity(self.bindings.len());
         for (i, (visibility, ty)) in self.bindings.into_iter().enumerate() {
             let layout_binding = wgpu::BindGroupLayoutEntry {
                 binding: i as u32,
                 visibility,
                 ty,
+                // TODO: Investigate how to use this properly:
+                // https://docs.rs/wgpu/0.6.0/wgpu/struct.BindGroupLayoutEntry.html#structfield.count
+                count: None,
             };
-            bindings.push(layout_binding);
+            entries.push(layout_binding);
         }
         let descriptor = wgpu::BindGroupLayoutDescriptor {
             label: Some("nannou"),
-            bindings: &bindings,
+            entries: &entries,
         };
         device.create_bind_group_layout(&descriptor)
     }
@@ -178,7 +208,9 @@ impl<'a> Builder<'a> {
         buffer: &'a wgpu::Buffer,
         range: std::ops::Range<wgpu::BufferAddress>,
     ) -> Self {
-        let resource = wgpu::BindingResource::Buffer { buffer, range };
+        let size = range.end - range.start;
+        let buffer_slice = wgpu::BindingResource::Buffer { buffer, range, size };
+        let resource = wgpu::BindingResource::Buffer(buffer_slice);
         self.binding(resource)
     }
 
@@ -213,18 +245,18 @@ impl<'a> Builder<'a> {
 
     /// Build the bind group with the specified resources.
     pub fn build(self, device: &wgpu::Device, layout: &wgpu::BindGroupLayout) -> wgpu::BindGroup {
-        let mut bindings = Vec::with_capacity(self.resources.len());
+        let mut entries = Vec::with_capacity(self.resources.len());
         for (i, resource) in self.resources.into_iter().enumerate() {
-            let binding = wgpu::Binding {
+            let binding = wgpu::BindGroupEntry {
                 binding: i as u32,
                 resource,
             };
-            bindings.push(binding);
+            entries.push(binding);
         }
         let descriptor = wgpu::BindGroupDescriptor {
             label: Some("nannou"),
             layout,
-            bindings: &bindings,
+            entries: &entries,
         };
         device.create_bind_group(&descriptor)
     }

--- a/nannou/src/wgpu/render_pipeline_builder.rs
+++ b/nannou/src/wgpu/render_pipeline_builder.rs
@@ -91,15 +91,18 @@ impl<'a> RenderPipelineBuilder<'a> {
         wgpu::StencilStateFaceDescriptor::IGNORE;
     pub const DEFAULT_STENCIL_READ_MASK: u32 = 0;
     pub const DEFAULT_STENCIL_WRITE_MASK: u32 = 0;
+    pub const DEFAULT_STENCIL: wgpu::StencilStateDescriptor = wgpu::StencilStateDescriptor {
+        front: Self::DEFAULT_STENCIL_FRONT,
+        back: Self::DEFAULT_STENCIL_BACK,
+        read_mask: Self::DEFAULT_STENCIL_READ_MASK,
+        write_mask: Self::DEFAULT_STENCIL_WRITE_MASK,
+    };
     pub const DEFAULT_DEPTH_STENCIL_STATE: wgpu::DepthStencilStateDescriptor =
         wgpu::DepthStencilStateDescriptor {
             format: Self::DEFAULT_DEPTH_FORMAT,
             depth_write_enabled: Self::DEFAULT_DEPTH_WRITE_ENABLED,
             depth_compare: Self::DEFAULT_DEPTH_COMPARE,
-            stencil_front: Self::DEFAULT_STENCIL_FRONT,
-            stencil_back: Self::DEFAULT_STENCIL_BACK,
-            stencil_read_mask: Self::DEFAULT_STENCIL_READ_MASK,
-            stencil_write_mask: Self::DEFAULT_STENCIL_WRITE_MASK,
+            stencil: Self::DEFAULT_STENCIL,
         };
 
     // Vertex buffer defaults.
@@ -295,7 +298,7 @@ impl<'a> RenderPipelineBuilder<'a> {
         let state = self
             .depth_stencil_state
             .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
-        state.stencil_front = stencil;
+        state.stencil.front = stencil;
         self
     }
 
@@ -303,7 +306,7 @@ impl<'a> RenderPipelineBuilder<'a> {
         let state = self
             .depth_stencil_state
             .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
-        state.stencil_back = stencil;
+        state.stencil.back = stencil;
         self
     }
 
@@ -311,7 +314,7 @@ impl<'a> RenderPipelineBuilder<'a> {
         let state = self
             .depth_stencil_state
             .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
-        state.stencil_read_mask = mask;
+        state.stencil.read_mask = mask;
         self
     }
 
@@ -319,7 +322,7 @@ impl<'a> RenderPipelineBuilder<'a> {
         let state = self
             .depth_stencil_state
             .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
-        state.stencil_write_mask = mask;
+        state.stencil.write_mask = mask;
         self
     }
 
@@ -404,7 +407,10 @@ impl<'a> IntoPipelineLayoutDescriptor<'a> for wgpu::PipelineLayoutDescriptor<'a>
 impl<'a> IntoPipelineLayoutDescriptor<'a> for &'a [&'a wgpu::BindGroupLayout] {
     fn into_pipeline_layout_descriptor(self) -> wgpu::PipelineLayoutDescriptor<'a> {
         wgpu::PipelineLayoutDescriptor {
+            label: Some("nannou_pipeline_layout_descriptor"),
             bind_group_layouts: self,
+            // TODO: This should be exposed.
+            push_constant_ranges: &[],
         }
     }
 }
@@ -477,7 +483,9 @@ fn build(
     };
 
     let pipeline_desc = wgpu::RenderPipelineDescriptor {
-        layout,
+        // TODO: Expose a &'static str builder method.
+        lable: Some("nannou_render_pipeline_descriptor"),
+        layout: Some(layout),
         vertex_stage,
         fragment_stage,
         rasterization_state,

--- a/nannou/src/wgpu/sampler_builder.rs
+++ b/nannou/src/wgpu/sampler_builder.rs
@@ -14,7 +14,9 @@ impl SamplerBuilder {
     pub const DEFAULT_LOD_MIN_CLAMP: f32 = -100.0;
     pub const DEFAULT_LOD_MAX_CLAMP: f32 = 100.0;
     pub const DEFAULT_COMPARE: wgpu::CompareFunction = wgpu::CompareFunction::Always;
+    pub const DEFAULT_LABEL: &'static str = "nannou_sampler_descriptor";
     pub const DEFAULT_DESCRIPTOR: wgpu::SamplerDescriptor = wgpu::SamplerDescriptor {
+        label: Some(Self::DEFAULT_LABEL),
         address_mode_u: Self::DEFAULT_ADDRESS_MODE_U,
         address_mode_v: Self::DEFAULT_ADDRESS_MODE_V,
         address_mode_w: Self::DEFAULT_ADDRESS_MODE_W,
@@ -95,7 +97,12 @@ impl SamplerBuilder {
     }
 
     pub fn compare(mut self, f: wgpu::CompareFunction) -> Self {
-        self.descriptor.compare = f;
+        self.descriptor.compare = Some(f);
+        self
+    }
+
+    pub fn label(mut self, label: &'static str) -> Self {
+        self.descriptor.label = Some(label);
         self
     }
 
@@ -105,7 +112,7 @@ impl SamplerBuilder {
     }
 
     /// Consume the builder and produce the inner `SamplerDescriptor`.
-    pub fn into_descriptor(self) -> wgpu::SamplerDescriptor {
+    pub fn into_descriptor(self) -> wgpu::SamplerDescriptor<'static> {
         self.into()
     }
 }
@@ -118,14 +125,14 @@ impl Default for SamplerBuilder {
     }
 }
 
-impl Into<wgpu::SamplerDescriptor> for SamplerBuilder {
-    fn into(self) -> wgpu::SamplerDescriptor {
+impl Into<wgpu::SamplerDescriptor<'static>> for SamplerBuilder {
+    fn into(self) -> wgpu::SamplerDescriptor<'static> {
         self.descriptor
     }
 }
 
-impl From<wgpu::SamplerDescriptor> for SamplerBuilder {
-    fn from(descriptor: wgpu::SamplerDescriptor) -> Self {
+impl From<wgpu::SamplerDescriptor<'static>> for SamplerBuilder {
+    fn from(descriptor: wgpu::SamplerDescriptor<'static>) -> Self {
         SamplerBuilder { descriptor }
     }
 }

--- a/nannou/src/wgpu/texture/capturer.rs
+++ b/nannou/src/wgpu/texture/capturer.rs
@@ -380,7 +380,7 @@ fn create_converter_data_pair(
     // Create the converter.
     let src_sample_count = src_texture.sample_count();
     let src_component_type = src_texture.component_type();
-    let src_view = src_texture.create_default_view();
+    let src_view = src_texture.view().build();
     let dst_sample_count = 1;
     let dst_format = dst_texture.format();
     let reshaper = wgpu::TextureReshaper::new(


### PR DESCRIPTION
This is a WIP follow-up to #655, attempting to update to wgpu 0.6.

I was running into an issue where rustc would hang indefinitely, and there were quite a few lifetime issues I wanted to address so thought I would have a crack at this from scratch.

TODO:

- [ ] Store `Instance` somewhere at app-level, maybe with device map.
- [ ] Provide builder methods for specifying 'static labels.
- [ ] Solve capturer Snapshots async changes.
- [ ] Review `wgpu::create_pipeline_layout` - can be replaced with a builder?
- [ ] Review IntoPipelineLayoutDescriptor.

cc @alekspickle @yutannihilation @kazimuth