### PR TITLE
Add ability to color characters individually, update draw_text example

### DIFF
--- a/examples/draw/draw_text.rs
+++ b/examples/draw/draw_text.rs
@@ -18,7 +18,14 @@ fn view(app: &App, frame: Frame) {
 
     let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nResize the window to test dynamic layout.";
 
-    draw.text(text).color(BLACK).font_size(24).wh(win_rect.wh());
+    //                         L     o     r     e     m           i    p    s    u    m
+    let glyph_colors = vec![BLUE, BLUE, BLUE, BLUE, BLUE, BLACK, RED, RED, RED, RED, RED];
+
+    draw.text(text)
+        .color(BLACK)
+        .glyph_colors(glyph_colors)
+        .font_size(24)
+        .wh(win_rect.wh());
 
     draw.to_frame(app, &frame).unwrap();
 }


### PR DESCRIPTION
Adds a new method that colors text glyphs individually. 

For example, this could be useful for:
- Quickly colorizing the first character or word of a string. 
- Displaying syntax-highlighted code.

For an example, see `draw_text.rs`. Tested by running the examples, `cargo test`, and `cargo fmt`.
