### PR TITLE
Fix various resize crashes, texture memory leak

### DIFF
--- a/nannou/src/wgpu/texture/mod.rs
+++ b/nannou/src/wgpu/texture/mod.rs
@@ -202,7 +202,7 @@ impl Texture {
     /// This is useful for distinguishing between two **Texture**s or for producing a hashable
     /// representation.
     pub fn id(&self) -> TextureId {
-        TextureId(Arc::into_raw(self.handle.clone()) as usize)
+        TextureId(Arc::as_ptr(&self.handle) as usize)
     }
 
     /// Begin building a **TextureView** for this **Texture**.


### PR DESCRIPTION
Fixes #676, #690, #491, possibly #651 (only tested on Mac and Windows).

**Overview**
1. Fixes major texture memory leak. Solved by replacing `Arc::into_raw` with `Arc::as_ptr`.
2. Prevents crashes when the window is resized < 2x2:
    1. Enforces a minimum swap chain and window size.
    2. Adds additional error handling that recreates the swap chain if it gets lost or is invalid.

**Notes**
+ By default, this change disallows resizing windows below 2x2. However, any minimum size can still be chosen by the user when building the window. (It still will not crash when 0x0, due to the other fixes.)
+ In testing, determined the swap chain had to be at least 2x2 given a 4x MSAA. However, the [wgpu-rs msaa-line example](https://github.com/gfx-rs/wgpu-rs/tree/master/examples/msaa-line) allows a minimum size of 1x1. Have not investigated the discrepancy.
+ Rust 1.45+ is now required due to using `Arc::as_ptr`.