### PR TITLE
Update wgpu to 0.7, conrod to 0.72, winit to 0.24.

### DIFF
--- a/examples/draw/draw_capture_hi_res.rs
+++ b/examples/draw/draw_capture_hi_res.rs
@@ -42,9 +42,9 @@ fn model(app: &App) -> Model {
     let sample_count = window.msaa_samples();
     let texture = wgpu::TextureBuilder::new()
         .size(texture_size)
-        // Our texture will be used as the OUTPUT_ATTACHMENT for our `Draw` render pass.
+        // Our texture will be used as the RENDER_ATTACHMENT for our `Draw` render pass.
         // It will also be SAMPLED by the `TextureCapturer` and `TextureResizer`.
-        .usage(wgpu::TextureUsage::OUTPUT_ATTACHMENT | wgpu::TextureUsage::SAMPLED)
+        .usage(wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::SAMPLED)
         // Use nannou's default multisampling sample count.
         .sample_count(sample_count)
         // Use a spacious 16-bit linear sRGBA format suitable for high quality drawing.
@@ -63,13 +63,13 @@ fn model(app: &App) -> Model {
 
     // Create the texture reshaper.
     let texture_view = texture.view().build();
-    let texture_component_type = texture.component_type();
+    let texture_sample_type = texture.sample_type();
     let dst_format = Frame::TEXTURE_FORMAT;
     let texture_reshaper = wgpu::TextureReshaper::new(
         device,
         &texture_view,
         sample_count,
-        texture_component_type,
+        texture_sample_type,
         sample_count,
         dst_format,
     );

--- a/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
+++ b/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
@@ -92,9 +92,12 @@ fn model(app: &App) -> Model {
     let texture_view = texture_array.view().layer(layer).build();
 
     // Create the sampler for sampling from the source texture.
-    let sampler = wgpu::SamplerBuilder::new().build(device);
+    let sampler_desc = wgpu::SamplerBuilder::new().into_descriptor();
+    let sampler_filtering = wgpu::sampler_filtering(&sampler_desc);
+    let sampler = device.create_sampler(&sampler_desc);
 
-    let bind_group_layout = create_bind_group_layout(device, texture_view.component_type());
+    let bind_group_layout =
+        create_bind_group_layout(device, texture_view.sample_type(), sampler_filtering);
     let bind_group = create_bind_group(device, &bind_group_layout, &texture_view, &sampler);
     let pipeline_layout = create_pipeline_layout(device, &bind_group_layout);
     let render_pipeline = create_render_pipeline(
@@ -182,7 +185,7 @@ fn load_images(dir: &Path) -> (Vec<(PathBuf, RgbaImage)>, (u32, u32)) {
         let entry = entry.unwrap();
         let path = entry.path();
         let image = match image::open(&path) {
-            Ok(img) => img.into_rgba(),
+            Ok(img) => img.into_rgba8(),
             Err(err) => {
                 eprintln!("failed to open {} as an image: {}", path.display(), err);
                 continue;
@@ -198,16 +201,17 @@ fn load_images(dir: &Path) -> (Vec<(PathBuf, RgbaImage)>, (u32, u32)) {
 
 fn create_bind_group_layout(
     device: &wgpu::Device,
-    texture_component_type: wgpu::TextureComponentType,
+    texture_sample_type: wgpu::TextureSampleType,
+    sampler_filtering: bool,
 ) -> wgpu::BindGroupLayout {
     wgpu::BindGroupLayoutBuilder::new()
-        .sampled_texture(
+        .texture(
             wgpu::ShaderStage::FRAGMENT,
             false,
             wgpu::TextureViewDimension::D2,
-            texture_component_type,
+            texture_sample_type,
         )
-        .sampler(wgpu::ShaderStage::FRAGMENT)
+        .sampler(wgpu::ShaderStage::FRAGMENT, sampler_filtering)
         .build(device)
 }
 

--- a/examples/wgpu/wgpu_instancing/wgpu_instancing.rs
+++ b/examples/wgpu/wgpu_instancing/wgpu_instancing.rs
@@ -348,7 +348,7 @@ fn view(app: &App, model: &Model, frame: Frame) {
     render_pass.set_vertex_buffer(0, g.vertex_buffer.slice(..));
     render_pass.set_vertex_buffer(1, g.normal_buffer.slice(..));
     render_pass.set_vertex_buffer(2, instance_buffer.slice(..));
-    render_pass.set_index_buffer(g.index_buffer.slice(..));
+    render_pass.set_index_buffer(g.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
     let index_range = 0..data::INDICES.len() as u32;
     let start_vertex = 0;
     let instance_range = 0..instances.len() as u32;
@@ -383,7 +383,7 @@ fn create_depth_texture(
     wgpu::TextureBuilder::new()
         .size(size)
         .format(depth_format)
-        .usage(wgpu::TextureUsage::OUTPUT_ATTACHMENT)
+        .usage(wgpu::TextureUsage::RENDER_ATTACHMENT)
         .sample_count(sample_count)
         .build(device)
 }
@@ -428,40 +428,39 @@ fn create_render_pipeline(
     wgpu::RenderPipelineBuilder::from_layout(layout, vs_mod)
         .fragment_shader(&fs_mod)
         .color_format(dst_format)
-        .color_blend(wgpu::BlendDescriptor::REPLACE)
-        .alpha_blend(wgpu::BlendDescriptor::REPLACE)
+        .color_blend(wgpu::BlendState::REPLACE)
+        .alpha_blend(wgpu::BlendState::REPLACE)
         .add_vertex_buffer::<Vertex>(&wgpu::vertex_attr_array![0 => Float3])
         .add_vertex_buffer::<Normal>(&wgpu::vertex_attr_array![1 => Float3])
         // TODO: this can use the macro again when https://github.com/gfx-rs/wgpu/issues/836 is fixed
         .add_instance_buffer::<Instance>(&[
-            wgpu::VertexAttributeDescriptor {
+            wgpu::VertexAttribute {
                 shader_location: 2,
                 format: wgpu::VertexFormat::Float4,
                 offset: std::mem::size_of::<[f32; 4]>() as u64 * 0,
             },
-            wgpu::VertexAttributeDescriptor {
+            wgpu::VertexAttribute {
                 shader_location: 3,
                 format: wgpu::VertexFormat::Float4,
                 offset: std::mem::size_of::<[f32; 4]>() as u64 * 1,
             },
-            wgpu::VertexAttributeDescriptor {
+            wgpu::VertexAttribute {
                 shader_location: 4,
                 format: wgpu::VertexFormat::Float4,
                 offset: std::mem::size_of::<[f32; 4]>() as u64 * 2,
             },
-            wgpu::VertexAttributeDescriptor {
+            wgpu::VertexAttribute {
                 shader_location: 5,
                 format: wgpu::VertexFormat::Float4,
                 offset: std::mem::size_of::<[f32; 4]>() as u64 * 3,
             },
-            wgpu::VertexAttributeDescriptor {
+            wgpu::VertexAttribute {
                 shader_location: 6,
                 format: wgpu::VertexFormat::Float4,
                 offset: std::mem::size_of::<[f32; 4]>() as u64 * 4,
             },
         ])
         .depth_format(depth_format)
-        .index_format(wgpu::IndexFormat::Uint16)
         .sample_count(sample_count)
         .build(device)
 }

--- a/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
+++ b/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
@@ -161,7 +161,7 @@ fn view(app: &App, model: &Model, frame: Frame) {
     render_pass.set_pipeline(&g.render_pipeline);
     render_pass.set_vertex_buffer(0, g.vertex_buffer.slice(..));
     render_pass.set_vertex_buffer(1, g.normal_buffer.slice(..));
-    render_pass.set_index_buffer(g.index_buffer.slice(..));
+    render_pass.set_index_buffer(g.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
     let index_range = 0..data::INDICES.len() as u32;
     let start_vertex = 0;
     let instance_range = 0..1;
@@ -194,7 +194,7 @@ fn create_depth_texture(
     wgpu::TextureBuilder::new()
         .size(size)
         .format(depth_format)
-        .usage(wgpu::TextureUsage::OUTPUT_ATTACHMENT)
+        .usage(wgpu::TextureUsage::RENDER_ATTACHMENT)
         .sample_count(sample_count)
         .build(device)
 }
@@ -239,12 +239,11 @@ fn create_render_pipeline(
     wgpu::RenderPipelineBuilder::from_layout(layout, vs_mod)
         .fragment_shader(&fs_mod)
         .color_format(dst_format)
-        .color_blend(wgpu::BlendDescriptor::REPLACE)
-        .alpha_blend(wgpu::BlendDescriptor::REPLACE)
+        .color_blend(wgpu::BlendState::REPLACE)
+        .alpha_blend(wgpu::BlendState::REPLACE)
         .add_vertex_buffer::<Vertex>(&wgpu::vertex_attr_array![0 => Float3])
         .add_vertex_buffer::<Normal>(&wgpu::vertex_attr_array![1 => Float3])
         .depth_format(depth_format)
-        .index_format(wgpu::IndexFormat::Uint16)
         .sample_count(sample_count)
         .build(device)
 }

--- a/examples/wgpu/wgpu_teapot_camera/wgpu_teapot_camera.rs
+++ b/examples/wgpu/wgpu_teapot_camera/wgpu_teapot_camera.rs
@@ -295,7 +295,7 @@ fn view(_app: &App, model: &Model, frame: Frame) {
     render_pass.set_pipeline(&g.render_pipeline);
     render_pass.set_vertex_buffer(0, g.vertex_buffer.slice(..));
     render_pass.set_vertex_buffer(1, g.normal_buffer.slice(..));
-    render_pass.set_index_buffer(g.index_buffer.slice(..));
+    render_pass.set_index_buffer(g.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
     let index_range = 0..data::INDICES.len() as u32;
     let start_vertex = 0;
     let instance_range = 0..1;
@@ -323,7 +323,7 @@ fn create_depth_texture(
     wgpu::TextureBuilder::new()
         .size(size)
         .format(depth_format)
-        .usage(wgpu::TextureUsage::OUTPUT_ATTACHMENT)
+        .usage(wgpu::TextureUsage::RENDER_ATTACHMENT)
         .sample_count(sample_count)
         .build(device)
 }
@@ -368,12 +368,11 @@ fn create_render_pipeline(
     wgpu::RenderPipelineBuilder::from_layout(layout, vs_mod)
         .fragment_shader(&fs_mod)
         .color_format(dst_format)
-        .color_blend(wgpu::BlendDescriptor::REPLACE)
-        .alpha_blend(wgpu::BlendDescriptor::REPLACE)
+        .color_blend(wgpu::BlendState::REPLACE)
+        .alpha_blend(wgpu::BlendState::REPLACE)
         .add_vertex_buffer::<Vertex>(&wgpu::vertex_attr_array![0 => Float3])
         .add_vertex_buffer::<Normal>(&wgpu::vertex_attr_array![1 => Float3])
         .depth_format(depth_format)
-        .index_format(wgpu::IndexFormat::Uint16)
         .sample_count(sample_count)
         .build(device)
 }

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -15,9 +15,9 @@ default = ["notosans"]
 
 [dependencies]
 cgmath = { version = "0.17", features = ["serde"] }
-conrod_core = "0.71"
-conrod_wgpu = "0.71"
-conrod_winit = "0.71"
+conrod_core = "0.72"
+conrod_wgpu = "0.72"
+conrod_winit = "0.72"
 daggy = "0.6"
 find_folder = "0.3"
 futures = { version = "0.3", features = ["executor", "thread-pool"] }
@@ -36,5 +36,5 @@ serde_derive = "1"
 serde_json = "1"
 toml = "0.5"
 walkdir = "2"
-wgpu_upstream = { version = "0.6.2", package = "wgpu" }
+wgpu_upstream = { version = "0.7.1", package = "wgpu" }
 winit = "0.24"

--- a/nannou/src/draw/mod.rs
+++ b/nannou/src/draw/mod.rs
@@ -60,13 +60,15 @@ where
     context: Context<S>,
 }
 
-/// The current **Transform**, alpha **BlendDescriptor** and **Scissor** of a **Draw** instance.
+/// The current **Transform**, alpha **BlendState** and **Scissor** of a **Draw** instance.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Context<S = geom::scalar::Default> {
     pub transform: Matrix4<S>,
-    pub alpha_blend: wgpu::BlendDescriptor,
-    pub color_blend: wgpu::BlendDescriptor,
+    pub alpha_blend: wgpu::BlendState,
+    pub color_blend: wgpu::BlendState,
     pub scissor: Scissor<S>,
+    // TODO: Consider changing `PolygonMode` (added as of wgpu 0.7) rather than `PrimitiveTopology`
+    // here.
     pub topology: wgpu::PrimitiveTopology,
     pub sampler: wgpu::SamplerDescriptor<'static>,
 }
@@ -401,21 +403,21 @@ where
     }
 
     /// Produce a new **Draw** instance that will draw with the given alpha blend descriptor.
-    pub fn alpha_blend(&self, blend_descriptor: wgpu::BlendDescriptor) -> Self {
+    pub fn alpha_blend(&self, blend_descriptor: wgpu::BlendState) -> Self {
         let mut context = self.context.clone();
         context.alpha_blend = blend_descriptor;
         self.context(context)
     }
 
     /// Produce a new **Draw** instance that will draw with the given color blend descriptor.
-    pub fn color_blend(&self, blend_descriptor: wgpu::BlendDescriptor) -> Self {
+    pub fn color_blend(&self, blend_descriptor: wgpu::BlendState) -> Self {
         let mut context = self.context.clone();
         context.color_blend = blend_descriptor;
         self.context(context)
     }
 
     /// Short-hand for `color_blend`, the common use-case.
-    pub fn blend(&self, blend_descriptor: wgpu::BlendDescriptor) -> Self {
+    pub fn blend(&self, blend_descriptor: wgpu::BlendState) -> Self {
         self.color_blend(blend_descriptor)
     }
 

--- a/nannou/src/frame/mod.rs
+++ b/nannou/src/frame/mod.rs
@@ -301,7 +301,7 @@ impl RenderData {
             device,
             &intermediary_lin_srgba.texture_view,
             src_sample_count,
-            intermediary_lin_srgba.texture_view.component_type(),
+            intermediary_lin_srgba.texture_view.sample_type(),
             swap_chain_sample_count,
             swap_chain_format,
         );
@@ -330,7 +330,7 @@ fn create_lin_srgba_msaa_texture(
     wgpu::TextureBuilder::new()
         .size(swap_chain_dims)
         .sample_count(msaa_samples)
-        .usage(wgpu::TextureUsage::OUTPUT_ATTACHMENT)
+        .usage(wgpu::TextureUsage::RENDER_ATTACHMENT)
         .format(Frame::TEXTURE_FORMAT)
         .build(device)
 }
@@ -339,7 +339,7 @@ fn create_lin_srgba_texture(device: &wgpu::Device, swap_chain_dims: [u32; 2]) ->
     wgpu::TextureBuilder::new()
         .size(swap_chain_dims)
         .format(Frame::TEXTURE_FORMAT)
-        .usage(wgpu::TextureUsage::OUTPUT_ATTACHMENT | wgpu::TextureUsage::SAMPLED)
+        .usage(wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::SAMPLED)
         .build(device)
 }
 

--- a/nannou/src/ui.rs
+++ b/nannou/src/ui.rs
@@ -489,6 +489,7 @@ pub fn encode_render_pass(
 
     // Begin the render pass and add the draw commands.
     let render_pass_desc = wgpu::RenderPassDescriptor {
+        label: Some("nannou_ui_render_pass_descriptor"),
         color_attachments: &[color_attachment_desc],
         depth_stencil_attachment: None,
     };

--- a/nannou/src/wgpu/blend.rs
+++ b/nannou/src/wgpu/blend.rs
@@ -2,37 +2,37 @@
 
 use crate::wgpu;
 
-pub const NORMAL: wgpu::BlendDescriptor = wgpu::BlendDescriptor {
+pub const NORMAL: wgpu::BlendState = wgpu::BlendState {
     src_factor: wgpu::BlendFactor::SrcAlpha,
     dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
     operation: wgpu::BlendOperation::Add,
 };
 
-pub const ADD: wgpu::BlendDescriptor = wgpu::BlendDescriptor {
+pub const ADD: wgpu::BlendState = wgpu::BlendState {
     src_factor: wgpu::BlendFactor::SrcColor,
     dst_factor: wgpu::BlendFactor::DstColor,
     operation: wgpu::BlendOperation::Add,
 };
 
-pub const SUBTRACT: wgpu::BlendDescriptor = wgpu::BlendDescriptor {
+pub const SUBTRACT: wgpu::BlendState = wgpu::BlendState {
     src_factor: wgpu::BlendFactor::SrcColor,
     dst_factor: wgpu::BlendFactor::DstColor,
     operation: wgpu::BlendOperation::Subtract,
 };
 
-pub const REVERSE_SUBTRACT: wgpu::BlendDescriptor = wgpu::BlendDescriptor {
+pub const REVERSE_SUBTRACT: wgpu::BlendState = wgpu::BlendState {
     src_factor: wgpu::BlendFactor::SrcColor,
     dst_factor: wgpu::BlendFactor::DstColor,
     operation: wgpu::BlendOperation::ReverseSubtract,
 };
 
-pub const DARKEST: wgpu::BlendDescriptor = wgpu::BlendDescriptor {
+pub const DARKEST: wgpu::BlendState = wgpu::BlendState {
     src_factor: wgpu::BlendFactor::SrcColor,
     dst_factor: wgpu::BlendFactor::DstColor,
     operation: wgpu::BlendOperation::Min,
 };
 
-pub const LIGHTEST: wgpu::BlendDescriptor = wgpu::BlendDescriptor {
+pub const LIGHTEST: wgpu::BlendState = wgpu::BlendState {
     src_factor: wgpu::BlendFactor::SrcColor,
     dst_factor: wgpu::BlendFactor::DstColor,
     operation: wgpu::BlendOperation::Max,

--- a/nannou/src/wgpu/render_pass.rs
+++ b/nannou/src/wgpu/render_pass.rs
@@ -210,6 +210,7 @@ impl<'a> Builder<'a> {
     pub fn begin(self, encoder: &'a mut wgpu::CommandEncoder) -> wgpu::RenderPass<'a> {
         let (color_attachments, depth_stencil_attachment) = self.into_inner();
         let descriptor = wgpu::RenderPassDescriptor {
+            label: Some("nannou_render_pass"),
             color_attachments: &color_attachments,
             depth_stencil_attachment,
         };

--- a/nannou/src/wgpu/render_pipeline_builder.rs
+++ b/nannou/src/wgpu/render_pipeline_builder.rs
@@ -28,56 +28,46 @@ pub struct RenderPipelineBuilder<'a> {
     fs_mod: Option<&'a wgpu::ShaderModule>,
     vs_entry_point: &'a str,
     fs_entry_point: &'a str,
-    rasterization_state: Option<wgpu::RasterizationStateDescriptor>,
-    primitive_topology: wgpu::PrimitiveTopology,
-    color_state: Option<wgpu::ColorStateDescriptor>,
-    color_states: &'a [wgpu::ColorStateDescriptor],
-    depth_stencil_state: Option<wgpu::DepthStencilStateDescriptor>,
-    index_format: wgpu::IndexFormat,
-    vertex_buffers: Vec<wgpu::VertexBufferDescriptor<'static>>,
-    sample_count: u32,
-    sample_mask: u32,
-    alpha_to_coverage_enabled: bool,
+    primitive: wgpu::PrimitiveState,
+    color_state: Option<wgpu::ColorTargetState>,
+    color_states: &'a [wgpu::ColorTargetState],
+    depth_stencil: Option<wgpu::DepthStencilState>,
+    vertex_buffers: Vec<wgpu::VertexBufferLayout<'static>>,
+    multisample: wgpu::MultisampleState,
 }
 
 impl<'a> RenderPipelineBuilder<'a> {
     // The default entry point used for shaders when unspecified.
     pub const DEFAULT_SHADER_ENTRY_POINT: &'static str = "main";
 
-    // Rasterization state defaults for the case where the user has submitted a fragment shader.
+    // Primitive state.
     pub const DEFAULT_FRONT_FACE: wgpu::FrontFace = wgpu::FrontFace::Ccw;
     pub const DEFAULT_CULL_MODE: wgpu::CullMode = wgpu::CullMode::None;
-    pub const DEFAULT_DEPTH_BIAS: i32 = 0;
-    pub const DEFAULT_DEPTH_BIAS_SLOPE_SCALE: f32 = 0.0;
-    pub const DEFAULT_DEPTH_BIAS_CLAMP: f32 = 0.0;
-    pub const DEFAULT_RASTERIZATION_STATE: wgpu::RasterizationStateDescriptor =
-        wgpu::RasterizationStateDescriptor {
-            front_face: Self::DEFAULT_FRONT_FACE,
-            cull_mode: Self::DEFAULT_CULL_MODE,
-            depth_bias: Self::DEFAULT_DEPTH_BIAS,
-            depth_bias_slope_scale: Self::DEFAULT_DEPTH_BIAS_SLOPE_SCALE,
-            depth_bias_clamp: Self::DEFAULT_DEPTH_BIAS_CLAMP,
-            clamp_depth: false,
-        };
-
-    // Primitive topology.
+    pub const DEFAULT_POLYGON_MODE: wgpu::PolygonMode = wgpu::PolygonMode::Fill;
     pub const DEFAULT_PRIMITIVE_TOPOLOGY: wgpu::PrimitiveTopology =
         wgpu::PrimitiveTopology::TriangleList;
+    pub const DEFAULT_PRIMITIVE: wgpu::PrimitiveState = wgpu::PrimitiveState {
+        topology: Self::DEFAULT_PRIMITIVE_TOPOLOGY,
+        strip_index_format: None,
+        front_face: Self::DEFAULT_FRONT_FACE,
+        cull_mode: Self::DEFAULT_CULL_MODE,
+        polygon_mode: Self::DEFAULT_POLYGON_MODE,
+    };
 
     // Color state defaults.
     pub const DEFAULT_COLOR_FORMAT: wgpu::TextureFormat = crate::frame::Frame::TEXTURE_FORMAT;
-    pub const DEFAULT_COLOR_BLEND: wgpu::BlendDescriptor = wgpu::BlendDescriptor {
+    pub const DEFAULT_COLOR_BLEND: wgpu::BlendState = wgpu::BlendState {
         src_factor: wgpu::BlendFactor::SrcAlpha,
         dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
         operation: wgpu::BlendOperation::Add,
     };
-    pub const DEFAULT_ALPHA_BLEND: wgpu::BlendDescriptor = wgpu::BlendDescriptor {
+    pub const DEFAULT_ALPHA_BLEND: wgpu::BlendState = wgpu::BlendState {
         src_factor: wgpu::BlendFactor::One,
         dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
         operation: wgpu::BlendOperation::Add,
     };
     pub const DEFAULT_COLOR_WRITE: wgpu::ColorWrite = wgpu::ColorWrite::ALL;
-    pub const DEFAULT_COLOR_STATE: wgpu::ColorStateDescriptor = wgpu::ColorStateDescriptor {
+    pub const DEFAULT_COLOR_STATE: wgpu::ColorTargetState = wgpu::ColorTargetState {
         format: Self::DEFAULT_COLOR_FORMAT,
         color_blend: Self::DEFAULT_COLOR_BLEND,
         alpha_blend: Self::DEFAULT_ALPHA_BLEND,
@@ -88,32 +78,43 @@ impl<'a> RenderPipelineBuilder<'a> {
     pub const DEFAULT_DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
     pub const DEFAULT_DEPTH_WRITE_ENABLED: bool = true;
     pub const DEFAULT_DEPTH_COMPARE: wgpu::CompareFunction = wgpu::CompareFunction::LessEqual;
-    pub const DEFAULT_STENCIL_FRONT: wgpu::StencilStateFaceDescriptor =
-        wgpu::StencilStateFaceDescriptor::IGNORE;
-    pub const DEFAULT_STENCIL_BACK: wgpu::StencilStateFaceDescriptor =
-        wgpu::StencilStateFaceDescriptor::IGNORE;
+    pub const DEFAULT_STENCIL_FRONT: wgpu::StencilFaceState = wgpu::StencilFaceState::IGNORE;
+    pub const DEFAULT_STENCIL_BACK: wgpu::StencilFaceState = wgpu::StencilFaceState::IGNORE;
     pub const DEFAULT_STENCIL_READ_MASK: u32 = 0;
     pub const DEFAULT_STENCIL_WRITE_MASK: u32 = 0;
-    pub const DEFAULT_STENCIL: wgpu::StencilStateDescriptor = wgpu::StencilStateDescriptor {
+    pub const DEFAULT_STENCIL: wgpu::StencilState = wgpu::StencilState {
         front: Self::DEFAULT_STENCIL_FRONT,
         back: Self::DEFAULT_STENCIL_BACK,
         read_mask: Self::DEFAULT_STENCIL_READ_MASK,
         write_mask: Self::DEFAULT_STENCIL_WRITE_MASK,
     };
-    pub const DEFAULT_DEPTH_STENCIL_STATE: wgpu::DepthStencilStateDescriptor =
-        wgpu::DepthStencilStateDescriptor {
-            format: Self::DEFAULT_DEPTH_FORMAT,
-            depth_write_enabled: Self::DEFAULT_DEPTH_WRITE_ENABLED,
-            depth_compare: Self::DEFAULT_DEPTH_COMPARE,
-            stencil: Self::DEFAULT_STENCIL,
-        };
+    pub const DEFAULT_DEPTH_BIAS_CONSTANT: i32 = 0;
+    pub const DEFAULT_DEPTH_BIAS_SLOPE_SCALE: f32 = 0.0;
+    pub const DEFAULT_DEPTH_BIAS_CLAMP: f32 = 0.0;
+    pub const DEFAULT_DEPTH_BIAS: wgpu::DepthBiasState = wgpu::DepthBiasState {
+        constant: Self::DEFAULT_DEPTH_BIAS_CONSTANT,
+        slope_scale: Self::DEFAULT_DEPTH_BIAS_SLOPE_SCALE,
+        clamp: Self::DEFAULT_DEPTH_BIAS_CLAMP,
+    };
+    pub const DEFAULT_CLAMP_DEPTH: bool = false;
+    pub const DEFAULT_DEPTH_STENCIL: wgpu::DepthStencilState = wgpu::DepthStencilState {
+        format: Self::DEFAULT_DEPTH_FORMAT,
+        depth_write_enabled: Self::DEFAULT_DEPTH_WRITE_ENABLED,
+        depth_compare: Self::DEFAULT_DEPTH_COMPARE,
+        stencil: Self::DEFAULT_STENCIL,
+        bias: Self::DEFAULT_DEPTH_BIAS,
+        clamp_depth: Self::DEFAULT_CLAMP_DEPTH,
+    };
 
-    // Vertex buffer defaults.
-    pub const DEFAULT_INDEX_FORMAT: wgpu::IndexFormat = wgpu::IndexFormat::Uint32;
-    // No MSAA by default.
+    // Multisample state.
     pub const DEFAULT_SAMPLE_COUNT: u32 = 1;
-    pub const DEFAULT_SAMPLE_MASK: u32 = !0;
+    pub const DEFAULT_SAMPLE_MASK: u64 = !0;
     pub const DEFAULT_ALPHA_TO_COVERAGE_ENABLED: bool = false;
+    pub const DEFAULT_MULTISAMPLE: wgpu::MultisampleState = wgpu::MultisampleState {
+        count: Self::DEFAULT_SAMPLE_COUNT,
+        mask: Self::DEFAULT_SAMPLE_MASK,
+        alpha_to_coverage_enabled: Self::DEFAULT_ALPHA_TO_COVERAGE_ENABLED,
+    };
 
     // Constructors
 
@@ -143,92 +144,76 @@ impl<'a> RenderPipelineBuilder<'a> {
             fs_mod: None,
             vs_entry_point: Self::DEFAULT_SHADER_ENTRY_POINT,
             fs_entry_point: Self::DEFAULT_SHADER_ENTRY_POINT,
-            rasterization_state: None,
             color_state: None,
             color_states: &[],
-            primitive_topology: Self::DEFAULT_PRIMITIVE_TOPOLOGY,
-            depth_stencil_state: None,
-            index_format: Self::DEFAULT_INDEX_FORMAT,
+            primitive: Self::DEFAULT_PRIMITIVE,
+            depth_stencil: None,
             vertex_buffers: vec![],
-            sample_count: Self::DEFAULT_SAMPLE_COUNT,
-            sample_mask: Self::DEFAULT_SAMPLE_MASK,
-            alpha_to_coverage_enabled: Self::DEFAULT_ALPHA_TO_COVERAGE_ENABLED,
+            multisample: Self::DEFAULT_MULTISAMPLE,
         }
     }
 
     // Builders
 
+    /// The name of the entry point in the compiled shader.
+    ///
+    /// There must be a function that returns void with this name in the shader.
     pub fn vertex_entry_point(mut self, entry_point: &'a str) -> Self {
         self.vs_entry_point = entry_point;
         self
     }
 
+    /// The name of the entry point in the compiled shader.
+    ///
+    /// There must be a function that returns void with this name in the shader.
     pub fn fragment_entry_point(mut self, entry_point: &'a str) -> Self {
         self.fs_entry_point = entry_point;
         self
     }
 
-    /// Specify a fragment shader for the render pipeline.
+    /// Specify a compiled fragment shader for the render pipeline.
     pub fn fragment_shader(mut self, fs_mod: &'a wgpu::ShaderModule) -> Self {
         self.fs_mod = Some(fs_mod);
         self
     }
 
-    // Rasterization state.
+    // Primitive state.
 
-    /// Specify the full rasterization state.
-    pub fn rasterization_state(mut self, state: wgpu::RasterizationStateDescriptor) -> Self {
-        self.rasterization_state = Some(state);
+    /// Specify the full primitive state.
+    ///
+    /// Describes the state of primitive assembly and rasterization in a render pipeline.
+    pub fn primitive(mut self, p: wgpu::PrimitiveState) -> Self {
+        self.primitive = p;
         self
     }
 
+    /// The face to consider the front for the purpose of culling and stencil operations.
     pub fn front_face(mut self, front_face: wgpu::FrontFace) -> Self {
-        let state = self
-            .rasterization_state
-            .get_or_insert(Self::DEFAULT_RASTERIZATION_STATE);
-        state.front_face = front_face;
+        self.primitive.front_face = front_face;
         self
     }
 
+    /// The face culling mode.
     pub fn cull_mode(mut self, cull_mode: wgpu::CullMode) -> Self {
-        let state = self
-            .rasterization_state
-            .get_or_insert(Self::DEFAULT_RASTERIZATION_STATE);
-        state.cull_mode = cull_mode;
+        self.primitive.cull_mode = cull_mode;
         self
     }
-
-    pub fn depth_bias(mut self, bias: i32) -> Self {
-        let state = self
-            .rasterization_state
-            .get_or_insert(Self::DEFAULT_RASTERIZATION_STATE);
-        state.depth_bias = bias;
-        self
-    }
-
-    pub fn depth_bias_slope_scale(mut self, scale: f32) -> Self {
-        let state = self
-            .rasterization_state
-            .get_or_insert(Self::DEFAULT_RASTERIZATION_STATE);
-        state.depth_bias_slope_scale = scale;
-        self
-    }
-
-    pub fn depth_bias_clamp(mut self, clamp: f32) -> Self {
-        let state = self
-            .rasterization_state
-            .get_or_insert(Self::DEFAULT_RASTERIZATION_STATE);
-        state.depth_bias_clamp = clamp;
-        self
-    }
-
-    // Primitive topology.
 
     /// Specify the primitive topology.
     ///
     /// This represents the way vertices will be read from the **VertexBuffer**.
     pub fn primitive_topology(mut self, topology: wgpu::PrimitiveTopology) -> Self {
-        self.primitive_topology = topology;
+        self.primitive.topology = topology;
+        self
+    }
+
+    /// Controls the way each polygon is rasterized. Can be either `Fill` (default), `Line` or
+    /// `Point`.
+    ///
+    /// Setting this to something other than `Fill` requires `Features::NON_FILL_POLYGON_MODE` to
+    /// be enabled.
+    pub fn polygon_mode(mut self, mode: wgpu::PolygonMode) -> Self {
+        self.primitive.polygon_mode = mode;
         self
     }
 
@@ -237,29 +222,35 @@ impl<'a> RenderPipelineBuilder<'a> {
     /// Specify the full color state for drawing to the output attachment.
     ///
     /// If you have multiple output attachments, see the `color_states` method.
-    pub fn color_state(mut self, state: wgpu::ColorStateDescriptor) -> Self {
+    pub fn color_state(mut self, state: wgpu::ColorTargetState) -> Self {
         self.color_state = Some(state);
         self
     }
 
+    /// The texture formrat of the image that this pipelinew ill render to.
+    ///
+    /// Must match the format of the corresponding color attachment.
     pub fn color_format(mut self, format: wgpu::TextureFormat) -> Self {
         let state = self.color_state.get_or_insert(Self::DEFAULT_COLOR_STATE);
         state.format = format;
         self
     }
 
-    pub fn color_blend(mut self, blend: wgpu::BlendDescriptor) -> Self {
+    /// The color blending used for this pipeline.
+    pub fn color_blend(mut self, blend: wgpu::BlendState) -> Self {
         let state = self.color_state.get_or_insert(Self::DEFAULT_COLOR_STATE);
         state.color_blend = blend;
         self
     }
 
-    pub fn alpha_blend(mut self, blend: wgpu::BlendDescriptor) -> Self {
+    /// The alpha blending used for this pipeline.
+    pub fn alpha_blend(mut self, blend: wgpu::BlendState) -> Self {
         let state = self.color_state.get_or_insert(Self::DEFAULT_COLOR_STATE);
         state.alpha_blend = blend;
         self
     }
 
+    /// Mask which enables/disables writes to different color/alpha channel.
     pub fn write_mask(mut self, mask: wgpu::ColorWrite) -> Self {
         let state = self.color_state.get_or_insert(Self::DEFAULT_COLOR_STATE);
         state.write_mask = mask;
@@ -268,80 +259,139 @@ impl<'a> RenderPipelineBuilder<'a> {
 
     // Depth / Stencil state
 
-    pub fn depth_stencil_state(mut self, state: wgpu::DepthStencilStateDescriptor) -> Self {
-        self.depth_stencil_state = Some(state);
+    /// Specify the full depth stencil state.
+    pub fn depth_stencil(mut self, state: wgpu::DepthStencilState) -> Self {
+        self.depth_stencil = Some(state);
         self
     }
 
+    /// Format of the depth/stencil buffer. Must be one of the depth formats. Must match the format
+    /// of the depth/stencil attachment.
     pub fn depth_format(mut self, format: wgpu::TextureFormat) -> Self {
         let state = self
-            .depth_stencil_state
-            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
         state.format = format;
         self
     }
 
     pub fn depth_write_enabled(mut self, enabled: bool) -> Self {
         let state = self
-            .depth_stencil_state
-            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
         state.depth_write_enabled = enabled;
         self
     }
 
+    /// Comparison function used to compare depth values in the depth test.
     pub fn depth_compare(mut self, compare: wgpu::CompareFunction) -> Self {
         let state = self
-            .depth_stencil_state
-            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
         state.depth_compare = compare;
         self
     }
 
-    pub fn stencil_front(mut self, stencil: wgpu::StencilStateFaceDescriptor) -> Self {
+    /// Specify the full set of stencil parameters.
+    pub fn stencil(mut self, stencil: wgpu::StencilState) -> Self {
         let state = self
-            .depth_stencil_state
-            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
+        state.stencil = stencil;
+        self
+    }
+
+    /// Front face mode.
+    pub fn stencil_front(mut self, stencil: wgpu::StencilFaceState) -> Self {
+        let state = self
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
         state.stencil.front = stencil;
         self
     }
 
-    pub fn stencil_back(mut self, stencil: wgpu::StencilStateFaceDescriptor) -> Self {
+    /// Back face mode.
+    pub fn stencil_back(mut self, stencil: wgpu::StencilFaceState) -> Self {
         let state = self
-            .depth_stencil_state
-            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
         state.stencil.back = stencil;
         self
     }
 
+    /// Stencil values are AND'd with this mask when reading and writing from the stencil buffer.
+    /// Only low 8 bits are used.
     pub fn stencil_read_mask(mut self, mask: u32) -> Self {
         let state = self
-            .depth_stencil_state
-            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
         state.stencil.read_mask = mask;
         self
     }
 
+    /// Stencil values are AND'd with this mask when writing to the stencil buffer.
+    /// Only low 8 bits are used.
     pub fn stencil_write_mask(mut self, mask: u32) -> Self {
         let state = self
-            .depth_stencil_state
-            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL_STATE);
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
         state.stencil.write_mask = mask;
+        self
+    }
+
+    /// Specify the full set of depth bias parameters.
+    ///
+    /// Describes the biasing setting for the depth target.
+    pub fn depth_bias(mut self, bias: wgpu::DepthBiasState) -> Self {
+        let state = self
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
+        state.bias = bias;
+        self
+    }
+
+    /// Constant depth biasing factor, in basic units of the depth format.
+    pub fn depth_bias_constant(mut self, constant: i32) -> Self {
+        let state = self
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
+        state.bias.constant = constant;
+        self
+    }
+
+    /// Slope depth biasing factor.
+    pub fn depth_bias_slope_scale(mut self, scale: f32) -> Self {
+        let state = self
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
+        state.bias.slope_scale = scale;
+        self
+    }
+
+    /// Depth bias clamp value (absolute).
+    pub fn depth_bias_clamp(mut self, clamp: f32) -> Self {
+        let state = self
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
+        state.bias.clamp = clamp;
+        self
+    }
+
+    /// If enabled polygon depth is clamped to 0-1 range instead of being clipped.
+    ///
+    /// Requires `Features::DEPTH_CLAMPING` enabled.
+    pub fn clamp_depth(mut self, b: bool) -> Self {
+        let state = self
+            .depth_stencil
+            .get_or_insert(Self::DEFAULT_DEPTH_STENCIL);
+        state.clamp_depth = b;
         self
     }
 
     // Vertex buffer methods.
 
-    /// The format of the type used within the index buffer.
-    pub fn index_format(mut self, format: wgpu::IndexFormat) -> Self {
-        self.index_format = format;
-        self
-    }
-
     /// Add a new vertex buffer descriptor to the render pipeline.
-    pub fn add_vertex_buffer_descriptor(
-        mut self,
-        d: wgpu::VertexBufferDescriptor<'static>,
-    ) -> Self {
+    pub fn add_vertex_buffer_layout(mut self, d: wgpu::VertexBufferLayout<'static>) -> Self {
         self.vertex_buffers.push(d);
         self
     }
@@ -350,34 +400,64 @@ impl<'a> RenderPipelineBuilder<'a> {
     /// of the given vertex type.
     ///
     /// The vertex stride is assumed to be equal to `size_of::<V>()`. If this is not the case,
-    /// consider using `add_vertex_buffer_descriptor` instead.
-    pub fn add_vertex_buffer<V>(self, attrs: &'static [wgpu::VertexAttributeDescriptor]) -> Self {
-        let stride = std::mem::size_of::<V>() as wgpu::BufferAddress;
+    /// consider using `add_vertex_buffer_layout` instead.
+    pub fn add_vertex_buffer<V>(self, attrs: &'static [wgpu::VertexAttribute]) -> Self {
+        let array_stride = std::mem::size_of::<V>() as wgpu::BufferAddress;
         let step_mode = wgpu::InputStepMode::Vertex;
-        let descriptor = wgpu::VertexBufferDescriptor {
-            stride,
+        let descriptor = wgpu::VertexBufferLayout {
+            array_stride,
             step_mode,
             attributes: attrs,
         };
-        self.add_vertex_buffer_descriptor(descriptor)
+        self.add_vertex_buffer_layout(descriptor)
     }
 
     /// Short-hand for adding a descriptor to the render pipeline describing a buffer of instances
     /// of the given vertex type.
-    pub fn add_instance_buffer<I>(self, attrs: &'static [wgpu::VertexAttributeDescriptor]) -> Self {
-        let stride = std::mem::size_of::<I>() as wgpu::BufferAddress;
+    pub fn add_instance_buffer<I>(self, attrs: &'static [wgpu::VertexAttribute]) -> Self {
+        let array_stride = std::mem::size_of::<I>() as wgpu::BufferAddress;
         let step_mode = wgpu::InputStepMode::Instance;
-        let descriptor = wgpu::VertexBufferDescriptor {
-            stride,
+        let descriptor = wgpu::VertexBufferLayout {
+            array_stride,
             step_mode,
             attributes: attrs,
         };
-        self.add_vertex_buffer_descriptor(descriptor)
+        self.add_vertex_buffer_layout(descriptor)
     }
 
-    /// The sample count of the output attachment.
+    // Multisample state.
+
+    /// Specify the full multisample state.
+    pub fn multisample(mut self, multisample: wgpu::MultisampleState) -> Self {
+        self.multisample = multisample;
+        self
+    }
+
+    /// The number of samples calculated per pixel (for MSAA).
+    ///
+    /// For non-multisampled textures, this should be 1 (the default).
     pub fn sample_count(mut self, sample_count: u32) -> Self {
-        self.sample_count = sample_count;
+        self.multisample.count = sample_count;
+        self
+    }
+
+    /// Bitmask that restricts the samples of a pixel modified by this pipeline. All samples can be
+    /// enabled using the value !0 (the default).
+    pub fn sample_mask(mut self, sample_mask: u64) -> Self {
+        self.multisample.mask = sample_mask;
+        self
+    }
+
+    /// When enabled, produces another sample mask per pixel based on the alpha output value, that
+    /// is ANDed with the sample_mask and the primitive coverage to restrict the set of samples
+    /// affected by a primitive.
+    ///
+    /// The implicit mask produced for alpha of zero is guaranteed to be zero, and for alpha of one
+    /// is guaranteed to be all 1-s.
+    ///
+    /// Disabled by default.
+    pub fn alpha_to_coverage_enabled(mut self, b: bool) -> Self {
+        self.multisample.alpha_to_coverage_enabled = b;
         self
     }
 
@@ -428,43 +508,45 @@ fn build(
         fs_mod,
         vs_entry_point,
         fs_entry_point,
-        rasterization_state,
-        primitive_topology,
+        primitive,
         color_state,
         color_states,
-        depth_stencil_state,
-        index_format,
+        depth_stencil,
+        multisample,
         vertex_buffers,
-        sample_count,
-        sample_mask,
-        alpha_to_coverage_enabled,
     } = builder;
 
-    let vertex_stage = wgpu::ProgrammableStageDescriptor {
+    // let vertex_stage = wgpu::ProgrammableStageDescriptor {
+    //     module: &vs_mod,
+    //     entry_point: vs_entry_point,
+    // };
+
+    // let fragment_stage = fs_mod.map(|fs_mod| wgpu::ProgrammableStageDescriptor {
+    //     module: fs_mod,
+    //     entry_point: fs_entry_point,
+    // });
+
+    // let rasterization_state = match fragment_stage.is_some() {
+    //     true => {
+    //         Some(rasterization_state.unwrap_or(RenderPipelineBuilder::DEFAULT_RASTERIZATION_STATE))
+    //     }
+    //     false => {
+    //         if rasterization_state.is_some() {
+    //             panic!("specified rasterization state fields but no fragment shader");
+    //         } else {
+    //             None
+    //         }
+    //     }
+    // };
+
+    let vertex = wgpu::VertexState {
         module: &vs_mod,
         entry_point: vs_entry_point,
-    };
-
-    let fragment_stage = fs_mod.map(|fs_mod| wgpu::ProgrammableStageDescriptor {
-        module: fs_mod,
-        entry_point: fs_entry_point,
-    });
-
-    let rasterization_state = match fragment_stage.is_some() {
-        true => {
-            Some(rasterization_state.unwrap_or(RenderPipelineBuilder::DEFAULT_RASTERIZATION_STATE))
-        }
-        false => {
-            if rasterization_state.is_some() {
-                panic!("specified rasterization state fields but no fragment shader");
-            } else {
-                None
-            }
-        }
+        buffers: &vertex_buffers[..],
     };
 
     let mut single_color_state = [RenderPipelineBuilder::DEFAULT_COLOR_STATE];
-    let color_states = match (fragment_stage.is_some(), color_states.is_empty()) {
+    let color_states = match (fs_mod.is_some(), color_states.is_empty()) {
         (true, true) => {
             if let Some(cs) = color_state {
                 single_color_state[0] = cs;
@@ -478,25 +560,23 @@ fn build(
             false => &[],
         },
     };
-
-    let vertex_state = wgpu::VertexStateDescriptor {
-        index_format,
-        vertex_buffers: &vertex_buffers[..],
+    let fragment = match (fs_mod, color_states.is_empty()) {
+        (Some(fs_mod), false) => Some(wgpu::FragmentState {
+            module: &fs_mod,
+            entry_point: fs_entry_point,
+            targets: color_states,
+        }),
+        _ => None,
     };
 
     let pipeline_desc = wgpu::RenderPipelineDescriptor {
         label: Some("nannou render pipeline"),
         layout: Some(layout),
-        vertex_stage,
-        fragment_stage,
-        rasterization_state,
-        primitive_topology,
-        color_states,
-        depth_stencil_state,
-        vertex_state,
-        sample_count,
-        sample_mask,
-        alpha_to_coverage_enabled,
+        vertex,
+        primitive,
+        depth_stencil,
+        multisample,
+        fragment,
     };
 
     device.create_render_pipeline(&pipeline_desc)

--- a/nannou/src/wgpu/render_pipeline_builder.rs
+++ b/nannou/src/wgpu/render_pipeline_builder.rs
@@ -516,29 +516,6 @@ fn build(
         vertex_buffers,
     } = builder;
 
-    // let vertex_stage = wgpu::ProgrammableStageDescriptor {
-    //     module: &vs_mod,
-    //     entry_point: vs_entry_point,
-    // };
-
-    // let fragment_stage = fs_mod.map(|fs_mod| wgpu::ProgrammableStageDescriptor {
-    //     module: fs_mod,
-    //     entry_point: fs_entry_point,
-    // });
-
-    // let rasterization_state = match fragment_stage.is_some() {
-    //     true => {
-    //         Some(rasterization_state.unwrap_or(RenderPipelineBuilder::DEFAULT_RASTERIZATION_STATE))
-    //     }
-    //     false => {
-    //         if rasterization_state.is_some() {
-    //             panic!("specified rasterization state fields but no fragment shader");
-    //         } else {
-    //             None
-    //         }
-    //     }
-    // };
-
     let vertex = wgpu::VertexState {
         module: &vs_mod,
         entry_point: vs_entry_point,

--- a/nannou/src/wgpu/sampler_builder.rs
+++ b/nannou/src/wgpu/sampler_builder.rs
@@ -19,7 +19,7 @@ impl<'b> SamplerBuilder {
     pub const DEFAULT_LOD_MAX_CLAMP: f32 = 100.0;
     pub const DEFAULT_COMPARE: Option<wgpu::CompareFunction> = None;
     pub const DEFAULT_ANISOTROPY_CLAMP: Option<NonZeroU8> = None;
-    pub const DEFAULT_LABEL: Option<&'static str> = None;
+    pub const DEFAULT_LABEL: &'static str = "nannou-sampler";
     pub const DEFAULT_BORDER_COLOR: Option<wgpu::SamplerBorderColor> = None;
     pub const DEFAULT_DESCRIPTOR: wgpu::SamplerDescriptor<'static> = wgpu::SamplerDescriptor {
         address_mode_u: Self::DEFAULT_ADDRESS_MODE_U,
@@ -32,7 +32,7 @@ impl<'b> SamplerBuilder {
         lod_max_clamp: Self::DEFAULT_LOD_MAX_CLAMP,
         compare: Self::DEFAULT_COMPARE,
         anisotropy_clamp: Self::DEFAULT_ANISOTROPY_CLAMP,
-        label: Self::DEFAULT_LABEL,
+        label: Some(Self::DEFAULT_LABEL),
         border_color: Self::DEFAULT_BORDER_COLOR,
     };
 

--- a/nannou/src/wgpu/sampler_builder.rs
+++ b/nannou/src/wgpu/sampler_builder.rs
@@ -20,6 +20,7 @@ impl<'b> SamplerBuilder {
     pub const DEFAULT_COMPARE: Option<wgpu::CompareFunction> = None;
     pub const DEFAULT_ANISOTROPY_CLAMP: Option<NonZeroU8> = None;
     pub const DEFAULT_LABEL: Option<&'static str> = None;
+    pub const DEFAULT_BORDER_COLOR: Option<wgpu::SamplerBorderColor> = None;
     pub const DEFAULT_DESCRIPTOR: wgpu::SamplerDescriptor<'static> = wgpu::SamplerDescriptor {
         address_mode_u: Self::DEFAULT_ADDRESS_MODE_U,
         address_mode_v: Self::DEFAULT_ADDRESS_MODE_V,
@@ -32,6 +33,7 @@ impl<'b> SamplerBuilder {
         compare: Self::DEFAULT_COMPARE,
         anisotropy_clamp: Self::DEFAULT_ANISOTROPY_CLAMP,
         label: Self::DEFAULT_LABEL,
+        border_color: Self::DEFAULT_BORDER_COLOR,
     };
 
     /// Begin building a `Sampler`, starting with the `Default` parameters.

--- a/nannou/src/wgpu/texture/capturer.rs
+++ b/nannou/src/wgpu/texture/capturer.rs
@@ -339,12 +339,12 @@ fn create_converter_data_pair(
     let dst_texture = wgpu::TextureBuilder::from(src_texture.descriptor.clone())
         .sample_count(1)
         .format(Capturer::DST_FORMAT)
-        .usage(wgpu::TextureUsage::OUTPUT_ATTACHMENT | wgpu::TextureUsage::COPY_SRC)
+        .usage(wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_SRC)
         .build(device);
 
     // Create the converter.
     let src_sample_count = src_texture.sample_count();
-    let src_component_type = src_texture.component_type();
+    let src_sample_type = src_texture.sample_type();
     let src_view = src_texture.create_view(&wgpu::TextureViewDescriptor::default());
     let dst_sample_count = 1;
     let dst_format = dst_texture.format();
@@ -352,7 +352,7 @@ fn create_converter_data_pair(
         device,
         &src_view,
         src_sample_count,
-        src_component_type,
+        src_sample_type,
         dst_sample_count,
         dst_format,
     );

--- a/nannou/src/wgpu/texture/image.rs
+++ b/nannou/src/wgpu/texture/image.rs
@@ -42,7 +42,7 @@ impl wgpu::TextureBuilder {
         wgpu::TextureUsage::COPY_SRC
             | wgpu::TextureUsage::COPY_DST
             | wgpu::TextureUsage::SAMPLED
-            | wgpu::TextureUsage::OUTPUT_ATTACHMENT
+            | wgpu::TextureUsage::RENDER_ATTACHMENT
     }
 }
 
@@ -68,7 +68,7 @@ impl wgpu::Texture {
     /// keeping in mind if you have more than one window and they do not share the same device.
     ///
     /// By default, the texture will have the `COPY_SRC`, `COPY_DST`, `SAMPLED` and
-    /// `OUTPUT_ATTACHMENT` usages enabled. If you wish to specify the usage yourself, see the
+    /// `RENDER_ATTACHMENT` usages enabled. If you wish to specify the usage yourself, see the
     /// `load_from_path` constructor.
     ///
     /// If the `&App` is passed as the `src`, the window returned via `app.main_window()` will be
@@ -95,7 +95,7 @@ impl wgpu::Texture {
     /// keeping in mind if you have more than one window and they do not share the same device.
     ///
     /// By default, the texture will have the `COPY_SRC`, `COPY_DST`, `SAMPLED` and
-    /// `OUTPUT_ATTACHMENT` usages enabled. If you wish to specify the usage yourself, see the
+    /// `RENDER_ATTACHMENT` usages enabled. If you wish to specify the usage yourself, see the
     /// `load_from_path` constructor.
     ///
     /// If the `&App` is passed as the `src`, the window returned via `app.main_window()` will be

--- a/nannou/src/wgpu/texture/mod.rs
+++ b/nannou/src/wgpu/texture/mod.rs
@@ -174,8 +174,8 @@ impl Texture {
     }
 
     /// The component type associated with the texture's format.
-    pub fn component_type(&self) -> wgpu::TextureComponentType {
-        self.format().into()
+    pub fn sample_type(&self) -> wgpu::TextureSampleType {
+        self.format().describe().sample_type
     }
 
     // Custom constructors.
@@ -301,7 +301,7 @@ impl Texture {
             let descriptor = self.descriptor.clone();
             let resolved_texture = wgpu::TextureBuilder::from(descriptor)
                 .sample_count(1)
-                .usage(wgpu::TextureUsage::OUTPUT_ATTACHMENT | wgpu::TextureUsage::COPY_SRC)
+                .usage(wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_SRC)
                 .build(device);
             let resolved_view =
                 resolved_texture.create_view(&wgpu::TextureViewDescriptor::default());
@@ -371,8 +371,8 @@ impl TextureView {
         self.info.array_layer_count
     }
 
-    pub fn component_type(&self) -> wgpu::TextureComponentType {
-        self.format().into()
+    pub fn sample_type(&self) -> wgpu::TextureSampleType {
+        self.format().describe().sample_type
     }
 
     pub fn id(&self) -> TextureViewId {
@@ -751,23 +751,7 @@ pub fn data_size_bytes(desc: &wgpu::TextureDescriptor) -> usize {
 
 /// Return the size of the given texture format in bytes.
 pub fn format_size_bytes(format: wgpu::TextureFormat) -> u32 {
-    use crate::wgpu::TextureFormat::*;
-    match format {
-        R8Unorm | R8Snorm | R8Uint | R8Sint => 1,
-
-        R16Uint | R16Sint | R16Float | Rg8Unorm | Rg8Snorm | Rg8Uint | Rg8Sint => 2,
-
-        R32Uint | R32Sint | R32Float | Rg16Uint | Rg16Sint | Rg16Float | Rgba8Unorm
-        | Rgba8UnormSrgb | Rgba8Snorm | Rgba8Uint | Rgba8Sint | Bgra8Unorm | Bgra8UnormSrgb
-        | Rgb10a2Unorm | Rg11b10Float => 4,
-
-        Rg32Uint | Rg32Sint | Rg32Float | Rgba16Uint | Rgba16Sint | Rgba16Float | Rgba32Uint
-        | Rgba32Sint | Rgba32Float => 8,
-
-        Depth32Float | Depth24Plus | Depth24PlusStencil8 => 4,
-
-        _ => unimplemented!(),
-    }
+    format.describe().block_size as u32
 }
 
 /// Returns `true` if the given `wgpu::Extent3d`s are equal.

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -40,7 +40,7 @@ pub struct Builder<'app> {
     title_was_set: bool,
     swap_chain_builder: SwapChainBuilder,
     power_preference: wgpu::PowerPreference,
-    device_desc: Option<wgpu::DeviceDescriptor>,
+    device_desc: Option<wgpu::DeviceDescriptor<'static>>,
     user_functions: UserFunctions,
     msaa_samples: Option<u32>,
     max_capture_frame_jobs: u32,
@@ -280,7 +280,7 @@ pub struct SwapChainBuilder {
 }
 
 impl SwapChainBuilder {
-    pub const DEFAULT_USAGE: wgpu::TextureUsage = wgpu::TextureUsage::OUTPUT_ATTACHMENT;
+    pub const DEFAULT_USAGE: wgpu::TextureUsage = wgpu::TextureUsage::RENDER_ATTACHMENT;
     pub const DEFAULT_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8UnormSrgb;
     pub const DEFAULT_PRESENT_MODE: wgpu::PresentMode = wgpu::PresentMode::Fifo;
 
@@ -384,7 +384,7 @@ impl<'app> Builder<'app> {
 
     /// Specify a device descriptor to use when requesting the logical device from the adapter.
     /// This allows for specifying custom wgpu device extensions.
-    pub fn device_descriptor(mut self, device_desc: wgpu::DeviceDescriptor) -> Self {
+    pub fn device_descriptor(mut self, device_desc: wgpu::DeviceDescriptor<'static>) -> Self {
         self.device_desc = Some(device_desc);
         self
     }

--- a/nannou_timeline/Cargo.toml
+++ b/nannou_timeline/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/nannou-org/nannou_timeline.git"
 homepage = "https://nannou.cc"
 
 [dependencies]
-conrod_derive = "0.71"
-conrod_core = "0.71"
+conrod_derive = "0.72"
+conrod_core = "0.72"
 envelope = "0.8"
 itertools = "0.4.16"
 num = "0.1.27"


### PR DESCRIPTION
This consists of pretty simple name changes for the most part, however there is some pretty significant restructuring of the `RenderPipelineDescriptor`. This meant quite a few changes in the `render_pipeline_builder` module - I tried improving the builder method docs here while I was at it.

The `Sampler` binding type now requires that you specify whether or not it uses `Linear` filtering for any of its minify, magnify or mipmap filters. A `wgpu::sampler_filtering` function was added to make it a little easier to retrieve this bool from the `SamplerDescriptor` type. That said, this does require a little extra boilerplate for graphics pipelines that involve a texture sampler. I think the `wgpu_image.rs` example is probably the simplest example of how to update for this.

---

@danwilhelm @JoshuaBatty unfortunately (or maybe fortunately?) the new validation checks didn't turn up anything new. I wonder if maybe it was simply a bug in wgpu 0.6 that has since been fixed? Would you mind testing if #719 is still a problem on this branch?

---

@mattheusroxas the `PowerPreference::Default` variant was removed in the latest version of 0.7. I have a suspicion that the bug you were running into may have been fixed in this latest version of wgpu, so I've tried adding the `HighPerformance` preference back. Would you mind testing this branch? You can do so by changing your nannou dependency in your cargo.toml to this:
```toml
nannou = { git = "https://github.com/mitchmindtree/nannou", branch = "wgpu-0.7" }
```

---

Closes #721.
Closes #719.