### PR TITLE
Adds a new fm_synth example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 
 [dev-dependencies]
 audrey = "0.2"
+dasp = { version = "0.11", features = ["signal"] }
 futures = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 hrtf = "0.2"
@@ -29,23 +30,27 @@ time_calc = { version= "0.13", features = ["serde"] }
 walkdir = "2"
 hound = "3.4.0"
 ringbuf = "0.2.2"
+musical_keyboard = "0.6.0"
 
 # Audio
 [[example]]
+name = "feedback"
+path = "audio/feedback.rs"
+[[example]]
+name = "fm_synth"
+path = "audio/fm_synth/fm_synth.rs"
+[[example]]
 name = "hrtf-noise"
 path = "audio/hrtf-noise.rs"
+[[example]]
+name = "record_wav"
+path = "audio/record_wav.rs"
 [[example]]
 name = "simple_audio"
 path = "audio/simple_audio.rs"
 [[example]]
 name = "simple_audio_file"
 path = "audio/simple_audio_file.rs"
-[[example]]
-name = "record_wav"
-path = "audio/record_wav.rs"
-[[example]]
-name = "feedback"
-path = "audio/feedback.rs"
 
 # Communication
 [[example]]

--- a/examples/audio/fm_synth/adsr.rs
+++ b/examples/audio/fm_synth/adsr.rs
@@ -1,0 +1,212 @@
+//  Created by Nigel Redmon on 12/18/12.
+//  EarLevel Engineering: earlevel.com
+//  Copyright 2012 Nigel Redmon
+//
+//  Ported to Rust by Joshua Batty 2020
+//
+//  For a complete explanation of the ADSR envelope generator and code,
+//  read the series of articles by the author, starting here:
+//  http://www.earlevel.com/main/2013/06/01/envelope-generators/
+//
+//  License:
+//
+//  This source code is provided as is, without warranty.
+//  You may copy and distribute verbatim copies of this document.
+//  You may modify and use this source code to create binary code for your own purposes, free or commercial.
+//
+//  1.01  2016-01-02  njr   added calcCoef to SetTargetRatio functions that were in the ADSR widget but missing in this code
+//  1.02  2017-01-04  njr   in calcCoef, checked for rate 0, to support non-IEEE compliant compilers
+//  1.03  2020-04-08  njr   changed float to double; large target ratio and rate resulted in exp returning 1 in calcCoef
+
+use dasp::signal::Signal;
+use ringbuf::Consumer;
+
+#[derive(Debug, PartialEq)]
+enum EnvState {
+    Idle,
+    Attack,
+    Decay,
+    Sustain,
+    Release,
+}
+
+pub struct Adsr {
+    sample_rate: f64,
+    state: EnvState,
+    output: f64,
+    attack_rate: f64,
+    decay_rate: f64,
+    release_rate: f64,
+    attack_coef: f64,
+    decay_coef: f64,
+    release_coef: f64,
+    sustain_level: f64,
+    target_ratio_a: f64,
+    target_ratio_dr: f64,
+    attack_base: f64,
+    decay_base: f64,
+    release_base: f64,
+    on_off_cons: Consumer<bool>,
+    attack_cons: Consumer<f64>,
+    decay_cons: Consumer<f64>,
+    sustain_cons: Consumer<f64>,
+    release_cons: Consumer<f64>,
+}
+
+impl Adsr {
+    pub fn new(
+        sample_rate: f64,
+        attack_cons: Consumer<f64>,
+        decay_cons: Consumer<f64>,
+        sustain_cons: Consumer<f64>,
+        release_cons: Consumer<f64>,
+        on_off_cons: Consumer<bool>,
+    ) -> Self {
+        let mut adsr = Adsr {
+            sample_rate,
+            state: EnvState::Idle,
+            output: Default::default(),
+            attack_rate: Default::default(),
+            decay_rate: Default::default(),
+            release_rate: Default::default(),
+            attack_coef: Default::default(),
+            decay_coef: Default::default(),
+            release_coef: Default::default(),
+            sustain_level: Default::default(),
+            target_ratio_a: Default::default(),
+            target_ratio_dr: Default::default(),
+            attack_base: Default::default(),
+            decay_base: Default::default(),
+            release_base: Default::default(),
+            attack_cons,
+            decay_cons,
+            sustain_cons,
+            release_cons,
+            on_off_cons,
+        };
+
+        adsr.reset();
+        adsr.target_ratio_a(1.0);
+        adsr.target_ratio_dr(0.3);
+
+        adsr
+    }
+
+    fn calc_coef(&self, rate: f64, target_ratio: f64) -> f64 {
+        if rate <= 0.0 {
+            0.0
+        } else {
+            (-((1.0 + target_ratio) / target_ratio).ln() / rate).exp()
+        }
+    }
+
+    pub fn attack_rate(&mut self, rate: f64) {
+        self.attack_rate = rate;
+        self.attack_coef = self.calc_coef(rate, self.target_ratio_a);
+        self.attack_base = (1.0 + self.target_ratio_a) * (1.0 - self.attack_coef);
+    }
+
+    pub fn decay_rate(&mut self, rate: f64) {
+        self.decay_rate = rate;
+        self.decay_coef = self.calc_coef(rate, self.target_ratio_dr);
+        self.decay_base = (self.sustain_level - self.target_ratio_dr) * (1.0 - self.decay_coef);
+    }
+
+    pub fn release_rate(&mut self, rate: f64) {
+        self.release_rate = rate;
+        self.release_coef = self.calc_coef(rate, self.target_ratio_dr);
+        self.release_base = -self.target_ratio_dr * (1.0 - self.release_coef);
+    }
+
+    pub fn sustain_level(&mut self, level: f64) {
+        self.sustain_level = level;
+        self.decay_base = (self.sustain_level - self.target_ratio_dr) * (1.0 - self.decay_coef);
+    }
+
+    pub fn target_ratio_a(&mut self, target_ratio: f64) {
+        self.target_ratio_a = target_ratio.max(0.000000001); // -180.0 dB
+        self.attack_coef = self.calc_coef(self.attack_rate, self.target_ratio_a);
+        self.attack_base = (1.0 + self.target_ratio_a) * (1.0 - self.attack_coef);
+    }
+
+    pub fn target_ratio_dr(&mut self, target_ratio: f64) {
+        self.target_ratio_dr = target_ratio.max(0.000000001); // -180.0 dB
+        self.decay_coef = self.calc_coef(self.decay_rate, self.target_ratio_dr);
+        self.release_coef = self.calc_coef(self.release_rate, self.target_ratio_dr);
+        self.decay_base = (self.sustain_level - self.target_ratio_dr) * (1.0 - self.decay_coef);
+        self.release_base = -self.target_ratio_dr * (1.0 - self.release_coef);
+    }
+
+    #[inline]
+    pub fn process(&mut self) -> f64 {
+        if let Some(attack) = self.attack_cons.pop() {
+            self.attack_rate(attack * self.sample_rate);
+        }
+        if let Some(decay) = self.decay_cons.pop() {
+            self.decay_rate(decay * self.sample_rate);
+        }
+        if let Some(sustain) = self.sustain_cons.pop() {
+            self.sustain_level(sustain);
+        }
+        if let Some(release) = self.release_cons.pop() {
+            self.release_rate(release * self.sample_rate);
+        }
+        if let Some(gate) = self.on_off_cons.pop() {
+            if gate {
+                self.state = EnvState::Attack;
+            } else if self.state != EnvState::Idle {
+                self.state = EnvState::Release;
+            }
+        }
+
+        match self.state {
+            EnvState::Idle => {
+                self.output = 0.0;
+            }
+            EnvState::Attack => {
+                self.output = self.attack_base + self.output * self.attack_coef;
+                if self.output >= 1.0 {
+                    self.output = 1.0;
+                    self.state = EnvState::Decay;
+                }
+            }
+            EnvState::Decay => {
+                self.output = self.decay_base + self.output * self.decay_coef;
+                if self.output <= self.sustain_level {
+                    self.state = EnvState::Sustain;
+                }
+            }
+            EnvState::Sustain => {
+                self.output = self.sustain_level;
+            }
+            EnvState::Release => {
+                self.output = self.release_base + self.output * self.release_coef;
+                if self.output <= 0.0 {
+                    self.output = 0.0;
+                    self.state = EnvState::Idle;
+                }
+            }
+        }
+        self.output
+    }
+
+    pub fn _gate(&mut self, on: bool) {
+        if on {
+            self.state = EnvState::Attack;
+        } else if self.state != EnvState::Idle {
+            self.state = EnvState::Release;
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.state = EnvState::Idle;
+        self.output = 0.0;
+    }
+}
+
+impl Signal for Adsr {
+    type Frame = f64;
+    fn next(&mut self) -> Self::Frame {
+        self.process()
+    }
+}

--- a/examples/audio/fm_synth/biquad.rs
+++ b/examples/audio/fm_synth/biquad.rs
@@ -1,0 +1,247 @@
+//  Biquad code from EarLevel
+//
+//  Created by Nigel Redmon on 11/24/12
+//  EarLevel Engineering: earlevel.com
+//  Copyright 2012 Nigel Redmon
+//
+//  Ported to Rust by Joshua Batty 2020
+//
+//  For a complete explanation of the Biquad code:
+//  http://www.earlevel.com/main/2012/11/26/biquad-c-source-code/
+//
+//  License:
+//
+//  This source code is provided as is, without warranty.
+//  You may copy and distribute verbatim copies of this document.
+//  You may modify and use this source code to create binary code
+//  for your own purposes, free or commercial.
+
+use dasp::signal::Signal;
+use ringbuf::Consumer;
+
+#[derive(Debug)]
+pub enum FilterType {
+    Lowpass,
+    Highpass,
+    Bandpass,
+    Notch,
+    Peak,
+    Lowshelf,
+    Highshelf,
+}
+
+pub struct Biquad<S>
+where
+    S: Signal<Frame = f64>,
+{
+    signal: S,
+    sample_rate: f64,
+    filter_type: FilterType,
+    a0: f64,
+    a1: f64,
+    a2: f64,
+    b1: f64,
+    b2: f64,
+    fc: f64,
+    q: f64,
+    peak_gain: f64,
+    z1: f64,
+    z2: f64,
+    filter_type_cons: Consumer<FilterType>,
+    cutoff_cons: Consumer<f64>,
+    resonance_cons: Consumer<f64>,
+    peak_gain_cons: Consumer<f64>,
+}
+
+impl<S> Biquad<S>
+where
+    S: Signal<Frame = f64>,
+{
+    pub fn new(
+        signal: S,
+        sample_rate: f64,
+        filter_type_cons: Consumer<FilterType>,
+        cutoff_cons: Consumer<f64>,
+        resonance_cons: Consumer<f64>,
+        peak_gain_cons: Consumer<f64>,
+    ) -> Self {
+        let mut biquad = Biquad {
+            signal,
+            sample_rate,
+            filter_type: FilterType::Lowpass,
+            a0: 1.0,
+            a1: 0.0,
+            a2: 0.0,
+            b1: 0.0,
+            b2: 0.0,
+            fc: 0.0,
+            q: 0.707,
+            peak_gain: 0.0,
+            z1: 0.0,
+            z2: 0.0,
+            filter_type_cons,
+            cutoff_cons,
+            resonance_cons,
+            peak_gain_cons,
+        };
+        biquad.calc_biquad();
+        biquad
+    }
+
+    pub fn filter_type(&mut self, filter_type: FilterType) {
+        self.filter_type = filter_type;
+        self.calc_biquad();
+    }
+
+    pub fn resonance(&mut self, q: f64) {
+        self.q = q;
+        self.calc_biquad();
+    }
+
+    pub fn cutoff(&mut self, fc: f64) {
+        self.fc = fc / self.sample_rate;
+        self.calc_biquad();
+    }
+
+    pub fn peak_gain(&mut self, peak_gain_db: f64) {
+        self.peak_gain = peak_gain_db;
+        self.calc_biquad();
+    }
+
+    pub fn _set_biquad(&mut self, filter_type: FilterType, fc: f64, q: f64, peak_gain_db: f64) {
+        self.filter_type = filter_type;
+        self.q = q;
+        self.fc = fc;
+        self.peak_gain(peak_gain_db);
+    }
+
+    fn calc_biquad(&mut self) {
+        let v = 10.0_f64.powf(self.peak_gain.abs() / 20.0);
+        let k = std::f64::consts::PI * self.fc;
+        match self.filter_type {
+            FilterType::Lowpass => {
+                let norm = 1.0 / (1.0 + k / self.q + k * k);
+                self.a0 = k * k * norm;
+                self.a1 = 2.0 * self.a0;
+                self.a2 = self.a0;
+                self.b1 = 2.0 * (k * k - 1.0) * norm;
+                self.b2 = (1.0 - k / self.q + k * k) * norm;
+            }
+            FilterType::Highpass => {
+                let norm = 1.0 / (1.0 + k / self.q + k * k);
+                self.a0 = 1.0 * norm;
+                self.a1 = -2.0 * self.a0;
+                self.a2 = self.a0;
+                self.b1 = 2.0 * (k * k - 1.0) * norm;
+                self.b2 = (1.0 - k / self.q + k * k) * norm;
+            }
+            FilterType::Bandpass => {
+                let norm = 1.0 / (1.0 + k / self.q + k * k);
+                self.a0 = k / self.q * norm;
+                self.a1 = 0.0;
+                self.a2 = -self.a0;
+                self.b1 = 2.0 * (k * k - 1.0) * norm;
+                self.b2 = (1.0 - k / self.q + k * k) * norm;
+            }
+            FilterType::Notch => {
+                let norm = 1.0 / (1.0 + k / self.q + k * k);
+                self.a0 = (1.0 + k * k) * norm;
+                self.a1 = 2.0 * (k * k - 1.0) * norm;
+                self.a2 = self.a0;
+                self.b1 = self.a1;
+                self.b2 = (1.0 - k / self.q + k * k) * norm;
+            }
+            FilterType::Peak => {
+                if self.peak_gain >= 0.0 {
+                    // boost
+                    let norm = 1.0 / (1.0 + 1.0 / self.q * k + k * k);
+                    self.a0 = (1.0 + v / self.q * k + k * k) * norm;
+                    self.a1 = 2.0 * (k * k - 1.0) * norm;
+                    self.a2 = (1.0 - v / self.q * k + k * k) * norm;
+                    self.b1 = self.a1;
+                    self.b2 = (1.0 - 1.0 / self.q * k + k * k) * norm;
+                } else {
+                    // cut
+                    let norm = 1.0 / (1.0 + v / self.q * k + k * k);
+                    self.a0 = (1.0 + 1.0 / self.q * k + k * k) * norm;
+                    self.a1 = 2.0 * (k * k - 1.0) * norm;
+                    self.a2 = (1.0 - 1.0 / self.q * k + k * k) * norm;
+                    self.b1 = self.a1;
+                    self.b2 = (1.0 - v / self.q * k + k * k) * norm;
+                }
+            }
+            FilterType::Lowshelf => {
+                if self.peak_gain >= 0.0 {
+                    // boost
+                    let norm = 1.0 / (1.0 + 2.0_f64.sqrt() * k + k * k);
+                    self.a0 = (1.0 + (2.0_f64 * v).sqrt() * k + v * k * k) * norm;
+                    self.a1 = 2.0 * (v * k * k - 1.0) * norm;
+                    self.a2 = (1.0 - (2.0_f64 * v).sqrt() * k + v * k * k) * norm;
+                    self.b1 = 2.0 * (k * k - 1.0) * norm;
+                    self.b2 = (1.0 - 2.0_f64.sqrt() * k + k * k) * norm;
+                } else {
+                    // cut
+                    let norm = 1.0 / (1.0 + (2.0_f64 * v).sqrt() * k + v * k * k);
+                    self.a0 = (1.0 + 2.0_f64.sqrt() * k + k * k) * norm;
+                    self.a1 = 2.0 * (k * k - 1.0) * norm;
+                    self.a2 = (1.0 - 2.0_f64.sqrt() * k + k * k) * norm;
+                    self.b1 = 2.0 * (v * k * k - 1.0) * norm;
+                    self.b2 = (1.0 - (2.0_f64 * v).sqrt() * k + v * k * k) * norm;
+                }
+            }
+            FilterType::Highshelf => {
+                if self.peak_gain >= 0.0 {
+                    // boost
+                    let norm = 1.0 / (1.0 + 2.0_f64.sqrt() * k + k * k);
+                    self.a0 = (v + (2.0_f64 * v).sqrt() * k + k * k) * norm;
+                    self.a1 = 2.0 * (k * k - v) * norm;
+                    self.a2 = (v - (2.0_f64 * v).sqrt() * k + k * k) * norm;
+                    self.b1 = 2.0 * (k * k - 1.0) * norm;
+                    self.b2 = (1.0 - 2.0_f64.sqrt() * k + k * k) * norm;
+                } else {
+                    // cut
+                    let norm = 1.0 / (v + (2.0_f64 * v).sqrt() * k + k * k);
+                    self.a0 = (1.0 + 2.0_f64.sqrt() * k + k * k) * norm;
+                    self.a1 = 2.0 * (k * k - 1.0) * norm;
+                    self.a2 = (1.0 - 2.0_f64.sqrt() * k + k * k) * norm;
+                    self.b1 = 2.0 * (k * k - v) * norm;
+                    self.b2 = (v - (2.0_f64 * v).sqrt() * k + k * k) * norm;
+                }
+            }
+        }
+    }
+
+    pub fn process(&mut self) -> f64 {
+        if let Some(filter_type) = self.filter_type_cons.pop() {
+            self.filter_type(filter_type);
+        }
+        if let Some(fc) = self.cutoff_cons.pop() {
+            self.cutoff(fc);
+        }
+        if let Some(q) = self.resonance_cons.pop() {
+            self.resonance(q);
+        }
+        if let Some(gain) = self.peak_gain_cons.pop() {
+            self.peak_gain(gain);
+        }
+
+        let input: f64 = self.signal.next();
+
+        let out = input * self.a0 + self.z1;
+        self.z1 = input * self.a1 + self.z2 - self.b1 * out;
+        self.z2 = input * self.a2 - self.b2 * out;
+        out
+    }
+}
+
+impl<S> Signal for Biquad<S>
+where
+    S: Signal<Frame = f64>,
+{
+    type Frame = S::Frame;
+
+    #[inline]
+    fn next(&mut self) -> Self::Frame {
+        self.process()
+    }
+}

--- a/examples/audio/fm_synth/fm_synth.rs
+++ b/examples/audio/fm_synth/fm_synth.rs
@@ -1,0 +1,298 @@
+use nannou::prelude::*;
+use nannou::ui::prelude::*;
+use nannou_audio as audio;
+use nannou_audio::Buffer;
+
+use dasp::signal::Signal;
+use musical_keyboard as mkb;
+
+mod adsr;
+mod biquad;
+mod gui;
+mod synth;
+
+fn main() {
+    nannou::app(model).update(update).run();
+}
+
+pub struct Parameters {
+    master_frequency: f32,
+    op1: synth::Operator,
+    op2: synth::Operator,
+    filter: synth::Filter,
+    note_on_off: bool,
+    master_volume: f32,
+}
+
+struct Model {
+    stream: audio::Stream<Audio>,
+    ui: Ui,
+    ids: gui::Ids,
+    parameters: Parameters,
+    synth_control: synth::Synth,
+    musical_keyboard: mkb::MusicalKeyboard,
+}
+
+struct Audio {
+    master_volume: f32,
+    fm_synth: Box<dyn Signal<Frame = f64> + Send>,
+}
+
+fn model(app: &App) -> Model {
+    // Create a window to receive key pressed events.
+    app.new_window()
+        .size(240, 890)
+        .key_pressed(key_pressed)
+        .key_released(key_released)
+        .view(view)
+        .build()
+        .unwrap();
+
+    let op1 = synth::Operator {
+        pitch: synth::Pitch {
+            ratio: 3.5,
+            ratio_offset: 0.0,
+        },
+        env: synth::Envelope {
+            attack: 0.71,
+            decay: 0.3,
+            sustain: 1.0,
+            release: 0.8,
+        },
+        amp: 800.0,
+    };
+
+    let op2 = synth::Operator {
+        pitch: synth::Pitch {
+            ratio: 0.25,
+            ratio_offset: 0.0,
+        },
+        env: synth::Envelope {
+            attack: 0.1,
+            decay: 0.3,
+            sustain: 1.0,
+            release: 0.8,
+        },
+        amp: 0.5,
+    };
+
+    let filter = synth::Filter {
+        cutoff: 1000.0,
+        resonance: 0.707,
+        filter_type: 0,
+        peak_gain: 0.0,
+    };
+
+    let master_frequency = 100.0;
+    let master_volume = 0.8;
+    let sample_rate = 44100.0;
+    let (synth_control, synth_signal) =
+        synth::Synth::new(sample_rate, master_frequency, &op1, &op2, &filter);
+
+    let audio_model = Audio {
+        master_volume,
+        fm_synth: synth_signal,
+    };
+
+    // Initialise the audio API so we can spawn an audio stream.
+    let audio_host = audio::Host::new();
+    let stream = audio_host
+        .new_output_stream(audio_model)
+        .render(audio)
+        .build()
+        .unwrap();
+
+    let parameters = Parameters {
+        master_frequency,
+        op1,
+        op2,
+        filter,
+        note_on_off: false,
+        master_volume,
+    };
+
+    let musical_keyboard = mkb::MusicalKeyboard::default();
+
+    // Create the UI.
+    let mut ui = app.new_ui().build().unwrap();
+
+    // Generate some ids for our widgets.
+    let ids = gui::Ids::new(ui.widget_id_generator());
+
+    Model {
+        stream,
+        ui,
+        ids,
+        parameters,
+        synth_control,
+        musical_keyboard,
+    }
+}
+
+// A function that renders the given `Audio` to the given `Buffer`.
+fn audio(audio: &mut Audio, buffer: &mut Buffer) {
+    for frame in buffer.frames_mut() {
+        for channel in frame {
+            *channel = audio.fm_synth.next() as f32 * audio.master_volume;
+        }
+    }
+}
+
+fn update(_app: &App, model: &mut Model, _update: Update) {
+    // Calling `set_widgets` allows us to instantiate some widgets.
+    let ui = model.ui.set_widgets();
+
+    gui::update(
+        ui,
+        &mut model.ids,
+        &mut model.parameters,
+        &mut model.synth_control.producers,
+    );
+
+    let volume = model.parameters.master_volume.clone();
+    model
+        .stream
+        .send(move |audio| {
+            audio.master_volume = volume;
+        })
+        .unwrap();
+}
+
+fn key_pressed(_app: &App, model: &mut Model, key: Key) {
+    if let Some(k) = convert_key(key) {
+        if let Some(note) = model.musical_keyboard.key_pressed(k) {
+            let nn = convert_key_note_number(note.letter, note.octave);
+            model.parameters.master_frequency = note_to_frequency(nn);
+
+            if let Ok(_) =
+                model
+                    .synth_control
+                    .producers
+                    .mod_hz
+                    .push(crate::calculate_operator_frequency(
+                        model.parameters.master_frequency,
+                        &model.parameters.op1,
+                    ) as f64)
+            {}
+
+            if let Ok(_) =
+                model
+                    .synth_control
+                    .producers
+                    .carrier_hz
+                    .push(crate::calculate_operator_frequency(
+                        model.parameters.master_frequency,
+                        &model.parameters.op2,
+                    ) as f64)
+            {}
+
+            if !model.parameters.note_on_off {
+                if model
+                    .synth_control
+                    .producers
+                    .mod_env_on_off
+                    .push(true)
+                    .is_ok()
+                    && model
+                        .synth_control
+                        .producers
+                        .carrier_env_on_off
+                        .push(true)
+                        .is_ok()
+                {
+                    model.parameters.note_on_off = true;
+                }
+            }
+        }
+    }
+}
+
+fn key_released(_app: &App, model: &mut Model, key: Key) {
+    if let Some(k) = convert_key(key) {
+        let _off = model.musical_keyboard.key_released(k);
+        if model
+            .synth_control
+            .producers
+            .mod_env_on_off
+            .push(false)
+            .is_ok()
+            && model
+                .synth_control
+                .producers
+                .carrier_env_on_off
+                .push(false)
+                .is_ok()
+        {
+            model.parameters.note_on_off = false;
+        }
+    };
+}
+
+fn view(app: &App, model: &Model, frame: Frame) {
+    frame.clear(rgb(0.1, 0.1, 0.1));
+
+    // Draw the state of the `Ui` to the frame.
+    model.ui.draw_to_frame(app, &frame).unwrap();
+}
+
+pub fn calculate_operator_frequency(master_frequency: f32, op: &synth::Operator) -> f32 {
+    master_frequency * (op.pitch.ratio + op.pitch.ratio_offset)
+}
+
+pub fn note_to_frequency(n: i32) -> f32 {
+    const BASE_A4: f32 = 440.0; // A4 = 440Hz
+    BASE_A4 * 2.0.powf((n as f32 - 49.0) / 12.0)
+}
+
+pub fn convert_key_note_number(key: mkb::Letter, octave: i32) -> i32 {
+    let n = match key {
+        mkb::Letter::C => 1,
+        mkb::Letter::Csh => 2,
+        mkb::Letter::Db => 2,
+        mkb::Letter::D => 3,
+        mkb::Letter::Dsh => 4,
+        mkb::Letter::Eb => 4,
+        mkb::Letter::E => 5,
+        mkb::Letter::F => 6,
+        mkb::Letter::Fsh => 7,
+        mkb::Letter::Gb => 7,
+        mkb::Letter::G => 8,
+        mkb::Letter::Gsh => 9,
+        mkb::Letter::Ab => 9,
+        mkb::Letter::A => 10,
+        mkb::Letter::Ash => 11,
+        mkb::Letter::Bb => 11,
+        mkb::Letter::B => 12,
+    };
+    let offset = 3;
+    (12 * octave) + n + offset
+}
+
+pub fn convert_key(key: Key) -> Option<mkb::Key> {
+    let k = match key {
+        Key::A => mkb::Key::A,
+        Key::W => mkb::Key::W,
+        Key::S => mkb::Key::S,
+        Key::E => mkb::Key::E,
+        Key::D => mkb::Key::D,
+        Key::F => mkb::Key::F,
+        Key::T => mkb::Key::T,
+        Key::G => mkb::Key::G,
+        Key::Y => mkb::Key::Y,
+        Key::H => mkb::Key::H,
+        Key::U => mkb::Key::U,
+        Key::J => mkb::Key::J,
+        Key::K => mkb::Key::K,
+        Key::O => mkb::Key::O,
+        Key::L => mkb::Key::L,
+        Key::P => mkb::Key::P,
+        Key::Semicolon => mkb::Key::Semicolon,
+        Key::Apostrophe => mkb::Key::Quote,
+        Key::Z => mkb::Key::Z,
+        Key::X => mkb::Key::X,
+        Key::C => mkb::Key::C,
+        Key::V => mkb::Key::V,
+        _ => return None,
+    };
+    Some(k)
+}

--- a/examples/audio/fm_synth/gui.rs
+++ b/examples/audio/fm_synth/gui.rs
@@ -1,0 +1,342 @@
+use crate::biquad::FilterType;
+use nannou::ui::prelude::*;
+use std::fmt::Write;
+
+widget_ids! {
+    pub struct Ids {
+        instructions_text,
+        fm_text,
+        master_volume,
+
+        op1_text,
+        op1_ratio,
+        op1_ratio_offset,
+        op1_attack,
+        op1_decay,
+        op1_sustain,
+        op1_release,
+        op1_amp,
+
+        op2_text,
+        op2_ratio,
+        op2_ratio_offset,
+        op2_attack,
+        op2_decay,
+        op2_sustain,
+        op2_release,
+        op2_amp,
+
+        filter_text,
+        filter_type,
+        filter_cutoff,
+        filter_resonance,
+        filter_peak_gain,
+    }
+}
+
+pub fn update(
+    ref mut ui: UiCell,
+    ids: &mut Ids,
+    parameters: &mut crate::Parameters,
+    producers: &mut crate::synth::Producers,
+) {
+    fn slider(val: f32, min: f32, max: f32) -> widget::Slider<'static, f32> {
+        widget::Slider::new(val, min, max)
+            .w_h(200.0, 30.0)
+            .label_font_size(15)
+            .rgb(0.305, 0.956, 0.6)
+            .label_rgb(0.0, 0.0, 0.0)
+            .border_color(nannou::ui::color::rgb(0.635, 0.635, 0.635))
+            .border(0.0)
+    }
+
+    widget::Text::new("FM SYNTH")
+        .top_left_with_margin(20.0)
+        .color(color::WHITE)
+        .font_size(16)
+        .set(ids.fm_text, ui);
+
+    let label = format!("Master Volume: {:.2}", parameters.master_volume);
+    for value in slider(parameters.master_volume, 0.0, 1.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.master_volume, ui)
+    {
+        parameters.master_volume = value;
+    }
+
+    widget::Text::new("OP1: MODULATOR")
+        .down(20.0)
+        .color(color::WHITE)
+        .font_size(16)
+        .set(ids.op1_text, ui);
+
+    let label = format!("Ratio: {:.2}", parameters.op1.pitch.ratio);
+    for value in slider(parameters.op1.pitch.ratio, 0.0, 35.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op1_ratio, ui)
+    {
+        let idx = value.ceil() as usize;
+        parameters.op1.pitch.ratio = crate::synth::MODULATOR_RATIOS[idx];
+
+        if let Ok(_) = producers.mod_hz.push(crate::calculate_operator_frequency(
+            parameters.master_frequency,
+            &parameters.op1,
+        ) as f64)
+        {}
+    }
+
+    let label = format!("Ratio Offset: {:.2}", parameters.op1.pitch.ratio_offset);
+    for value in slider(parameters.op1.pitch.ratio_offset, -1.0, 1.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op1_ratio_offset, ui)
+    {
+        parameters.op1.pitch.ratio_offset = value;
+
+        if let Ok(_) = producers.mod_hz.push(crate::calculate_operator_frequency(
+            parameters.master_frequency,
+            &parameters.op1,
+        ) as f64)
+        {}
+    }
+
+    let label = format!("Attack: {:.2}", parameters.op1.env.attack);
+    for value in slider(parameters.op1.env.attack, 0.0, 8.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op1_attack, ui)
+    {
+        if producers.mod_attack.push(value as f64).is_ok() {
+            parameters.op1.env.attack = value;
+        }
+    }
+
+    let label = format!("Decay: {:.2}", parameters.op1.env.decay);
+    for value in slider(parameters.op1.env.decay, 0.0, 1.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op1_decay, ui)
+    {
+        if producers.mod_decay.push(value as f64).is_ok() {
+            parameters.op1.env.decay = value;
+        }
+    }
+
+    let label = format!("Sustain: {:.2}", parameters.op1.env.sustain);
+    for value in slider(parameters.op1.env.sustain, 0.0, 1.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op1_sustain, ui)
+    {
+        if producers.mod_sustain.push(value as f64).is_ok() {
+            parameters.op1.env.sustain = value;
+        }
+    }
+
+    let label = format!("Release: {:.2}", parameters.op1.env.release);
+    for value in slider(parameters.op1.env.release, 0.0, 6.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op1_release, ui)
+    {
+        if producers.mod_release.push(value as f64).is_ok() {
+            parameters.op1.env.release = value;
+        }
+    }
+
+    let label = format!("Amp: {:.2}", parameters.op1.amp);
+    for value in slider(parameters.op1.amp, 0.0, 1000.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op1_amp, ui)
+    {
+        if producers.mod_amp.push(value as f64).is_ok() {
+            parameters.op1.amp = value;
+        }
+    }
+
+    widget::Text::new("OP2: CARRIER")
+        .down(20.0)
+        .color(color::WHITE)
+        .font_size(16)
+        .set(ids.op2_text, ui);
+
+    let label = format!("Ratio: {:.2}", parameters.op2.pitch.ratio);
+    for value in slider(parameters.op2.pitch.ratio, 0.0, 18.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op2_ratio, ui)
+    {
+        let idx = value.ceil() as usize;
+        parameters.op2.pitch.ratio = crate::synth::CARRIER_RATIOS[idx];
+
+        if let Ok(_) = producers
+            .carrier_hz
+            .push(
+                crate::calculate_operator_frequency(parameters.master_frequency, &parameters.op2)
+                    as f64,
+            )
+        {}
+    }
+
+    let label = format!("Ratio Offset: {:.2}", parameters.op2.pitch.ratio_offset);
+    for value in slider(parameters.op2.pitch.ratio_offset, -1.0, 1.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op2_ratio_offset, ui)
+    {
+        parameters.op2.pitch.ratio_offset = value;
+
+        if let Ok(_) = producers
+            .carrier_hz
+            .push(
+                crate::calculate_operator_frequency(parameters.master_frequency, &parameters.op2)
+                    as f64,
+            )
+        {}
+    }
+
+    let label = format!("Attack: {:.2}", parameters.op2.env.attack);
+    for value in slider(parameters.op2.env.attack, 0.0, 2.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op2_attack, ui)
+    {
+        if producers.carrier_attack.push(value as f64).is_ok() {
+            parameters.op2.env.attack = value;
+        }
+    }
+
+    let label = format!("Decay: {:.2}", parameters.op2.env.decay);
+    for value in slider(parameters.op2.env.decay, 0.0, 2.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op2_decay, ui)
+    {
+        if producers.carrier_decay.push(value as f64).is_ok() {
+            parameters.op2.env.decay = value;
+        }
+    }
+
+    let label = format!("Sustain: {:.2}", parameters.op2.env.sustain);
+    for value in slider(parameters.op2.env.sustain, 0.0, 1.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op2_sustain, ui)
+    {
+        if producers.carrier_sustain.push(value as f64).is_ok() {
+            parameters.op2.env.sustain = value;
+        }
+    }
+
+    let label = format!("Release: {:.2}", parameters.op2.env.release);
+    for value in slider(parameters.op2.env.release, 0.0, 6.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op2_release, ui)
+    {
+        if producers.carrier_release.push(value as f64).is_ok() {
+            parameters.op2.env.release = value;
+        }
+    }
+
+    let label = format!("Amp: {:.2}", parameters.op2.amp);
+    for value in slider(parameters.op2.amp, 0.0, 1.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.op2_amp, ui)
+    {
+        if producers.carrier_amp.push(value as f64).is_ok() {
+            parameters.op2.amp = value;
+        }
+    }
+
+    widget::Text::new("FILTER")
+        .down(20.0)
+        .color(color::WHITE)
+        .font_size(16)
+        .set(ids.filter_text, ui);
+
+    let filters = vec![
+        "LOW PASS".to_string(),
+        "HIGH PASS".to_string(),
+        "BAND PASS".to_string(),
+        "NOTCH".to_string(),
+        "PEAK".to_string(),
+        "LOW SHELF".to_string(),
+        "HIGH SHELF".to_string(),
+    ];
+
+    if let Some(selected_idx) =
+        widget::DropDownList::new(&filters, Some(parameters.filter.filter_type))
+            .down(4.0)
+            .w_h(200.0, 30.0)
+            .rgb(0.305, 0.956, 0.6)
+            .label("Filter Types")
+            .label_font_size(15)
+            .set(ids.filter_type, ui)
+    {
+        parameters.filter.filter_type = selected_idx;
+        let filter_type = match selected_idx {
+            0 => FilterType::Lowpass,
+            1 => FilterType::Highpass,
+            2 => FilterType::Bandpass,
+            3 => FilterType::Notch,
+            4 => FilterType::Peak,
+            5 => FilterType::Lowshelf,
+            6 => FilterType::Highshelf,
+            _ => unreachable!(),
+        };
+
+        if producers.filter_type.push(filter_type).is_ok() {
+            parameters.filter.filter_type = selected_idx;
+        }
+    }
+
+    let label = format!("Cutoff: {:.2}", parameters.filter.cutoff);
+    for value in slider(parameters.filter.cutoff, 20.0, 1000.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.filter_cutoff, ui)
+    {
+        if producers.cutoff.push(value as f64).is_ok() {
+            parameters.filter.cutoff = value;
+        }
+    }
+
+    let label = format!("Resonance: {:.2}", parameters.filter.resonance);
+    for value in slider(parameters.filter.resonance, 0.01, 10.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.filter_resonance, ui)
+    {
+        if producers.resonance.push(value as f64).is_ok() {
+            parameters.filter.resonance = value;
+        }
+    }
+
+    let label = format!("Peak Gain: {:.2}", parameters.filter.peak_gain);
+    for value in slider(parameters.filter.peak_gain, -6.0, 6.0)
+        .down(4.0)
+        .label(&label)
+        .set(ids.filter_peak_gain, ui)
+    {
+        if producers.peak_gain.push(value as f64).is_ok() {
+            parameters.filter.peak_gain = value;
+        };
+    }
+
+    let mut instructions = String::new();
+    writeln!(&mut instructions, "Use your keyboard to trigger notes").unwrap();
+    writeln!(&mut instructions, "").unwrap();
+    writeln!(&mut instructions, "Press Z and X to change octaves").unwrap();
+
+    widget::Text::new(&instructions)
+        .font_size(12)
+        .down(20.0)
+        .color(nannou::ui::color::WHITE)
+        .left_justify()
+        .set(ids.instructions_text, ui);
+}

--- a/examples/audio/fm_synth/synth.rs
+++ b/examples/audio/fm_synth/synth.rs
@@ -1,0 +1,256 @@
+use crate::adsr::Adsr;
+use crate::biquad::{Biquad, FilterType};
+use dasp::signal::{self as signal, Signal};
+use ringbuf::{Consumer, Producer, RingBuffer};
+
+pub struct Filter {
+    pub cutoff: f32,
+    pub resonance: f32,
+    pub peak_gain: f32,
+    pub filter_type: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Envelope {
+    pub attack: f32,
+    pub decay: f32,
+    pub sustain: f32,
+    pub release: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Pitch {
+    pub ratio: f32,
+    pub ratio_offset: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Operator {
+    pub pitch: Pitch,
+    pub env: Envelope,
+    pub amp: f32,
+}
+
+pub struct Producers {
+    pub mod_amp: Producer<f64>,
+    pub carrier_amp: Producer<f64>,
+
+    pub cutoff: Producer<f64>,
+    pub resonance: Producer<f64>,
+    pub peak_gain: Producer<f64>,
+    pub filter_type: Producer<FilterType>,
+
+    pub mod_hz: Producer<f64>,
+    pub carrier_hz: Producer<f64>,
+
+    pub mod_env_on_off: Producer<bool>,
+    pub mod_attack: Producer<f64>,
+    pub mod_decay: Producer<f64>,
+    pub mod_sustain: Producer<f64>,
+    pub mod_release: Producer<f64>,
+
+    pub carrier_env_on_off: Producer<bool>,
+    pub carrier_attack: Producer<f64>,
+    pub carrier_decay: Producer<f64>,
+    pub carrier_sustain: Producer<f64>,
+    pub carrier_release: Producer<f64>,
+}
+
+pub struct Synth {
+    pub producers: Producers,
+}
+
+impl Synth {
+    pub fn new(
+        sample_rate: f64,
+        master_frequency: f32,
+        op1: &Operator,
+        op2: &Operator,
+        filter: &Filter,
+    ) -> (Self, Box<dyn Signal<Frame = f64> + Send>) {
+        let mod_env_on_off = RingBuffer::<bool>::new(1);
+        let (mod_env_on_off_producer, mod_env_on_off_cons) = mod_env_on_off.split();
+
+        let mod_attack = RingBuffer::<f64>::new(1);
+        let (mut mod_attack_producer, mod_attack_cons) = mod_attack.split();
+        mod_attack_producer.push(op1.env.attack as f64).unwrap();
+
+        let mod_decay = RingBuffer::<f64>::new(1);
+        let (mut mod_decay_producer, mod_decay_cons) = mod_decay.split();
+        mod_decay_producer.push(op1.env.decay as f64).unwrap();
+
+        let mod_sustain = RingBuffer::<f64>::new(1);
+        let (mut mod_sustain_producer, mod_sustain_cons) = mod_sustain.split();
+        mod_sustain_producer.push(op1.env.sustain as f64).unwrap();
+
+        let mod_release = RingBuffer::<f64>::new(1);
+        let (mut mod_release_producer, mod_release_cons) = mod_release.split();
+        mod_release_producer.push(op1.env.release as f64).unwrap();
+
+        let op1_frequency = crate::calculate_operator_frequency(master_frequency, &op1);
+        let mod_hz = RingBuffer::<f64>::new(1);
+        let (mut mod_hz_producer, mod_hz_cons) = mod_hz.split();
+        mod_hz_producer.push(op1_frequency as f64).unwrap();
+
+        let mod_amp = RingBuffer::<f64>::new(1);
+        let (mut mod_amp_producer, mod_amp_cons) = mod_amp.split();
+        mod_amp_producer.push(op1.amp as f64).unwrap();
+
+        let modulator_hz_signal = Param::new(op1_frequency as f64, mod_hz_cons);
+        let modulator_amp_signal = Param::new(op1.amp as f64, mod_amp_cons);
+
+        let modulator_envelope = Adsr::new(
+            sample_rate,
+            mod_attack_cons,
+            mod_decay_cons,
+            mod_sustain_cons,
+            mod_release_cons,
+            mod_env_on_off_cons,
+        );
+
+        let modulator = signal::rate(sample_rate)
+            .hz(modulator_hz_signal)
+            .sine()
+            .mul_amp(modulator_envelope)
+            .mul_amp(modulator_amp_signal);
+
+        let carrier_env_on_off = RingBuffer::<bool>::new(1);
+        let (carrier_env_on_off_producer, carrier_env_on_off_cons) = carrier_env_on_off.split();
+
+        let carrier_attack = RingBuffer::<f64>::new(1);
+        let (mut carrier_attack_producer, carrier_attack_cons) = carrier_attack.split();
+        carrier_attack_producer.push(op2.env.attack as f64).unwrap();
+
+        let carrier_decay = RingBuffer::<f64>::new(1);
+        let (mut carrier_decay_producer, carrier_decay_cons) = carrier_decay.split();
+        carrier_decay_producer.push(op2.env.decay as f64).unwrap();
+
+        let carrier_sustain = RingBuffer::<f64>::new(1);
+        let (mut carrier_sustain_producer, carrier_sustain_cons) = carrier_sustain.split();
+        carrier_sustain_producer
+            .push(op2.env.sustain as f64)
+            .unwrap();
+
+        let carrier_release = RingBuffer::<f64>::new(1);
+        let (mut carrier_release_producer, carrier_release_cons) = carrier_release.split();
+        carrier_release_producer
+            .push(op2.env.release as f64)
+            .unwrap();
+
+        let carrier_envelope = Adsr::new(
+            sample_rate,
+            carrier_attack_cons,
+            carrier_decay_cons,
+            carrier_sustain_cons,
+            carrier_release_cons,
+            carrier_env_on_off_cons,
+        );
+
+        let op2_frequency = crate::calculate_operator_frequency(master_frequency, &op2);
+        let carrier_hz = RingBuffer::<f64>::new(1);
+        let (mut carrier_hz_producer, carrier_hz_cons) = carrier_hz.split();
+        carrier_hz_producer.push(op2_frequency as f64).unwrap();
+
+        let carrier_amp = RingBuffer::<f64>::new(1);
+        let (mut carrier_amp_producer, carrier_amp_cons) = carrier_amp.split();
+        carrier_amp_producer.push(op2.amp as f64).unwrap();
+
+        let carrier_hz_signal = Param::new(op2_frequency as f64, carrier_hz_cons);
+        let carrier_amp_signal = Param::new(op2.amp as f64, carrier_amp_cons);
+
+        let final_hz_signal = carrier_hz_signal.add_amp(modulator);
+        let carrier = signal::rate(sample_rate)
+            .hz(final_hz_signal)
+            .sine()
+            .mul_amp(carrier_amp_signal)
+            .mul_amp(carrier_envelope);
+
+        let filter_type = RingBuffer::<FilterType>::new(1);
+        let (mut filter_type_producer, filter_type_cons) = filter_type.split();
+        filter_type_producer.push(FilterType::Lowpass).unwrap();
+
+        let cutoff = RingBuffer::<f64>::new(1);
+        let (mut cutoff_producer, cutoff_cons) = cutoff.split();
+        cutoff_producer.push(filter.cutoff as f64).unwrap();
+
+        let resonance = RingBuffer::<f64>::new(1);
+        let (mut resonance_producer, resonance_cons) = resonance.split();
+        resonance_producer.push(filter.resonance as f64).unwrap();
+
+        let peak_gain = RingBuffer::<f64>::new(1);
+        let (mut peak_gain_producer, peak_gain_cons) = peak_gain.split();
+        peak_gain_producer.push(filter.peak_gain as f64).unwrap();
+
+        let filter_dsp = Biquad::new(
+            carrier,
+            sample_rate,
+            filter_type_cons,
+            cutoff_cons,
+            resonance_cons,
+            peak_gain_cons,
+        );
+
+        let fm_synth_signal = Box::new(filter_dsp) as Box<dyn Signal<Frame = f64> + Send>;
+
+        let producers = Producers {
+            mod_hz: mod_hz_producer,
+            mod_amp: mod_amp_producer,
+            carrier_hz: carrier_hz_producer,
+            carrier_amp: carrier_amp_producer,
+            cutoff: cutoff_producer,
+            resonance: resonance_producer,
+            peak_gain: peak_gain_producer,
+            filter_type: filter_type_producer,
+            mod_env_on_off: mod_env_on_off_producer,
+            mod_attack: mod_attack_producer,
+            mod_decay: mod_decay_producer,
+            mod_sustain: mod_sustain_producer,
+            mod_release: mod_release_producer,
+            carrier_env_on_off: carrier_env_on_off_producer,
+            carrier_attack: carrier_attack_producer,
+            carrier_decay: carrier_decay_producer,
+            carrier_sustain: carrier_sustain_producer,
+            carrier_release: carrier_release_producer,
+        };
+
+        (Synth { producers }, fm_synth_signal)
+    }
+}
+
+struct Param<T> {
+    last: T,
+    consumer: Consumer<T>,
+}
+
+impl<T> Param<T> {
+    pub fn new(init_value: T, consumer: Consumer<T>) -> Self {
+        let last = init_value;
+        Self { consumer, last }
+    }
+}
+
+impl<T> Signal for Param<T>
+where
+    T: dasp::Frame,
+{
+    type Frame = T;
+    fn next(&mut self) -> Self::Frame {
+        match self.consumer.pop() {
+            None => self.last,
+            Some(v) => {
+                self.last = v;
+                v
+            }
+        }
+    }
+}
+
+pub const CARRIER_RATIOS: &[f32] = &[
+    0.25, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
+    15.0, 16.0,
+];
+pub const MODULATOR_RATIOS: &[f32] = &[
+    0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0, 3.25, 3.5, 3.75, 4.0, 4.25,
+    4.5, 4.75, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0, 11.0, 12.0, 13.0, 14.0,
+    15.0, 16.0,
+];


### PR DESCRIPTION
This is a very basic example of how to create a 2 operator monophonic FM Synth using nannou and the DASP crate. 

Biquad filter and ADSR code is from Nigel Redmon at earlevel.com and have been ported from C++ to Rust. 

