### PR TITLE
Update changelog for wgpu 0.6 changes

### DIFF
--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -7,6 +7,40 @@ back to the origins.
 
 # Unreleased
 
+**Update to wgpu 0.6**
+
+For the most part, these changes will affect users of the `nannou::wgpu` module,
+but not so much the users of the `draw` or `ui` APIs. *Find the relevant wgpu
+changelog entry
+[here](https://github.com/gfx-rs/wgpu/blob/master/CHANGELOG.md#v06-2020-08-17).*
+
+- `Window::current_monitor` now returns a result.
+- `wgpu::Device::create_buffer_with_data` has been removed in favour of
+  a new `wgpu::DeviceExt::create_buffer_init` trait method that takes a
+  `wgpu::BufferInitDescripor` as an argument.
+- `wgpu::BufferDescriptor` now requires specifying whether or not the buffer
+  should be mapped (accessible via CPU) upon creation.
+- The swap chain queue `submit` method now takes an iterator yielding commands
+  rather than a slice.
+- The async API for mapped reads/writes has changed.
+- `wgpu::Buffer`s can now be sliced.
+- `wgpu::PipelineLayoutDescriptor` requires specifying `push_constant_ranges`.
+- The render pass `set_vertex_buffer` method now takes a buffer slice directly,
+  rather than a range.
+- A new `wgpu::TextureViewInfo` type was added. It represents the
+  `wgpu::TextureViewDescriptor` parameters that were supplied to build a
+  `wgpu::TextureView`.
+- A top-level `wgpu::Instance` type has been introduced.
+- Load and store ops have been consolidated into a `wgpu::Operations` type.
+- `wgpu::Binding` was renamed to `wgpu::BindGroupEntry`.
+- A `RowPaddedBuffer` abstraction was added to more gracefully/safely handle
+  conversions between `wgpu::Buffer`s and `wgpu::Texture`s.
+- Updates some dependencies:
+    - `audrey` to 0.3.
+    - `winit` to 0.24.
+    - `conrod_derive` and `conrod_core` to 0.71 (`nannou_timeline` only).
+
+
 ### nannou_audio
 
 - Update to CPAL 0.13.1 and from `sample` to `dasp_sample`.

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -1109,24 +1109,17 @@ fn run_loop<M, E>(
                 if let Some(model) = model.as_ref() {
                     let swap_chain_output = swap_chain.get_current_frame();
                     if let Err(e) = swap_chain_output {
-                        if let wgpu::SwapChainError::Outdated = e {
+                        match e {
                             // Sometimes redraws get delivered before resizes on x11 for unclear reasons.
                             // It goes all the way down to the API: if you ask x11 about the window size
-                            // at this time, it'll tell you that it hasn't changed. So... just don't draw
-                            // this frame. The resize'll show up in a bit and then we can get on with our
-                            // lives.
-
+                            // at this time, it'll tell you that it hasn't changed. So... we skip
+                            // this frame. The resize will show up in a bit and then we can get on
+                            // with our lives.
                             // If you turn on debug logging this does occasionally cause some vulkan
                             // validation errors... that's not great.
-                            // TODO find a better long-term fix.
-
-                            eprintln!(
-                                "swap chain outdated, skipping frame (did you resize on x11?)"
-                            );
-                        } else {
-                            // If it's not an Outdated, it's probably a real problem.
-                            // Crash.
-                            panic!("swap chain error: {}", e);
+                            // TODO find a better long-term fix than ignoring.
+                            wgpu::SwapChainError::Outdated => {}
+                            _ => panic!("an error occurred acquiring the swapchain frame: {}", e),
                         }
                     } else if let Ok(swap_chain_output) = swap_chain_output {
                         let swap_chain_texture = &swap_chain_output.output.view;

--- a/nannou/src/wgpu/texture/image.rs
+++ b/nannou/src/wgpu/texture/image.rs
@@ -556,7 +556,7 @@ where
 /// Encode the necessary commands to load a texture array directly from a sequence of image
 /// buffers.
 ///
-/// NOTE: The returned texture will remain empty u29ntil the given `encoder` has its command buffer
+/// NOTE: The returned texture will remain empty until the given `encoder` has its command buffer
 /// submitted to the given `device`'s queue.
 ///
 /// No format or size conversions are performed - the given buffer is loaded directly into GPU


### PR DESCRIPTION
Also ensures we don't print to stderr on Outdated swapchain texture -
instead we just ignore the error.