### PR TITLE
Ensure `Info` char index refers to orig string

### DIFF
--- a/nannou/src/draw/primitive/text.rs
+++ b/nannou/src/draw/primitive/text.rs
@@ -248,8 +248,10 @@ where
         self.map_ty(|ty| ty.layout(layout))
     }
 
-    /// Set a color for each glyph.
+    /// Set a color for each glyph, which is typically one character.
     /// Colors unspecified glyphs using the drawing color.
+    /// NOTE: Sometimes, a glyph can represent multiple characters,
+    ///       or be a part in other glyphs.
     pub fn glyph_colors<I, C>(self, glyph_colors: I) -> Self
     where
         I: IntoIterator<Item = C>,


### PR DESCRIPTION
When wrapping text, `Info` (and the enclosed `Break`) records the byte and character indexes of each wrapped line.

**Problem.** Currently, the byte index refers to the original string, but the char index does not. For example:

```
let s1 = "fn main() {\n    nannou::app(model)\n";              // Byte index is into original string
let s2 = "fn\n main(\n) {\n    \nnanno\nu::app\n(mode\nl)\n";  // Char index is into "wrapped" string
```

**Proposed Solution.** I propose making the byte and character indexes both refer to the original string, to avoid confusion. Currently, the char index is always incremented by 1 every break, even if the break itself is 0 chars (`""`), 1 char (`" "`, `"\n"`), or 2 chars (`"\r\n"`). It does not skip these end-of-break chars, even though the byte index skips them.

**Consequence.** Changing this will help the text coloring implementation, which assumes that text colors are ordered by character index into the original string. It is very difficult to tell the character->line mappings as it is currently implemented.

---

**Example.**

Suppose we have a string:

`let s = "fn main() {\n    nannou::app(model)\n";`

We then wrap this across numerous lines:

```
"fn"      <- Info { start_byte: 0, start_char: 0, end_break: Wrap { byte: 2, char: 2, len_bytes: 1 }, ...
"main("   <- Info { start_byte: 3, start_char: 3, end_break: Wrap { byte: 8, char: 8, len_bytes: 0 }, ...
") {"     <- Info { start_byte: 8, start_char: 9, end_break: Newline { byte: 11, char: 12, len_bytes: 1 }, ...
"   "     <- Info { start_byte: 12, start_char: 13, end_break: Wrap { byte: 15, char: 16, len_bytes: 1 }, ...
"nanno"   <- Info { start_byte: 16, start_char: 17, end_break: Wrap { byte: 21, char: 22, len_bytes: 0 }, ...
"u::app"  <- Info { start_byte: 21, start_char: 23, end_break: Wrap { byte: 27, char: 29, len_bytes: 0 }, ...
"(mode"   <- Info { start_byte: 27, start_char: 30, end_break: Wrap { byte: 27, char: 29, len_bytes: 0 }, ...
"l)"      <- Info { start_byte: 32, start_char: 36, end_break: Newline { byte: 34, char: 38, len_bytes: 1 }, ...
```

We observe the following from the above, which is not typical:
- `start_char > start_byte`.
- `start_char > s.chars.count()`.

Effectively, this `start_char` represents the character position in the following string, which is longer than the original: 
```
"fn\n main(\n) {\n    \nnanno\nu::app\n(mode\nl)\n"
```

To be consistent with `start_byte`, `start_char` should give the index into the characters of the original string.

