### PR TITLE
Fix warnings emitted when running draw example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-audrey = "0.2"
+audrey = "0.3"
 futures = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 hrtf = "0.2"

--- a/nannou/src/math.rs
+++ b/nannou/src/math.rs
@@ -46,7 +46,7 @@ where
 {
     macro_rules! unwrap_or_panic {
         ($result:expr, $arg:expr) => {
-            $result.unwrap_or_else(|| panic!("[map_range] failed to cast {} arg to `f64`"))
+            $result.unwrap_or_else(|| panic!("[map_range] failed to cast {} arg to `f64`", $arg))
         };
     }
 

--- a/nannou/src/wgpu/texture/image.rs
+++ b/nannou/src/wgpu/texture/image.rs
@@ -641,16 +641,16 @@ pub fn encode_load_texture_from_image(
         ImageLumaA16(img) => encode_load_texture_from_image_buffer(device, encoder, usage, img),
         ImageRgba16(img) => encode_load_texture_from_image_buffer(device, encoder, usage, img),
         ImageRgb8(_img) => {
-            let img = image.to_rgba();
+            let img = image.to_rgba8();
             encode_load_texture_from_image_buffer(device, encoder, usage, &img)
         }
         ImageBgr8(_img) => {
-            let img = image.to_bgra();
+            let img = image.to_bgra8();
             encode_load_texture_from_image_buffer(device, encoder, usage, &img)
         }
         ImageRgb16(_img) => {
             // TODO: I think we lose some quality here - e.g. 16-bit channels down to 8-bit??.
-            let img = image.to_rgba();
+            let img = image.to_rgba8();
             encode_load_texture_from_image_buffer(device, encoder, usage, &img)
         }
     }

--- a/nannou_isf/src/pipeline.rs
+++ b/nannou_isf/src/pipeline.rs
@@ -235,7 +235,7 @@ impl ImageState {
                 let (tx, rx) = mpsc::channel();
                 image_loader.threadpool.execute(move || {
                     let img_res = image::open(img_path)
-                        .map(|img| img.to_rgba())
+                        .map(|img| img.to_rgba8())
                         .map_err(|err| err.into());
                     tx.send(img_res).ok();
                 });


### PR DESCRIPTION
They confused me a bit when building for the first time (much slower) because I didn't realise they were warnings until the app window popped up, so I figured it would be worth saving someone else that confusion. :smiley: 

The bulk of them are converting deprecated `to_rgba` calls to `to_rgba8`, also adding a missing debug value to `unwrap_or_panic`.


