### PR TITLE
Update audrey crate to 0.3

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-audrey = "0.2"
+audrey = "0.3"
 futures = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 hrtf = "0.2"


### PR DESCRIPTION

Fixes  #699; 0.2 no longer compiles, so none of the examples under the  dir would build.