### PR TITLE
Update `nannou_audio` to latest `cpal` and `dasp_sample` versions 

### DIFF
--- a/examples/audio/record_wav.rs
+++ b/examples/audio/record_wav.rs
@@ -87,21 +87,21 @@ fn view(app: &App, model: &Model, frame: Frame) {
 
 // Get specification from default device format.
 fn get_spec(audio_host: &nannou_audio::Host) -> hound::WavSpec {
-    let default_input_format = audio_host
+    let default_input_config = audio_host
         .default_input_device()
         .unwrap()
-        .default_input_format()
+        .default_input_config()
         .unwrap();
 
-    let (bits_per_sample, sample_format) = match default_input_format.data_type {
+    let (bits_per_sample, sample_format) = match default_input_config.sample_format() {
         audio::cpal::SampleFormat::I16 => (16, hound::SampleFormat::Int),
         audio::cpal::SampleFormat::U16 => (16, hound::SampleFormat::Int),
         audio::cpal::SampleFormat::F32 => (32, hound::SampleFormat::Float),
     };
 
     hound::WavSpec {
-        channels: default_input_format.channels,
-        sample_rate: default_input_format.sample_rate.0,
+        channels: default_input_config.channels(),
+        sample_rate: default_input_config.sample_rate().0,
         bits_per_sample,
         sample_format,
     }

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -7,7 +7,15 @@ back to the origins.
 
 # Unreleased
 
-*There are no unreleased changes yet.*
+### nannou_audio
+
+- Update to CPAL 0.12 and from `sample` to `dasp_sample`.
+- Add the ability to specify a device buffer size.
+- Allow fallback to device default sample rate.
+- Add builder method for specifying a stream error callback. This replaces the
+  `render_result/capture_result` functions.
+- Switch from `failure` to `thiserror` for error handling.
+- Rename `format` to `config` throughout to match cpal 0.12.
 
 ---
 

--- a/nannou_audio/Cargo.toml
+++ b/nannou_audio/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 cpal = "0.12"
-failure = "0.1"
 dasp_sample = "0.11.0"
+thiserror = "1"
 
 [features]
 asio = ["cpal/asio"]

--- a/nannou_audio/Cargo.toml
+++ b/nannou_audio/Cargo.toml
@@ -11,9 +11,9 @@ homepage = "https://nannou.cc"
 edition = "2018"
 
 [dependencies]
-cpal = "0.11"
+cpal = "0.12"
 failure = "0.1"
-sample = "0.10"
+dasp_sample = "0.11.0"
 
 [features]
 asio = ["cpal/asio"]

--- a/nannou_audio/src/device.rs
+++ b/nannou_audio/src/device.rs
@@ -1,4 +1,6 @@
-use crate::{DefaultFormatError, DeviceNameError, Format, SupportedFormatsError};
+use crate::{
+    DefaultStreamConfigError, DeviceNameError, SupportedStreamConfig, SupportedStreamConfigsError,
+};
 use cpal::traits::DeviceTrait;
 use std::ops::Deref;
 
@@ -12,11 +14,11 @@ pub struct Devices {
     pub(crate) devices: cpal::Devices,
 }
 
-/// An iterator yielding formats that are supported by the backend.
-pub type SupportedInputFormats = cpal::SupportedInputFormats;
+/// An iterator yielding configs that are supported by the backend.
+pub type SupportedInputConfigs = cpal::SupportedInputConfigs;
 
-/// An iterator yielding formats that are supported by the backend.
-pub type SupportedOutputFormats = cpal::SupportedOutputFormats;
+/// An iterator yielding configs that are supported by the backend.
+pub type SupportedOutputConfigs = cpal::SupportedOutputConfigs;
 
 impl Device {
     /// The unique name associated with this device.
@@ -27,43 +29,45 @@ impl Device {
     /// An iterator yielding formats that are supported by the backend.
     ///
     /// Can return an error if the device is no longer valid (e.g. it has been disconnected).
-    pub fn supported_input_formats(&self) -> Result<SupportedInputFormats, SupportedFormatsError> {
-        self.device.supported_input_formats()
+    pub fn supported_input_configs(
+        &self,
+    ) -> Result<SupportedInputConfigs, SupportedStreamConfigsError> {
+        self.device.supported_input_configs()
     }
 
-    /// An iterator yielding formats that are supported by the backend.
+    /// An iterator yielding configs that are supported by the backend.
     ///
     /// Can return an error if the device is no longer valid (e.g. it has been disconnected).
-    pub fn supported_output_formats(
+    pub fn supported_output_configs(
         &self,
-    ) -> Result<SupportedOutputFormats, SupportedFormatsError> {
-        self.device.supported_output_formats()
+    ) -> Result<SupportedOutputConfigs, SupportedStreamConfigsError> {
+        self.device.supported_output_configs()
     }
 
-    /// The default format used for input streams.
-    pub fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
-        self.device.default_input_format()
+    /// The default config used for input streams.
+    pub fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        self.device.default_input_config()
     }
 
-    /// The default format used for output streams.
-    pub fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
-        self.device.default_output_format()
+    /// The default config used for output streams.
+    pub fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        self.device.default_output_config()
     }
 
     /// The maximum number of output channels of any format supported by this device.
     pub fn max_supported_output_channels(&self) -> usize {
-        self.supported_output_formats()
+        self.supported_output_configs()
             .expect("failed to get supported output audio stream formats")
-            .map(|fmt| fmt.channels as usize)
+            .map(|fmt| fmt.channels() as usize)
             .max()
             .unwrap_or(0)
     }
 
     /// The maximum number of input channels of any format supported by this device.
     pub fn max_supported_input_channels(&self) -> usize {
-        self.supported_input_formats()
+        self.supported_input_configs()
             .expect("failed to get supported input audio stream formats")
-            .map(|fmt| fmt.channels as usize)
+            .map(|fmt| fmt.channels() as usize)
             .max()
             .unwrap_or(0)
     }

--- a/nannou_audio/src/lib.rs
+++ b/nannou_audio/src/lib.rs
@@ -138,7 +138,6 @@ impl Host {
     fn new_stream<M, S>(&self, model: M) -> stream::Builder<M, S> {
         let process_fn_tx = if self.process_fn_tx.lock().unwrap().is_none() {
             let (tx, rx) = mpsc::channel();
-            let mut loop_context = stream::LoopContext::new(rx);
             thread::Builder::new()
                 .name("cpal::EventLoop::run thread".into())
                 .spawn(move || event_loop.run(move |id, data| loop_context.process(id, data)))

--- a/nannou_audio/src/lib.rs
+++ b/nannou_audio/src/lib.rs
@@ -12,7 +12,7 @@
 //!   [**Requester**](./requester/struct.Requester.html) for buffering input and output streams that
 //!   may deliver buffers of inconsistent sizes into a stream of consistently sized buffers.
 
-use cpal::traits::{EventLoopTrait, HostTrait};
+use cpal::traits::{HostTrait, StreamTrait};
 use std::marker::PhantomData;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
@@ -25,12 +25,14 @@ pub use self::stream::Stream;
 pub use cpal;
 #[doc(inline)]
 pub use cpal::{
-    BackendSpecificError, BuildStreamError, DefaultFormatError, DeviceNameError, DevicesError,
-    PauseStreamError, PlayStreamError, StreamError, SupportedFormatsError,
+    BackendSpecificError, BuildStreamError, DefaultStreamConfigError, DeviceNameError,
+    DevicesError, PauseStreamError, PlayStreamError, StreamError, SupportedStreamConfigsError,
 };
 #[doc(inline)]
-pub use cpal::{Format, HostId, HostUnavailable, SupportedInputFormats, SupportedOutputFormats};
-pub use sample;
+pub use cpal::{
+    HostId, HostUnavailable, SupportedInputConfigs, SupportedOutputConfigs, SupportedStreamConfig,
+};
+pub use dasp_sample;
 
 pub mod buffer;
 pub mod device;

--- a/nannou_audio/src/receiver.rs
+++ b/nannou_audio/src/receiver.rs
@@ -1,5 +1,5 @@
 use crate::{stream, Buffer};
-use sample::Sample;
+use dasp_sample::Sample;
 use std;
 
 /// A `Receiver` for converting audio delivered by the backend at varying buffer sizes into buffers

--- a/nannou_audio/src/receiver.rs
+++ b/nannou_audio/src/receiver.rs
@@ -40,17 +40,16 @@ where
     /// - `sample_rate` is not greater than `0`.
     /// - The number of `channels` is different to that with which the receiver was initialised.
     /// - The final input buffer frame does not contain a sample for every channel.
-    pub fn read_buffer<M, FA, FB>(
+    pub fn read_buffer<M, FC>(
         &mut self,
         mut model: M,
-        capture: &stream::input::Capture<FA, FB>,
+        capture: &FC,
         input: &[S],
         channels: usize,
         sample_rate: u32,
     ) -> M
     where
-        FA: stream::input::CaptureFn<M, S>,
-        FB: stream::input::CaptureResultFn<M, S>,
+        FC: stream::input::CaptureFn<M, S>,
     {
         let Receiver {
             ref mut samples,
@@ -93,7 +92,7 @@ where
                 channels,
                 sample_rate,
             };
-            capture.capture(&mut model, Ok(&buffer));
+            capture(&mut model, &buffer);
             std::mem::swap(samples, &mut buffer.interleaved_samples.into_vec());
             samples.clear();
         }

--- a/nannou_audio/src/requester.rs
+++ b/nannou_audio/src/requester.rs
@@ -36,17 +36,16 @@ where
     ///
     /// `Panic!`s if `sample_rate` is not greater than `0` or if the output buffer's length is not
     /// a multiple of the given number of channels.
-    pub fn fill_buffer<M, FA, FB>(
+    pub fn fill_buffer<M, FR>(
         &mut self,
         mut model: M,
-        render: &stream::output::Render<FA, FB>,
+        render: &FR,
         output: &mut [S],
         channels: usize,
         sample_rate: u32,
     ) -> M
     where
-        FA: stream::output::RenderFn<M, S>,
-        FB: stream::output::RenderResultFn<M, S>,
+        FR: stream::output::RenderFn<M, S>,
     {
         let Requester {
             ref mut samples,
@@ -55,7 +54,7 @@ where
         } = *self;
 
         // Ensure that the buffer length makes sense given the number of channels.
-        assert!(output.len() % channels == 0);
+        assert_eq!(output.len() % channels, 0);
 
         // Determine the number of samples in the buffer.
         let num_samples = num_frames * channels;
@@ -129,7 +128,7 @@ where
                 channels,
                 sample_rate,
             };
-            render.render(&mut model, Ok(&mut buffer));
+            render(&mut model, &mut buffer);
             let mut new_samples = buffer.interleaved_samples.into_vec();
             std::mem::swap(samples, &mut new_samples);
 

--- a/nannou_audio/src/requester.rs
+++ b/nannou_audio/src/requester.rs
@@ -1,5 +1,5 @@
 use crate::{stream, Buffer};
-use sample::Sample;
+use dasp_sample::Sample;
 use std;
 
 /// A `sound::Requester` for converting backend audio requests into requests for buffers of a fixed
@@ -26,7 +26,7 @@ where
         assert!(num_frames > 0);
         let num_samples = num_frames + num_channels;
         Requester {
-            samples: vec![S::equilibrium(); num_samples],
+            samples: vec![S::EQUILIBRIUM; num_samples],
             num_frames: num_frames,
             pending_range: None,
         }
@@ -68,7 +68,7 @@ where
         // Fill the given buffer with silence.
         fn silence<S: Sample>(buffer: &mut [S]) {
             for sample in buffer {
-                *sample = S::equilibrium();
+                *sample = S::EQUILIBRIUM;
             }
         }
 
@@ -109,7 +109,7 @@ where
         }
 
         // Ensure that our buffer has `num_frames` `frames`.
-        samples.resize(num_samples, S::equilibrium());
+        samples.resize(num_samples, S::EQUILIBRIUM);
 
         // Loop until the given `output` is filled.
         loop {

--- a/nannou_audio/src/stream/input.rs
+++ b/nannou_audio/src/stream/input.rs
@@ -1,46 +1,31 @@
-use crate::{stream, Buffer, Device, Receiver, Stream, StreamError};
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use crate::{
+    stream::{self, DefaultErrorFn, ErrorFn},
+    Buffer, Device, Receiver, Stream,
+};
+use cpal::traits::{DeviceTrait, HostTrait};
 use dasp_sample::{FromSample, Sample, ToSample};
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
-/// The buffer if it is ready for reading, or an error if something went wrong with the stream.
-pub type Result<'a, S = f32> = std::result::Result<&'a Buffer<S>, StreamError>;
-
 /// The function that will be called when a captured `Buffer` is ready to be read.
 pub trait CaptureFn<M, S>: Fn(&mut M, &Buffer<S>) {}
-/// The function that will be called when a stream result is ready to be handled.
-pub trait CaptureResultFn<M, S>: Fn(&mut M, Result<S>) {}
 
 /// The default capture function type used when unspecified.
 pub type DefaultCaptureFn<M, S> = fn(&mut M, &Buffer<S>);
-/// The default capture function type used when unspecified.
-pub type DefaultCaptureResultFn<M, S> = fn(&mut M, Result<S>);
 
-// The default render function used when unspecified.
+// The default capture function used when unspecified.
 pub(crate) fn default_capture_fn<M, S>(_: &mut M, _: &Buffer<S>) {}
 
-/// Either a function for processing a stream result, or a function for processing the buffer
-/// directly.
-pub enum Capture<A, B> {
-    /// A function that works directly with the buffer.
-    ///
-    /// Any stream errors that occur will cause a `panic!`.
-    BufferFn(A),
-    /// A function that handles the stream result and in turn the inner buffer.
-    ResultFn(B),
-}
-
 /// A type used for building an input stream.
-pub struct Builder<M, FA, FB, S = f32> {
+pub struct Builder<M, FC, FE, S = f32> {
     pub builder: super::Builder<M, S>,
-    pub capture: Capture<FA, FB>,
+    pub capture: FC,
+    pub error: FE,
 }
 
 /// The builder when first initialised.
-pub type BuilderInit<M, S = f32> =
-    Builder<M, DefaultCaptureFn<M, S>, DefaultCaptureResultFn<M, S>, S>;
+pub type BuilderInit<M, S = f32> = Builder<M, DefaultCaptureFn<M, S>, DefaultErrorFn<M>, S>;
 
 type InputDevices = cpal::InputDevices<cpal::Devices>;
 
@@ -50,58 +35,29 @@ pub struct Devices {
 }
 
 impl<M, S, F> CaptureFn<M, S> for F where F: Fn(&mut M, &Buffer<S>) {}
-impl<M, S, F> CaptureResultFn<M, S> for F where F: Fn(&mut M, Result<S>) {}
 
-impl<A, B> Capture<A, B> {
-    pub(crate) fn capture<M, S>(&self, model: &mut M, result: Result<S>)
-    where
-        A: CaptureFn<M, S>,
-        B: CaptureResultFn<M, S>,
-    {
-        match *self {
-            Capture::BufferFn(ref f) => {
-                let buffer = match result {
-                    Ok(b) => b,
-                    Err(err) => {
-                        panic!(
-                            "An input stream error occurred: {}\nIf you wish to handle this \
-                             error within your code, consider building your input stream with \
-                             a `capture_result` function rather than a `capture` function.",
-                            err,
-                        );
-                    }
-                };
-                f(model, buffer);
-            }
-            Capture::ResultFn(ref f) => f(model, result),
-        }
-    }
-}
-
-impl<M, FA, FB, S> Builder<M, FA, FB, S> {
+impl<M, FC, FE, S> Builder<M, FC, FE, S> {
     /// Specify the capture function to use for updating the model in accordance with the captured
     /// input samples.
-    ///
-    /// If you wish to handle errors produced by the stream, you should use `capture_result`
-    /// instead and ensure your `capture` function accepts a `input::Result<S>` rather than a
-    /// `&mut Buffer<S>`.
-    ///
-    /// Please note that only one `capture` or `capture_result` function may be submitted. Only the
-    /// last function submitted will be used.
-    pub fn capture<G>(self, capture: G) -> Builder<M, G, DefaultCaptureResultFn<M, S>, S> {
-        let Builder { builder, .. } = self;
-        let capture = Capture::BufferFn(capture);
-        Builder { capture, builder }
+    pub fn capture<GC>(self, capture: GC) -> Builder<M, GC, FE, S> {
+        let Builder { builder, error, .. } = self;
+        Builder {
+            builder,
+            capture,
+            error,
+        }
     }
 
-    /// Specify a function for processing capture stream results.
-    ///
-    /// Please note that only one `capture` or `capture_result` function may be submitted. Only the
-    /// last function submitted will be used.
-    pub fn capture_result<G>(self, capture_result: G) -> Builder<M, DefaultCaptureFn<M, S>, G, S> {
-        let Builder { builder, .. } = self;
-        let capture = Capture::ResultFn(capture_result);
-        Builder { capture, builder }
+    /// Specify a function for handling stream errors.
+    pub fn error<GE>(self, error: GE) -> Builder<M, FC, GE, S> {
+        let Builder {
+            builder, capture, ..
+        } = self;
+        Builder {
+            builder,
+            capture,
+            error,
+        }
     }
 
     pub fn sample_rate(mut self, sample_rate: u32) -> Self {
@@ -121,11 +77,14 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         self
     }
 
-    // TO DO add a buffer_size function
-
     pub fn frames_per_buffer(mut self, frames_per_buffer: usize) -> Self {
         assert!(frames_per_buffer > 0);
         self.builder.frames_per_buffer = Some(frames_per_buffer);
+        self
+    }
+
+    pub fn device_buffer_size(mut self, buffer_size: cpal::BufferSize) -> Self {
+        self.builder.device_buffer_size = Some(buffer_size);
         self
     }
 
@@ -133,28 +92,24 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
     where
         S: 'static + Send + Sample + FromSample<u16> + FromSample<i16> + FromSample<f32>,
         M: 'static + Send,
-        FA: 'static + CaptureFn<M, S> + Send,
-        FB: 'static + CaptureResultFn<M, S> + Send,
+        FC: 'static + CaptureFn<M, S> + Send,
+        FE: 'static + ErrorFn<M> + Send,
     {
         let Builder {
             capture,
+            error,
             builder:
                 stream::Builder {
                     host,
-                    process_fn_tx,
                     model,
                     sample_rate,
                     channels,
                     frames_per_buffer,
+                    device_buffer_size,
                     device,
                     ..
                 },
         } = self;
-
-        let sample_rate = sample_rate
-            .map(|sr| cpal::SampleRate(sr))
-            .or(Some(cpal::SampleRate(super::DEFAULT_SAMPLE_RATE)));
-        let sample_format = super::cpal_sample_format::<S>();
 
         let device = match device {
             None => host
@@ -163,22 +118,29 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             Some(Device { device }) => device,
         };
 
-        // Find the best matching config.
-        let config = super::find_best_matching_config(
-            &device,
-            sample_format,
+        let desired = super::DesiredStreamConfig {
+            sample_format: super::cpal_sample_format::<S>(),
             channels,
-            sample_rate,
+            sample_rate: sample_rate.map(cpal::SampleRate),
+            device_buffer_size,
+        };
+
+        // Find the best matching config.
+        let matching = super::find_best_matching_config(
+            &device,
+            desired,
             device.default_input_config().ok(),
             |device| device.supported_input_configs().map(|fs| fs.collect()),
         )?
         .expect("no matching supported audio input formats for the target device");
-        let stream_id = event_loop.build_input_stream(&device, &format)?;
         let (update_tx, update_rx) = mpsc::channel();
         let model = Arc::new(Mutex::new(Some(model)));
-        let model_2 = model.clone();
-        let num_channels = config.channels() as usize;
-        let sample_rate = config.sample_rate().0;
+        let model_render = model.clone();
+        let model_error = model.clone();
+        let num_channels = matching.config.channels as usize;
+        let sample_rate = matching.config.sample_rate.0;
+        let sample_format = matching.sample_format;
+        let stream_config = matching.config.into();
 
         // A buffer for collecting model updates.
         let mut pending_updates: Vec<Box<dyn FnMut(&mut M) + 'static + Send>> = Vec::new();
@@ -195,7 +157,7 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let mut samples = vec![S::EQUILIBRIUM; frames_per_buffer * num_channels];
 
         // The function used to process a buffer of samples.
-        let proc_input = move |data: cpal::StreamDataResult| {
+        let capture_fn = move |data: &cpal::Data, _info: &cpal::InputCallbackInfo| {
             // Collect and process any pending updates.
             macro_rules! process_pending_updates {
                 () => {
@@ -204,7 +166,7 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
 
                     // If there are some updates available, take the lock and apply them.
                     if !pending_updates.is_empty() {
-                        if let Ok(mut guard) = model_2.lock() {
+                        if let Ok(mut guard) = model_render.lock() {
                             let mut model = guard.take().unwrap();
                             for mut update in pending_updates.drain(..) {
                                 update(&mut model);
@@ -217,21 +179,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
 
             process_pending_updates!();
 
-            // Retrieve the input buffer.
-            let input = match data {
-                Err(err) => {
-                    if let Ok(mut guard) = model_2.lock() {
-                        let mut m = guard.take().unwrap();
-                        capture.capture(&mut m, Err(err));
-                    }
-                    return;
-                }
-                Ok(cpal::StreamData::Input { buffer }) => buffer,
-                _ => unreachable!(),
-            };
-
             samples.clear();
-            samples.resize(input.len(), S::EQUILIBRIUM);
+            samples.resize(data.len(), S::EQUILIBRIUM);
 
             // A function to simplify reading from the unknown buffer type.
             fn fill_input<I, S>(input: &mut [I], buffer: &[S])
@@ -244,19 +193,22 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
                 }
             }
 
-            match input {
-                cpal::UnknownTypeInputBuffer::U16(buffer) => {
-                    fill_input(&mut samples, &buffer);
+            match sample_format {
+                cpal::SampleFormat::U16 => {
+                    let input = data.as_slice::<u16>().expect("expected u16 data");
+                    fill_input(&mut samples, &input);
                 }
-                cpal::UnknownTypeInputBuffer::I16(buffer) => {
-                    fill_input(&mut samples, &buffer);
+                cpal::SampleFormat::I16 => {
+                    let input = data.as_slice::<i16>().expect("expected i16 data");
+                    fill_input(&mut samples, &input);
                 }
-                cpal::UnknownTypeInputBuffer::F32(buffer) => {
-                    fill_input(&mut samples, &buffer);
+                cpal::SampleFormat::F32 => {
+                    let input = data.as_slice::<f32>().expect("expected f32 data");
+                    fill_input(&mut samples, &input);
                 }
             }
 
-            if let Ok(mut guard) = model_2.lock() {
+            if let Ok(mut guard) = model_render.lock() {
                 let mut m = guard.take().unwrap();
                 m = receiver.read_buffer(m, &capture, &samples, num_channels, sample_rate);
                 *guard = Some(m);
@@ -265,29 +217,30 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             process_pending_updates!();
         };
 
-        // Send the buffer processing function to the event loop.
-        process_fn_tx
-            .send((stream_id.clone(), Box::new(proc_input)))
-            .unwrap();
+        // Wrap the user's error function.
+        let err_fn = move |err| {
+            if let Ok(mut guard) = model_error.lock() {
+                if let Some(ref mut model) = *guard {
+                    error(model, err);
+                }
+            }
+        };
+
+        let stream =
+            device.build_input_stream_raw(&stream_config, sample_format, capture_fn, err_fn)?;
 
         let shared = Arc::new(super::Shared {
+            stream,
             model,
             is_paused: AtomicBool::new(false),
         });
 
         let stream = Stream {
             shared,
-            process_fn_tx,
             update_tx,
-            cpal_stream_config: config,
+            cpal_config: stream_config,
         };
         Ok(stream)
-    }
-}
-
-impl<M, S> Default for Capture<DefaultCaptureFn<M, S>, DefaultCaptureResultFn<M, S>> {
-    fn default() -> Self {
-        Capture::BufferFn(default_capture_fn)
     }
 }
 

--- a/nannou_audio/src/stream/input.rs
+++ b/nannou_audio/src/stream/input.rs
@@ -121,6 +121,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         self
     }
 
+    // TO DO add a buffer_size function
+
     pub fn frames_per_buffer(mut self, frames_per_buffer: usize) -> Self {
         assert!(frames_per_buffer > 0);
         self.builder.frames_per_buffer = Some(frames_per_buffer);
@@ -270,7 +272,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
 
         let shared = Arc::new(super::Shared {
             model,
-            stream_id,
             is_paused: AtomicBool::new(false),
         });
 
@@ -278,7 +279,7 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             shared,
             process_fn_tx,
             update_tx,
-            cpal_stream_config: format,
+            cpal_stream_config: config,
         };
         Ok(stream)
     }

--- a/nannou_audio/src/stream/input.rs
+++ b/nannou_audio/src/stream/input.rs
@@ -139,7 +139,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             builder:
                 stream::Builder {
                     host,
-                    event_loop,
                     process_fn_tx,
                     model,
                     sample_rate,
@@ -162,8 +161,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             Some(Device { device }) => device,
         };
 
-        // Find the best matching format.
-        let format = super::find_best_matching_format(
+        // Find the best matching config.
+        let config = super::find_best_matching_config(
             &device,
             sample_format,
             channels,
@@ -176,8 +175,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let (update_tx, update_rx) = mpsc::channel();
         let model = Arc::new(Mutex::new(Some(model)));
         let model_2 = model.clone();
-        let num_channels = format.channels as usize;
-        let sample_rate = format.sample_rate.0;
+        let num_channels = config.channels() as usize;
+        let sample_rate = config.sample_rate().0;
 
         // A buffer for collecting model updates.
         let mut pending_updates: Vec<Box<dyn FnMut(&mut M) + 'static + Send>> = Vec::new();
@@ -272,7 +271,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let shared = Arc::new(super::Shared {
             model,
             stream_id,
-            event_loop,
             is_paused: AtomicBool::new(false),
         });
 

--- a/nannou_audio/src/stream/mod.rs
+++ b/nannou_audio/src/stream/mod.rs
@@ -26,7 +26,7 @@ pub const DEFAULT_SAMPLE_RATE: u32 = 44_100;
 pub type UpdateFn<M> = dyn FnOnce(&mut M) + Send + 'static;
 
 pub(crate) type ProcessFn = dyn FnMut(cpal::StreamDataResult) + 'static + Send;
-pub(crate) type ProcessFnMsg = (cpal::StreamId, Box<ProcessFn>);
+pub(crate) type ProcessFnMsg = Box<ProcessFn>;
 
 /// A clone-able handle around an audio stream.
 pub struct Stream<M> {
@@ -267,8 +267,6 @@ fn matching_supported_configs(
         let supported_channels = supported_stream_config_range.channels() as usize;
         if supported_channels < channels {
             return None;
-        } else if supported_channels > channels {
-            supported_stream_config_range.channels = channels as u16;
         }
     }
     // Check the sample rate.
@@ -282,12 +280,12 @@ fn matching_supported_configs(
         return Some(config);
     }
 
-    // cpal::SupportedStreamConfig {
+    // let config = cpal::SupportedStreamConfig {
     //     channels: channels,
     //     sample_rate: sample_rate,
     //     buffer_size: buffer_size,
     //     sample_format: sample_format,
-    // }
+    // };
 
     Some(supported_stream_config_range.with_max_sample_rate())
 }

--- a/nannou_audio/src/stream/output.rs
+++ b/nannou_audio/src/stream/output.rs
@@ -138,7 +138,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             builder:
                 stream::Builder {
                     host,
-                    event_loop,
                     process_fn_tx,
                     model,
                     sample_rate,
@@ -161,8 +160,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             Some(Device { device }) => device,
         };
 
-        // Find the best matching format.
-        let format = super::find_best_matching_format(
+        // Find the best matching config.
+        let config = super::find_best_matching_config(
             &device,
             sample_format,
             channels,
@@ -175,8 +174,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let (update_tx, update_rx) = mpsc::channel();
         let model = Arc::new(Mutex::new(Some(model)));
         let model_2 = model.clone();
-        let num_channels = format.channels as usize;
-        let sample_rate = format.sample_rate.0;
+        let num_channels = config.channels() as usize;
+        let sample_rate = config.sample_rate().0;
 
         // A buffer for collecting model updates.
         let mut pending_updates: Vec<Box<dyn FnMut(&mut M) + 'static + Send>> = Vec::new();
@@ -248,6 +247,12 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
                 }
             }
 
+            match config.sample_format() {
+                cpal::SampleFormat::F32 => {
+
+                }
+            }
+
             // Process the given buffer.
             match output {
                 cpal::UnknownTypeOutputBuffer::U16(mut buffer) => {
@@ -272,7 +277,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let shared = Arc::new(super::Shared {
             model,
             stream_id,
-            event_loop,
             is_paused: AtomicBool::new(false),
         });
 

--- a/nannou_audio/src/stream/output.rs
+++ b/nannou_audio/src/stream/output.rs
@@ -115,6 +115,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         self
     }
 
+    // TO DO add a buffer_size function
+
     pub fn device(mut self, device: Device) -> Self {
         self.builder.device = Some(device);
         self
@@ -248,9 +250,7 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             }
 
             match config.sample_format() {
-                cpal::SampleFormat::F32 => {
-
-                }
+                cpal::SampleFormat::F32 => {}
             }
 
             // Process the given buffer.
@@ -284,7 +284,7 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             shared,
             process_fn_tx,
             update_tx,
-            cpal_format: format,
+            cpal_stream_config: config,
         };
         Ok(stream)
     }

--- a/nannou_audio/src/stream/output.rs
+++ b/nannou_audio/src/stream/output.rs
@@ -276,7 +276,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
 
         let shared = Arc::new(super::Shared {
             model,
-            stream_id,
             is_paused: AtomicBool::new(false),
         });
 

--- a/nannou_audio/src/stream/output.rs
+++ b/nannou_audio/src/stream/output.rs
@@ -1,46 +1,31 @@
-use crate::{stream, Buffer, Device, Requester, Stream, StreamError};
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use crate::{
+    stream::{self, DefaultErrorFn, ErrorFn},
+    Buffer, Device, Requester, Stream,
+};
+use cpal::traits::{DeviceTrait, HostTrait};
 use dasp_sample::{Sample, ToSample};
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
-/// The buffer if it is ready for reading, or an error if something went wrong with the stream.
-pub type Result<'a, S = f32> = std::result::Result<&'a mut Buffer<S>, StreamError>;
-
 /// The function that will be called when a `Buffer` is ready to be rendered.
 pub trait RenderFn<M, S>: Fn(&mut M, &mut Buffer<S>) {}
-/// The function that will be called when a `StreamResult` is ready to be rendered.
-pub trait RenderResultFn<M, S>: Fn(&mut M, Result<S>) {}
 
 /// The default render function type used when unspecified.
 pub type DefaultRenderFn<M, S> = fn(&mut M, &mut Buffer<S>);
-/// The default render function type used when unspecified.
-pub type DefaultRenderResultFn<M, S> = fn(&mut M, Result<S>);
 
 // The default render function used when unspecified.
 pub(crate) fn default_render_fn<M, S>(_: &mut M, _: &mut Buffer<S>) {}
 
-/// Either a function for processing a stream result, or a function for processing the buffer
-/// directly.
-pub enum Render<A, B> {
-    /// A function that works directly with the buffer.
-    ///
-    /// Any stream errors that occur will cause a `panic!`.
-    BufferFn(A),
-    /// A function that handles the stream result and in turn the inner buffer.
-    ResultFn(B),
-}
-
 /// A type used for building an output stream.
-pub struct Builder<M, FA, FB, S = f32> {
+pub struct Builder<M, FR, FE, S = f32> {
     pub builder: super::Builder<M, S>,
-    pub render: Render<FA, FB>,
+    pub render: FR,
+    pub error: FE,
 }
 
 /// The builder when first initialised.
-pub type BuilderInit<M, S = f32> =
-    Builder<M, DefaultRenderFn<M, S>, DefaultRenderResultFn<M, S>, S>;
+pub type BuilderInit<M, S = f32> = Builder<M, DefaultRenderFn<M, S>, DefaultErrorFn<M>, S>;
 
 type OutputDevices = cpal::OutputDevices<cpal::Devices>;
 
@@ -50,57 +35,28 @@ pub struct Devices {
 }
 
 impl<M, S, F> RenderFn<M, S> for F where F: Fn(&mut M, &mut Buffer<S>) {}
-impl<M, S, F> RenderResultFn<M, S> for F where F: Fn(&mut M, Result<S>) {}
 
-impl<A, B> Render<A, B> {
-    pub(crate) fn render<M, S>(&self, model: &mut M, result: Result<S>)
-    where
-        A: RenderFn<M, S>,
-        B: RenderResultFn<M, S>,
-    {
-        match *self {
-            Render::BufferFn(ref f) => {
-                let buffer = match result {
-                    Ok(b) => b,
-                    Err(err) => {
-                        panic!(
-                            "An output stream error occurred: {}\nIf you wish to handle this \
-                             error within your code, consider building your output stream with \
-                             a `render_result` function rather than a `render` function.",
-                            err,
-                        );
-                    }
-                };
-                f(model, buffer);
-            }
-            Render::ResultFn(ref f) => f(model, result),
+impl<M, FR, FE, S> Builder<M, FR, FE, S> {
+    /// Specify the render function to use for rendering the model to the buffer.
+    pub fn render<GR>(self, render: GR) -> Builder<M, GR, FE, S> {
+        let Builder { builder, error, .. } = self;
+        Builder {
+            builder,
+            render,
+            error,
         }
     }
-}
 
-impl<M, FA, FB, S> Builder<M, FA, FB, S> {
-    /// Specify the render function to use for rendering the model to the buffer.
-    ///
-    /// If you wish to handle errors produced by the stream, you should use `render_result` instead
-    /// and ensure your `render` function accepts a `output::Result<S>` rather than a `&mut
-    /// Buffer<S>`.
-    ///
-    /// Please note that only one `render` or `render_result` function may be submitted. Only the
-    /// last function submitted will be used.
-    pub fn render<G>(self, render: G) -> Builder<M, G, DefaultRenderResultFn<M, S>, S> {
-        let Builder { builder, .. } = self;
-        let render = Render::BufferFn(render);
-        Builder { render, builder }
-    }
-
-    /// Specify a function for processing render stream results.
-    ///
-    /// Please note that only one `render` or `render_result` function may be submitted. Only the
-    /// last function submitted will be used.
-    pub fn render_result<G>(self, render_result: G) -> Builder<M, DefaultRenderFn<M, S>, G, S> {
-        let Builder { builder, .. } = self;
-        let render = Render::ResultFn(render_result);
-        Builder { render, builder }
+    /// Specify a function for processing stream errors.
+    pub fn error<GE>(self, error: GE) -> Builder<M, FR, GE, S> {
+        let Builder {
+            builder, render, ..
+        } = self;
+        Builder {
+            builder,
+            render,
+            error,
+        }
     }
 
     pub fn sample_rate(mut self, sample_rate: u32) -> Self {
@@ -115,8 +71,6 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         self
     }
 
-    // TO DO add a buffer_size function
-
     pub fn device(mut self, device: Device) -> Self {
         self.builder.device = Some(device);
         self
@@ -128,32 +82,33 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         self
     }
 
+    pub fn device_buffer_size(mut self, buffer_size: cpal::BufferSize) -> Self {
+        self.builder.device_buffer_size = Some(buffer_size);
+        self
+    }
+
     pub fn build(self) -> std::result::Result<Stream<M>, super::BuildError>
     where
         S: 'static + Send + Sample + ToSample<u16> + ToSample<i16> + ToSample<f32>,
         M: 'static + Send,
-        FA: 'static + RenderFn<M, S> + Send,
-        FB: 'static + RenderResultFn<M, S> + Send,
+        FR: 'static + RenderFn<M, S> + Send,
+        FE: 'static + ErrorFn<M> + Send,
     {
         let Builder {
             render,
+            error,
             builder:
                 stream::Builder {
                     host,
-                    process_fn_tx,
                     model,
                     sample_rate,
                     channels,
                     frames_per_buffer,
+                    device_buffer_size,
                     device,
                     ..
                 },
         } = self;
-
-        let sample_rate = sample_rate
-            .map(|sr| cpal::SampleRate(sr))
-            .or(Some(cpal::SampleRate(super::DEFAULT_SAMPLE_RATE)));
-        let sample_format = super::cpal_sample_format::<S>();
 
         let device = match device {
             None => host
@@ -162,22 +117,29 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
             Some(Device { device }) => device,
         };
 
-        // Find the best matching config.
-        let config = super::find_best_matching_config(
-            &device,
-            sample_format,
+        let desired = super::DesiredStreamConfig {
+            sample_format: super::cpal_sample_format::<S>(),
             channels,
-            sample_rate,
+            sample_rate: sample_rate.map(cpal::SampleRate),
+            device_buffer_size,
+        };
+
+        // Find the best matching config.
+        let matching = super::find_best_matching_config(
+            &device,
+            desired,
             device.default_output_config().ok(),
             |device| device.supported_output_configs().map(|fs| fs.collect()),
         )?
         .expect("no matching supported audio output formats for the target device");
-        let stream_id = event_loop.build_output_stream(&device, &format)?;
         let (update_tx, update_rx) = mpsc::channel();
         let model = Arc::new(Mutex::new(Some(model)));
-        let model_2 = model.clone();
-        let num_channels = config.channels() as usize;
-        let sample_rate = config.sample_rate().0;
+        let model_render = model.clone();
+        let model_error = model.clone();
+        let num_channels = matching.config.channels as usize;
+        let sample_rate = matching.config.sample_rate.0;
+        let sample_format = matching.sample_format;
+        let stream_config = matching.config.into();
 
         // A buffer for collecting model updates.
         let mut pending_updates: Vec<Box<dyn FnMut(&mut M) + 'static + Send>> = Vec::new();
@@ -194,7 +156,8 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
         let mut samples = vec![S::EQUILIBRIUM; frames_per_buffer * num_channels];
 
         // The function used to process a buffer of samples.
-        let proc_output = move |data: cpal::StreamDataResult| {
+        // TODO: We should notify the user of `OutputCallbackInfo`.
+        let render_fn = move |data: &mut cpal::Data, _info: &cpal::OutputCallbackInfo| {
             // Collect and process any pending updates.
             macro_rules! process_pending_updates {
                 () => {
@@ -203,7 +166,7 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
 
                     // If there are some updates available, take the lock and apply them.
                     if !pending_updates.is_empty() {
-                        if let Ok(mut guard) = model_2.lock() {
+                        if let Ok(mut guard) = model_render.lock() {
                             let mut model = guard.take().unwrap();
                             for mut update in pending_updates.drain(..) {
                                 update(&mut model);
@@ -216,23 +179,10 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
 
             process_pending_updates!();
 
-            // Retrieve the output buffer.
-            let output = match data {
-                Err(err) => {
-                    if let Ok(mut guard) = model_2.lock() {
-                        let mut m = guard.take().unwrap();
-                        render.render(&mut m, Err(err));
-                    }
-                    return;
-                }
-                Ok(cpal::StreamData::Output { buffer }) => buffer,
-                _ => unreachable!(),
-            };
-
             samples.clear();
-            samples.resize(output.len(), S::EQUILIBRIUM);
+            samples.resize(data.len(), S::EQUILIBRIUM);
 
-            if let Ok(mut guard) = model_2.lock() {
+            if let Ok(mut guard) = model_render.lock() {
                 let mut m = guard.take().unwrap();
                 m = requester.fill_buffer(m, &render, &mut samples, num_channels, sample_rate);
                 *guard = Some(m);
@@ -249,49 +199,47 @@ impl<M, FA, FB, S> Builder<M, FA, FB, S> {
                 }
             }
 
-            match config.sample_format() {
-                cpal::SampleFormat::F32 => {}
-            }
-
             // Process the given buffer.
-            match output {
-                cpal::UnknownTypeOutputBuffer::U16(mut buffer) => {
-                    fill_output(&mut buffer, &samples);
+            match sample_format {
+                cpal::SampleFormat::U16 => {
+                    let output = data.as_slice_mut::<u16>().expect("expected u16 data");
+                    fill_output(output, &samples);
                 }
-                cpal::UnknownTypeOutputBuffer::I16(mut buffer) => {
-                    fill_output(&mut buffer, &samples);
+                cpal::SampleFormat::I16 => {
+                    let output = data.as_slice_mut::<i16>().expect("expected i16 data");
+                    fill_output(output, &samples);
                 }
-                cpal::UnknownTypeOutputBuffer::F32(mut buffer) => {
-                    fill_output(&mut buffer, &samples)
+                cpal::SampleFormat::F32 => {
+                    let output = data.as_slice_mut::<f32>().expect("expected f32 data");
+                    fill_output(output, &samples);
                 }
             }
-
-            process_pending_updates!();
         };
 
-        // Send the buffer processing function to the event loop.
-        process_fn_tx
-            .send((stream_id.clone(), Box::new(proc_output)))
-            .unwrap();
+        // Wrap the user's error function.
+        let err_fn = move |err| {
+            if let Ok(mut guard) = model_error.lock() {
+                if let Some(ref mut model) = *guard {
+                    error(model, err);
+                }
+            }
+        };
+
+        let stream =
+            device.build_output_stream_raw(&stream_config, sample_format, render_fn, err_fn)?;
 
         let shared = Arc::new(super::Shared {
+            stream,
             model,
             is_paused: AtomicBool::new(false),
         });
 
         let stream = Stream {
             shared,
-            process_fn_tx,
             update_tx,
-            cpal_stream_config: config,
+            cpal_config: stream_config,
         };
         Ok(stream)
-    }
-}
-
-impl<M, S> Default for Render<DefaultRenderFn<M, S>, DefaultRenderResultFn<M, S>> {
-    fn default() -> Self {
-        Render::BufferFn(default_render_fn)
     }
 }
 


### PR DESCRIPTION
Finishes off the work started by @JoshuaBatty at #662.

We still need to provide a nice way of accessing the timestamps now
provided to CPAL streams. I'll open up a following issues with more
details on what makes this tricky in `nannou_audio`.

TODO
- [x] Open issue re timestamps.
- [x] Update CHANGELOG.