### PR TITLE
Publish 0.16 - Update changelog with related changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 *The CHANGELOG has been moved to [the guide](https://guide.nannou.cc/changelog.html).*
+
+*Contributors looking to update the changelog can find it in the nannou repository under `guide/src/changelog.md`.*

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,12 +18,12 @@ audrey = "0.3"
 futures = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 hrtf = "0.2"
-nannou = { version ="0.15.0", path = "../nannou" }
-nannou_audio = { version ="0.15.0", path = "../nannou_audio" }
+nannou = { version ="0.16.0", path = "../nannou" }
+nannou_audio = { version ="0.16.0", path = "../nannou_audio" }
 nannou_isf = { version ="0.1.0", path = "../nannou_isf" }
-nannou_laser = { version ="0.15.0", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
-nannou_osc = { version ="0.15.0", path = "../nannou_osc" }
-nannou_timeline = { version ="0.15.0", features = ["serde1"], path =  "../nannou_timeline" }
+nannou_laser = { version ="0.16.0", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
+nannou_osc = { version ="0.16.0", path = "../nannou_osc" }
+nannou_timeline = { version ="0.16.0", features = ["serde1"], path =  "../nannou_timeline" }
 pitch_calc = { version = "0.12", features = ["serde"] }
 time_calc = { version= "0.13", features = ["serde"] }
 walkdir = "2"

--- a/generative_design/Cargo.toml
+++ b/generative_design/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-nannou = { version ="0.15.0", path = "../nannou" }
+nannou = { version ="0.16.0", path = "../nannou" }
 usvg = "0.4"
 wikipedia = "0.3"
 

--- a/guide/book_tests/Cargo.toml
+++ b/guide/book_tests/Cargo.toml
@@ -16,6 +16,6 @@ skeptic = { git = "https://github.com/mitchmindtree/rust-skeptic", branch = "1.4
 # https://github.com/budziq/rust-skeptic/pull/121
 skeptic = { git = "https://github.com/mitchmindtree/rust-skeptic", branch = "1.45-extern" }
 #skeptic = "0.13"
-nannou = { version ="0.15.0", path = "../../nannou" }
-nannou_osc = { version ="0.15.0", path = "../../nannou_osc" }
+nannou = { version ="0.16.0", path = "../../nannou" }
+nannou_osc = { version ="0.16.0", path = "../../nannou_osc" }
 

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -7,6 +7,51 @@ back to the origins.
 
 # Unreleased
 
+*No unreleased changes as of yet.
+
+---
+
+# Version 0.16.0 (2021-04-21)
+
+- Add ability to color characters individually to `Draw` API, i.e.
+  `draw.text().glyph_colors(color_iter)`.
+- Add a `app.quit()` method to allow for quitting the application without user
+  input.
+- Use the `instant` crate rather than `std::time::Instant` in preparation for
+  wasm support.
+- Fix a major memory leak and various resize crashes - thanks danwilhelm!
+- Fix non-uniform scaling in `Draw` API.
+
+**Update to wgpu 0.7**
+
+These changes mostly involved renaming of items, though also included some
+significant refactoring of the `wgpu::RenderPipeline`.
+
+- The `wgpu::RenderPipelineBuilder` had some methods added, some removed in
+  order to more closely match the newly refactored `wpgu::RenderPipeline`.
+  Documentation of `RenderPipelineBuilder` methods has been added to match
+  the upstream wgpu docs of the associated fields.
+- The `Sampler` binding type now requires specifying whether or not it uses the
+  `Linear` option for any of its minify, magnify or mipmap filters. A
+  `wgpu::sampler_filtering` function was added to make it easier to retrieve
+  this bool from the `SamplerDescriptor`.
+- The vertex buffer `IndexFormat` is now specified while setting the index
+  buffer in the render pass command, rather than in the render pipeline
+  descriptor.
+- Item name changes include:
+    - `PowerPreference::Default` -> `PowerPreference::LowPower`
+    - `TextureUsage::OUTPUT_ATTACHMENT` -> `TextureUsage::RENDER_ATTACHMENT`
+    - `TextureComponentType` -> `TextureSampleType`
+    - `component_type` -> `sample_type` (for textures)
+    - `BlendDescriptor` -> `BlendState`
+    - `VertexAttributeDescriptor` -> `VertexAttribute`
+    - `BindingType::SampledTexture` -> `BindingType::Texture`
+    - `ColorStateDescriptor` -> `ColorTargetState`
+    - `DepthStencilStateDescriptor` -> `DepthStencilState`
+    - `VertexBufferDescriptor` -> `VertexBufferLayout`
+- Also updates related dependencies:
+    - `conrod_derive` and `conrod_core` to `0.72`.
+
 **Update to wgpu 0.6**
 
 For the most part, these changes will affect users of the `nannou::wgpu` module,
@@ -39,7 +84,6 @@ changelog entry
     - `audrey` to 0.3.
     - `winit` to 0.24.
     - `conrod_derive` and `conrod_core` to 0.71 (`nannou_timeline` only).
-
 
 ### nannou_audio
 

--- a/guide/src/getting_started/create_a_project.md
+++ b/guide/src/getting_started/create_a_project.md
@@ -31,7 +31,7 @@ create a new project with just a few small steps:
    edition = "2018"
 
    [dependencies]
-   nannou = "0.15"
+   nannou = "0.16"
    ```
 
    Note that there is a chance the nannou version above might be out of date.

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version ="0.15.0"
+version ="0.16.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"

--- a/nannou_audio/Cargo.toml
+++ b/nannou_audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_audio"
-version ="0.15.0"
+version ="0.16.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The audio API for Nannou, the creative coding framework."
 readme = "README.md"

--- a/nannou_isf/Cargo.toml
+++ b/nannou_isf/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 isf = { git = "https://github.com/nannou-org/isf", branch = "master" }
-nannou = { version ="0.15.0", path = "../nannou" }
+nannou = { version ="0.16.0", path = "../nannou" }
 thiserror = "1"
 threadpool = "1"
 walkdir = "2"

--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_laser"
-version ="0.15.0"
+version ="0.16.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 edition = "2018"

--- a/nannou_new/Cargo.toml
+++ b/nannou_new/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_new"
-version ="0.15.0"
+version ="0.16.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A tool for easily starting Nannou projects."
 readme = "README.md"

--- a/nannou_osc/Cargo.toml
+++ b/nannou_osc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_osc"
-version ="0.15.0"
+version ="0.16.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The OSC API for Nannou, the creative coding framework."
 readme = "README.md"

--- a/nannou_package/Cargo.toml
+++ b/nannou_package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_package"
-version ="0.15.0"
+version ="0.16.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The build packaging tool for the Nannou Creative Coding Framework."
 readme = "README.md"

--- a/nannou_timeline/Cargo.toml
+++ b/nannou_timeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_timeline"
-version ="0.15.0"
+version ="0.16.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A timeline widget, compatible with all conrod GUI projects."
 readme = "README.md"
@@ -27,6 +27,6 @@ serde1 = [
 ]
 
 [dev-dependencies]
-nannou = { version ="0.15.0", path = "../nannou" }
+nannou = { version ="0.16.0", path = "../nannou" }
 rand = "0.3.12"
 serde_json = "1.0"

--- a/nature_of_code/Cargo.toml
+++ b/nature_of_code/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-nannou = { version ="0.15.0", path = "../nannou" }
+nannou = { version ="0.16.0", path = "../nannou" }
 
 # Chapter 1 Vectors
 [[example]]


### PR DESCRIPTION
It's time!

Notable changes include the update from wgpu 0.5 to 0.7, a bunch of
bug fixes for graphics related stuff, and an update of dependencies and
related APIs in `nannou_audio`. See the `guide/src/changelog.md`
diff for a detailed list of the changes included in this release.

I think I mentioned on matrix that I was hoping to get #684 into this
release, but then realised that `nannou_isf` is still unpublished
anyway, so we can publish it at 0.16 if/when those changes are ready.