### PR TITLE
update Getting Started "vulkan-utils" reference for Debian Buster and other guide changes

### DIFF
--- a/guide/src/getting_started/platform-specific_setup.md
+++ b/guide/src/getting_started/platform-specific_setup.md
@@ -118,6 +118,11 @@ Ensure you have the following system packages installed:
 
   For Debian with NVIDIA graphic cards:
   ```bash
+  sudo apt-get install vulkan-tools
+  ```
+
+  Or, on older versions (pre-Buster i.e., < 10):
+  ```bash
   sudo apt-get install vulkan-utils
   ```
 

--- a/guide/src/tutorials.md
+++ b/guide/src/tutorials.md
@@ -12,12 +12,11 @@ want to add to your project!
 
 ## Rust Basics
 
-Tutorials for learning the basics of Rust with nannou.
+Tutorials for learning the basics of Rust with nannou. 
 
-- Rust variables
-- Rust conditions
-- Rust loops
-- Rust functions
+- [Rust variables](https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html)
+- [Rust control flows](https://doc.rust-lang.org/book/ch03-05-control-flow.html)
+- [Rust functions](https://doc.rust-lang.org/book/ch03-03-how-functions-work.html)
 
 ## Nannou Basics
 


### PR DESCRIPTION
Nothing huge, just came across this when setting up to use nannou on Debian Buster. The vulkan-utils package is transitional now. I'm unsure if this affects any other distros.