### PR TITLE
Fix osc version in the guide

### DIFF
--- a/guide/src/tutorials/osc/osc-introduction.md
+++ b/guide/src/tutorials/osc/osc-introduction.md
@@ -21,10 +21,10 @@ To use OSC in nannou, it is necessary to add the `nannou_osc` crate as a depende
 Open up your `Cargo.toml` file at the root of your nannou project and add the following line under the `[dependencies]` tag:
 
 ```toml
-nannou_osc = "0.1.0"
+nannou_osc = "0.15.0"
 ```
 
-The value in the quotes is the version of the OSC package. At the time of writing this, `"0.1.0"` is the latest version.
+The value in the quotes is the version of the OSC package. At the time of writing this, `"0.15.0"` is the latest version.
 
 To get the latest version of the osc library, execute `cargo search nannou_osc` on the command line and read the resulting version from there.
 


### PR DESCRIPTION
Hi, I've been following the guide and doing the tutorials. 
When I checked the latest version of nannou_osc, it was different from the one in the guide.
<img width="713" alt="スクリーンショット 2021-01-07 1 09 40" src="https://user-images.githubusercontent.com/24750002/103790815-07ffa900-5085-11eb-94f4-f1d85473c5ff.png">
