### PR TITLE
fix: NOC 3_04 exercise to work on Windows

### DIFF
--- a/nature_of_code/chp_03_oscillation/3_04_exercise_spiral.rs
+++ b/nature_of_code/chp_03_oscillation/3_04_exercise_spiral.rs
@@ -32,7 +32,11 @@ fn update(_app: &App, model: &mut Model, _update: Update) {
 fn view(app: &App, model: &Model, frame: Frame) {
     // Begin drawing
     let draw = app.draw();
-    //draw.background().color(WHITE);
+
+    // Set the background color on the first update/frame
+    if model.theta <= 0.01 {
+        draw.background().color(WHITE);
+    }
 
     let x = model.r * model.theta.cos();
     let y = model.r * model.theta.sin();


### PR DESCRIPTION
When running the 3_04 exercise on Windows, the background is completely
black, so the spiral path is not visible. I tested on my mac, the
background, without being set, is green, so it kinda works on macOS.
Nevertheless, this commit sets the background to white on the first
frame so it can work on both Windows and macOS and be consistent with
the Nature of Code's example, which has the white background as well.

### Before (On Windows)
![nannou - 3_04_exercise_spiral 14_06_2021 12_33_59 PM](https://user-images.githubusercontent.com/1403932/121832175-d0b8b680-cd0c-11eb-8a2b-f2f46db487d4.png)


### After (On Windows)
![nannou - 3_04_exercise_spiral 14_06_2021 12_02_39 PM](https://user-images.githubusercontent.com/1403932/121832130-af57ca80-cd0c-11eb-8644-321766f417a3.png)

### Before (on macOS)
<img width="637" alt="Screen Shot 2021-06-14 at 12 18 35 PM" src="https://user-images.githubusercontent.com/1403932/121832441-66544600-cd0d-11eb-890e-92092fc434be.png">

### After (On macOS)
<img width="632" alt="Screen Shot 2021-06-14 at 12 38 49 PM" src="https://user-images.githubusercontent.com/1403932/121832564-b3381c80-cd0d-11eb-9845-d9b8ca497885.png">
