### PR TITLE
Use instant crate for WASM compatibility

### DIFF
--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -22,6 +22,7 @@ daggy = "0.6"
 find_folder = "0.3"
 futures = { version = "0.3", features = ["executor", "thread-pool"] }
 image = "0.23"
+instant = "0.1.9"
 lyon = "0.15"
 noise = "0.6"
 notosans = { version = "0.1", optional = true }

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -18,13 +18,14 @@ use crate::ui;
 use crate::wgpu;
 use crate::window::{self, Window};
 use find_folder;
+use instant::Instant;
 use std;
 use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{self, AtomicBool};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use winit;
 use winit::event_loop::ControlFlow;
 
@@ -1210,7 +1211,7 @@ fn run_loop<M, E>(
                 // Trigger some extra updates for conrod GUIs to finish "animating". The number of
                 // updates used to be configurable, but I don't think there's any use besides GUI.
                 if loop_state.updates_since_event < LoopMode::UPDATES_PER_WAIT_EVENT as usize {
-                    let ten_ms = std::time::Instant::now() + std::time::Duration::from_millis(10);
+                    let ten_ms = Instant::now() + Duration::from_millis(10);
                     ControlFlow::WaitUntil(ten_ms)
                 } else {
                     ControlFlow::Wait

--- a/nannou/src/wgpu/texture/capturer.rs
+++ b/nannou/src/wgpu/texture/capturer.rs
@@ -83,7 +83,7 @@ impl ThreadPool {
         let mut interval_us = 128;
         while self.active_futures() >= self.workers() {
             if let Some(timeout) = self.timeout {
-                let start = start.get_or_insert_with(std::time::Instant::now);
+                let start = start.get_or_insert_with(instant::Instant::now);
                 if start.elapsed() > timeout {
                     return Err(AwaitWorkerTimeout(future));
                 }
@@ -120,7 +120,7 @@ impl ThreadPool {
         let mut interval_us = 128;
         while self.active_futures() > 0 {
             if let Some(timeout) = self.timeout {
-                let start = start.get_or_insert_with(std::time::Instant::now);
+                let start = start.get_or_insert_with(instant::Instant::now);
                 if start.elapsed() > timeout {
                     return Err(AwaitWorkerTimeout(()));
                 }


### PR DESCRIPTION
Use `instant::Instant` instead of `std::time::Instant`.

`instant::Instant` is a type alias for `std::time::Instant` on non-WASM environments. On WASM environments, however, `Instant` is replaced by a browser-friendly implementation which doesn't crash when `Instant::now` is called (which would be the case with `std::time::Instant`).

Relates to #475 
