### PR TITLE
nannou_laser - enable all features for docs.rs

### DIFF
--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -21,3 +21,6 @@ thiserror = "1"
 
 [features]
 ffi = []
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
Currently the `ilda` and `ffi` features are missing.