### PR TITLE
Refactor: use shorthand fields

### DIFF
--- a/nannou_timeline/src/env/mod.rs
+++ b/nannou_timeline/src/env/mod.rs
@@ -75,7 +75,7 @@ impl<T> std::iter::FromIterator<Point<T>> for Envelope<T> {
 
 impl<T> From<Vec<Point<T>>> for Envelope<T> {
     fn from(points: Vec<Point<T>>) -> Self {
-        Envelope { points: points }
+        Envelope { points }
     }
 }
 

--- a/nannou_timeline/src/timeline.rs
+++ b/nannou_timeline/src/timeline.rs
@@ -429,7 +429,7 @@ impl Tracks {
     /// Returns a context which can be used to set the `Playhead` and `Scrollbar`.
     pub fn end_tracks(self) -> Final {
         let Tracks { context, .. } = self;
-        Final { context: context }
+        Final { context }
     }
 }
 
@@ -741,7 +741,7 @@ where
             maybe_playhead: maybe_playhead,
         };
 
-        PinnedTracks { context: context }
+        PinnedTracks { context }
     }
 }
 

--- a/nannou_timeline/src/track/automation/bang.rs
+++ b/nannou_timeline/src/track/automation/bang.rs
@@ -317,7 +317,7 @@ impl<'a> conrod::Widget for Bang<'a> {
                 ticks: clamped_ticks_from_x(click_x),
                 value: BangValue,
             };
-            let add_point = super::AddPoint { point: point };
+            let add_point = super::AddPoint { point };
             events.push(Event::Mutate(add_point.into()));
         }
 

--- a/nannou_timeline/src/track/automation/dynamic.rs
+++ b/nannou_timeline/src/track/automation/dynamic.rs
@@ -171,7 +171,7 @@ impl<'a> conrod::Widget for Dynamic<'a> {
                                 ticks: ticks,
                                 value: value.into(),
                             };
-                            let add_point = super::AddPoint { point: point };
+                            let add_point = super::AddPoint { point };
                             let event = super::numeric::Event::Mutate(add_point.into());
                             Event::Numeric(event)
                         }

--- a/nannou_timeline/src/track/automation/numeric.rs
+++ b/nannou_timeline/src/track/automation/numeric.rs
@@ -328,7 +328,7 @@ where
                 ticks: clamped_ticks_from_x(click_abs_xy[0]),
                 value: clamped_value_from_y(click_abs_xy[1]),
             };
-            let add_point = super::AddPoint { point: point };
+            let add_point = super::AddPoint { point };
             events.push(Event::Mutate(add_point.into()));
         }
 

--- a/nannou_timeline/src/track/ruler.rs
+++ b/nannou_timeline/src/track/ruler.rs
@@ -117,7 +117,7 @@ impl<'a> conrod::Widget for Ruler<'a> {
                     ((x / w) * total_ticks.ticks() as conrod::Scalar) as time::calc::Ticks,
                 );
                 let ticks = std::cmp::max(std::cmp::min(ticks, total_ticks), time::Ticks(0));
-                ticks_triggered = Some(TicksTriggered { ticks: ticks });
+                ticks_triggered = Some(TicksTriggered { ticks });
             }
         }
 


### PR DESCRIPTION
The title says it all.

It was automated using [comby](https://comby.dev/) and this [pattern](https://catalog.comby.dev/#redundant-field-names-single).

As a suggestion, maybe this could be automated with GitHub Actions