### PR TITLE
Enable serializing of color types

### DIFF
--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -27,7 +27,7 @@ lyon = "0.15"
 noise = "0.6"
 notosans = { version = "0.1", optional = true }
 num_cpus = "1"
-palette = "0.5"
+palette = { version = "0.5", features = ["serializing"] }
 pennereq = "0.3"
 rand = { version = "0.7", features = ["small_rng"] }
 rusttype = "0.8"


### PR DESCRIPTION
Enabling palette's `serializing` feature allows colors to be saved to config files easily.