### PR TITLE
Update nannou_audio to use cpal 0.12 and replace sample crate with dasp_sample 

### DIFF
--- a/nannou_audio/Cargo.toml
+++ b/nannou_audio/Cargo.toml
@@ -11,9 +11,9 @@ homepage = "https://nannou.cc"
 edition = "2018"
 
 [dependencies]
-cpal = "0.11"
+cpal = "0.12"
 failure = "0.1"
-sample = "0.10"
+dasp_sample = "0.11.0"
 
 [features]
 asio = ["cpal/asio"]

--- a/nannou_audio/src/device.rs
+++ b/nannou_audio/src/device.rs
@@ -1,4 +1,6 @@
-use crate::{DefaultFormatError, DeviceNameError, Format, SupportedFormatsError};
+use crate::{
+    DefaultStreamConfigError, DeviceNameError, SupportedStreamConfig, SupportedStreamConfigsError,
+};
 use cpal::traits::DeviceTrait;
 use std::ops::Deref;
 
@@ -12,11 +14,11 @@ pub struct Devices {
     pub(crate) devices: cpal::Devices,
 }
 
-/// An iterator yielding formats that are supported by the backend.
-pub type SupportedInputFormats = cpal::SupportedInputFormats;
+/// An iterator yielding configs that are supported by the backend.
+pub type SupportedInputConfigs = cpal::SupportedInputConfigs;
 
-/// An iterator yielding formats that are supported by the backend.
-pub type SupportedOutputFormats = cpal::SupportedOutputFormats;
+/// An iterator yielding configs that are supported by the backend.
+pub type SupportedOutputConfigs = cpal::SupportedOutputConfigs;
 
 impl Device {
     /// The unique name associated with this device.
@@ -27,43 +29,45 @@ impl Device {
     /// An iterator yielding formats that are supported by the backend.
     ///
     /// Can return an error if the device is no longer valid (e.g. it has been disconnected).
-    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, SupportedFormatsError> {
-        self.device.supported_input_formats()
+    pub fn supported_input_configs(
+        &self,
+    ) -> Result<SupportedInputConfigs, SupportedStreamConfigsError> {
+        self.device.supported_input_configs()
     }
 
-    /// An iterator yielding formats that are supported by the backend.
+    /// An iterator yielding configs that are supported by the backend.
     ///
     /// Can return an error if the device is no longer valid (e.g. it has been disconnected).
-    pub fn supported_output_formats(
+    pub fn supported_output_configs(
         &self,
-    ) -> Result<SupportedOutputFormats, SupportedFormatsError> {
-        self.device.supported_output_formats()
+    ) -> Result<SupportedOutputConfigs, SupportedStreamConfigsError> {
+        self.device.supported_output_configs()
     }
 
-    /// The default format used for input streams.
-    pub fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
-        self.device.default_input_format()
+    /// The default config used for input streams.
+    pub fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        self.device.default_input_config()
     }
 
-    /// The default format used for output streams.
-    pub fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
-        self.device.default_output_format()
+    /// The default config used for output streams.
+    pub fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        self.device.default_output_config()
     }
 
     /// The maximum number of output channels of any format supported by this device.
     pub fn max_supported_output_channels(&self) -> usize {
-        self.supported_output_formats()
+        self.supported_output_configs()
             .expect("failed to get supported output audio stream formats")
-            .map(|fmt| fmt.channels as usize)
+            .map(|fmt| fmt.channels() as usize)
             .max()
             .unwrap_or(0)
     }
 
     /// The maximum number of input channels of any format supported by this device.
     pub fn max_supported_input_channels(&self) -> usize {
-        self.supported_input_formats()
+        self.supported_input_configs()
             .expect("failed to get supported input audio stream formats")
-            .map(|fmt| fmt.channels as usize)
+            .map(|fmt| fmt.channels() as usize)
             .max()
             .unwrap_or(0)
     }

--- a/nannou_audio/src/lib.rs
+++ b/nannou_audio/src/lib.rs
@@ -138,7 +138,6 @@ impl Host {
     fn new_stream<M, S>(&self, model: M) -> stream::Builder<M, S> {
         let process_fn_tx = if self.process_fn_tx.lock().unwrap().is_none() {
             let (tx, rx) = mpsc::channel();
-            let mut loop_context = stream::LoopContext::new(rx);
             thread::Builder::new()
                 .name("cpal::EventLoop::run thread".into())
                 .spawn(move || event_loop.run(move |id, data| loop_context.process(id, data)))

--- a/nannou_audio/src/lib.rs
+++ b/nannou_audio/src/lib.rs
@@ -12,7 +12,7 @@
 //!   [**Requester**](./requester/struct.Requester.html) for buffering input and output streams that
 //!   may deliver buffers of inconsistent sizes into a stream of consistently sized buffers.
 
-use cpal::traits::{EventLoopTrait, HostTrait};
+use cpal::traits::{HostTrait, StreamTrait};
 use std::marker::PhantomData;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
@@ -25,12 +25,14 @@ pub use self::stream::Stream;
 pub use cpal;
 #[doc(inline)]
 pub use cpal::{
-    BackendSpecificError, BuildStreamError, DefaultFormatError, DeviceNameError, DevicesError,
-    PauseStreamError, PlayStreamError, StreamError, SupportedFormatsError,
+    BackendSpecificError, BuildStreamError, DefaultStreamConfigError, DeviceNameError,
+    DevicesError, PauseStreamError, PlayStreamError, StreamError, SupportedStreamConfigsError,
 };
 #[doc(inline)]
-pub use cpal::{Format, HostId, HostUnavailable, SupportedInputFormats, SupportedOutputFormats};
-pub use sample;
+pub use cpal::{
+    HostId, HostUnavailable, SupportedInputConfigs, SupportedOutputConfigs, SupportedStreamConfig,
+};
+pub use dasp_sample;
 
 pub mod buffer;
 pub mod device;

--- a/nannou_audio/src/receiver.rs
+++ b/nannou_audio/src/receiver.rs
@@ -1,5 +1,5 @@
 use crate::{stream, Buffer};
-use sample::Sample;
+use dasp_sample::Sample;
 use std;
 
 /// A `Receiver` for converting audio delivered by the backend at varying buffer sizes into buffers

--- a/nannou_audio/src/requester.rs
+++ b/nannou_audio/src/requester.rs
@@ -1,5 +1,5 @@
 use crate::{stream, Buffer};
-use sample::Sample;
+use dasp_sample::Sample;
 use std;
 
 /// A `sound::Requester` for converting backend audio requests into requests for buffers of a fixed
@@ -26,7 +26,7 @@ where
         assert!(num_frames > 0);
         let num_samples = num_frames + num_channels;
         Requester {
-            samples: vec![S::equilibrium(); num_samples],
+            samples: vec![S::EQUILIBRIUM; num_samples],
             num_frames: num_frames,
             pending_range: None,
         }
@@ -68,7 +68,7 @@ where
         // Fill the given buffer with silence.
         fn silence<S: Sample>(buffer: &mut [S]) {
             for sample in buffer {
-                *sample = S::equilibrium();
+                *sample = S::EQUILIBRIUM;
             }
         }
 
@@ -109,7 +109,7 @@ where
         }
 
         // Ensure that our buffer has `num_frames` `frames`.
-        samples.resize(num_samples, S::equilibrium());
+        samples.resize(num_samples, S::EQUILIBRIUM);
 
         // Loop until the given `output` is filled.
         loop {

--- a/nannou_audio/src/stream/input.rs
+++ b/nannou_audio/src/stream/input.rs
@@ -121,6 +121,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         self
     }
 
+    // TO DO add a buffer_size function
+
     pub fn frames_per_buffer(mut self, frames_per_buffer: usize) -> Self {
         assert!(frames_per_buffer > 0);
         self.builder.frames_per_buffer = Some(frames_per_buffer);
@@ -270,7 +272,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
 
         let shared = Arc::new(super::Shared {
             model,
-            stream_id,
             is_paused: AtomicBool::new(false),
         });
 
@@ -278,7 +279,7 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             shared,
             process_fn_tx,
             update_tx,
-            cpal_stream_config: format,
+            cpal_stream_config: config,
         };
         Ok(stream)
     }

--- a/nannou_audio/src/stream/input.rs
+++ b/nannou_audio/src/stream/input.rs
@@ -139,7 +139,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             builder:
                 stream::Builder {
                     host,
-                    event_loop,
                     process_fn_tx,
                     model,
                     sample_rate,
@@ -162,8 +161,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             Some(Device { device }) => device,
         };
 
-        // Find the best matching format.
-        let format = super::find_best_matching_format(
+        // Find the best matching config.
+        let config = super::find_best_matching_config(
             &device,
             sample_format,
             channels,
@@ -176,8 +175,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let (update_tx, update_rx) = mpsc::channel();
         let model = Arc::new(Mutex::new(Some(model)));
         let model_2 = model.clone();
-        let num_channels = format.channels as usize;
-        let sample_rate = format.sample_rate.0;
+        let num_channels = config.channels() as usize;
+        let sample_rate = config.sample_rate().0;
 
         // A buffer for collecting model updates.
         let mut pending_updates: Vec<Box<dyn FnMut(&mut M) + 'static + Send>> = Vec::new();
@@ -272,7 +271,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let shared = Arc::new(super::Shared {
             model,
             stream_id,
-            event_loop,
             is_paused: AtomicBool::new(false),
         });
 

--- a/nannou_audio/src/stream/mod.rs
+++ b/nannou_audio/src/stream/mod.rs
@@ -26,7 +26,7 @@ pub const DEFAULT_SAMPLE_RATE: u32 = 44_100;
 pub type UpdateFn<M> = dyn FnOnce(&mut M) + Send + 'static;
 
 pub(crate) type ProcessFn = dyn FnMut(cpal::StreamDataResult) + 'static + Send;
-pub(crate) type ProcessFnMsg = (cpal::StreamId, Box<ProcessFn>);
+pub(crate) type ProcessFnMsg = Box<ProcessFn>;
 
 /// A clone-able handle around an audio stream.
 pub struct Stream<M> {
@@ -267,8 +267,6 @@ fn matching_supported_configs(
         let supported_channels = supported_stream_config_range.channels() as usize;
         if supported_channels < channels {
             return None;
-        } else if supported_channels > channels {
-            supported_stream_config_range.channels = channels as u16;
         }
     }
     // Check the sample rate.
@@ -282,12 +280,12 @@ fn matching_supported_configs(
         return Some(config);
     }
 
-    // cpal::SupportedStreamConfig {
+    // let config = cpal::SupportedStreamConfig {
     //     channels: channels,
     //     sample_rate: sample_rate,
     //     buffer_size: buffer_size,
     //     sample_format: sample_format,
-    // }
+    // };
 
     Some(supported_stream_config_range.with_max_sample_rate())
 }

--- a/nannou_audio/src/stream/output.rs
+++ b/nannou_audio/src/stream/output.rs
@@ -138,7 +138,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             builder:
                 stream::Builder {
                     host,
-                    event_loop,
                     process_fn_tx,
                     model,
                     sample_rate,
@@ -161,8 +160,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             Some(Device { device }) => device,
         };
 
-        // Find the best matching format.
-        let format = super::find_best_matching_format(
+        // Find the best matching config.
+        let config = super::find_best_matching_config(
             &device,
             sample_format,
             channels,
@@ -175,8 +174,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let (update_tx, update_rx) = mpsc::channel();
         let model = Arc::new(Mutex::new(Some(model)));
         let model_2 = model.clone();
-        let num_channels = format.channels as usize;
-        let sample_rate = format.sample_rate.0;
+        let num_channels = config.channels() as usize;
+        let sample_rate = config.sample_rate().0;
 
         // A buffer for collecting model updates.
         let mut pending_updates: Vec<Box<dyn FnMut(&mut M) + 'static + Send>> = Vec::new();
@@ -248,6 +247,12 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
                 }
             }
 
+            match config.sample_format() {
+                cpal::SampleFormat::F32 => {
+
+                }
+            }
+
             // Process the given buffer.
             match output {
                 cpal::UnknownTypeOutputBuffer::U16(mut buffer) => {
@@ -272,7 +277,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let shared = Arc::new(super::Shared {
             model,
             stream_id,
-            event_loop,
             is_paused: AtomicBool::new(false),
         });
 

--- a/nannou_audio/src/stream/output.rs
+++ b/nannou_audio/src/stream/output.rs
@@ -115,6 +115,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         self
     }
 
+    // TO DO add a buffer_size function
+
     pub fn device(mut self, device: Device) -> Self {
         self.builder.device = Some(device);
         self
@@ -248,9 +250,7 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             }
 
             match config.sample_format() {
-                cpal::SampleFormat::F32 => {
-
-                }
+                cpal::SampleFormat::F32 => {}
             }
 
             // Process the given buffer.
@@ -284,7 +284,7 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             shared,
             process_fn_tx,
             update_tx,
-            cpal_format: format,
+            cpal_stream_config: config,
         };
         Ok(stream)
     }

--- a/nannou_audio/src/stream/output.rs
+++ b/nannou_audio/src/stream/output.rs
@@ -276,7 +276,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
 
         let shared = Arc::new(super::Shared {
             model,
-            stream_id,
             is_paused: AtomicBool::new(false),
         });
 


### PR DESCRIPTION
This is nowhere near ready but i'm putting this up so people can follow along and leave comments. 

Quite a lot has changed between cpal 0.11 and cpal 0.12. Specifically, we can now request a BufferSize (great for low latency applications, which I assume is most nannou apps!) and the removal of the existing EventLoop. 

The `sample` crate has also been deprecated in favour of `dasp`. Instead of importing the whole of `dasp` I've only included the `dasp_sample` crate as it has everything that we need.

TODO:

- [ ] Remove the cpal event loop