### PR TITLE
Make nannou package compile in WASM environment

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", "web_sys_unstable_apis"]

--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -113,11 +113,17 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+        target: wasm32-unknown-unknown
     - name: Run check
       uses: actions-rs/cargo@v1
       with:
         command: check
         args: --examples --verbose
+    - name: Check nannou package builds against wasm32-unknown-unknown
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: -p nannou --features wasm-experimental --target wasm32-unknown-unknown
 
   cargo-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -31,8 +31,12 @@ toml = "0.5"
 walkdir = "2"
 wgpu_upstream = { version = "0.11", package = "wgpu" }
 winit = "0.25"
+getrandom = "0.2.3"
 
 [features]
 default = ["notosans"]
 # Enables SPIR-V support in the `wgpu` module.
 spirv = ["nannou_wgpu/spirv"]
+# Enables experimental WASM compilation for CI-use only
+wasm-experimental = ["winit/web-sys", "getrandom/js"]
+


### PR DESCRIPTION
Hi. This is a minimal example showing which changes will allow to compile the nannou module against the `wasm32-unknown-unknown` target.

Disclaimer: I am not saying that:
- Nannou Apps will run in a Browser after these changes. There are still some things to do.
- This PR should be merged. But it could! :wink:

This PR relates to #475.