### PR TITLE
Update conrod to 0.74 and wgpu to 0.9

### DIFF
--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2018"
 default = ["notosans"]
 
 [dependencies]
-conrod_core = "0.73"
-conrod_wgpu = "0.73"
-conrod_winit = "0.72"
+conrod_core = "0.74"
+conrod_wgpu = "0.74"
+conrod_winit = "0.74"
 daggy = "0.6"
 find_folder = "0.3"
 futures = { version = "0.3", features = ["executor", "thread-pool"] }
@@ -34,5 +34,5 @@ serde_derive = "1"
 serde_json = "1"
 toml = "0.5"
 walkdir = "2"
-wgpu_upstream = { version = "0.8", package = "wgpu" }
+wgpu_upstream = { version = "0.9", package = "wgpu" }
 winit = "0.24"

--- a/nannou_timeline/Cargo.toml
+++ b/nannou_timeline/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/nannou-org/nannou_timeline.git"
 homepage = "https://nannou.cc"
 
 [dependencies]
-conrod_derive = "0.73"
-conrod_core = "0.73"
+conrod_derive = "0.74"
+conrod_core = "0.74"
 envelope = "0.8"
 itertools = "0.4.16"
 num = "0.1.27"


### PR DESCRIPTION
See the wgpu changelog [here](https://github.com/gfx-rs/wgpu/blob/master/CHANGELOG.md).

For the most part, this just seems to be some fixes and extra validation checks! It looks like we've managed to dodge all breakage both here and upstream in `conrod_wgpu`.