### PR TITLE
Publish version 0.17 - Includes `wgpu` 0.9 update, `nannou_core`, text fixes and more.

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,12 +18,12 @@ audrey = "0.3"
 futures = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 hrtf = "0.2"
-nannou = { version ="0.16.0", path = "../nannou" }
-nannou_audio = { version ="0.16.0", path = "../nannou_audio" }
-nannou_isf = { version ="0.1.0", path = "../nannou_isf" }
-nannou_laser = { version ="0.16.0", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
-nannou_osc = { version ="0.16.0", path = "../nannou_osc" }
-nannou_timeline = { version ="0.16.0", features = ["serde1"], path =  "../nannou_timeline" }
+nannou = { version ="0.17.0", path = "../nannou" }
+nannou_audio = { version ="0.17.0", path = "../nannou_audio" }
+nannou_isf = { version ="0.17.0", path = "../nannou_isf" }
+nannou_laser = { version ="0.17.0", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
+nannou_osc = { version ="0.17.0", path = "../nannou_osc" }
+nannou_timeline = { version ="0.17.0", features = ["serde1"], path =  "../nannou_timeline" }
 pitch_calc = { version = "0.12", features = ["serde"] }
 time_calc = { version= "0.13", features = ["serde"] }
 walkdir = "2"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,7 +20,7 @@ hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 hrtf = "0.2"
 nannou = { version ="0.17.0", path = "../nannou" }
 nannou_audio = { version ="0.17.0", path = "../nannou_audio" }
-nannou_isf = { version ="0.17.0", path = "../nannou_isf" }
+nannou_isf = { version = "0.1.0", path = "../nannou_isf" }
 nannou_laser = { version ="0.17.0", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
 nannou_osc = { version ="0.17.0", path = "../nannou_osc" }
 nannou_timeline = { version ="0.17.0", features = ["serde1"], path =  "../nannou_timeline" }

--- a/generative_design/Cargo.toml
+++ b/generative_design/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-nannou = { version ="0.16.0", path = "../nannou" }
+nannou = { version ="0.17.0", path = "../nannou" }
 usvg = "0.4"
 wikipedia = "0.3"
 

--- a/guide/book_tests/Cargo.toml
+++ b/guide/book_tests/Cargo.toml
@@ -16,6 +16,6 @@ skeptic = { git = "https://github.com/mitchmindtree/rust-skeptic", branch = "1.4
 # https://github.com/budziq/rust-skeptic/pull/121
 skeptic = { git = "https://github.com/mitchmindtree/rust-skeptic", branch = "1.45-extern" }
 #skeptic = "0.13"
-nannou = { version ="0.16.0", path = "../../nannou" }
-nannou_osc = { version ="0.16.0", path = "../../nannou_osc" }
+nannou = { version ="0.17.0", path = "../../nannou" }
+nannou_osc = { version ="0.17.0", path = "../../nannou_osc" }
 

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -7,7 +7,13 @@ back to the origins.
 
 # Unreleased
 
-**Upgrade WGPU to 0.8**
+*No unreleased changes yet.*
+
+---
+
+# Version 0.17.0 (2021-06-20)
+
+**Upgrade WGPU to 0.9**
 
 Most changes have been about renaming Blend-related data structres and fixing shaders to avoid sampling textures inside of conditionals (wgpu validation layer found this one).
 - Item Name changes:
@@ -27,6 +33,22 @@ Most changes have been about renaming Blend-related data structres and fixing sh
 - Remove `cgmath` computer graphics linear algebra lib in favour of `glam` for
   faster compile times, simpler API, easier documentation, `no_std` support and
   more.
+- Refactor the `Rect` and `Cuboid` method implementations that expose `Point`
+  and `Vec` to avoid breakage. Previously, our `Point` and `Vector` types were
+  generic, however as of switching to `glam` this is no longer the case.
+  Instead, methods that used these types are now implemented independently for
+  `Rect<f32>` and `Rect<f64>` (likewise for `Cuboid`).
+
+**General**
+
+- Fix a bug in `text::line::Infos` iterator where reported character index was
+  incorrect.
+- Fix `glyph_colors` miscoloring on resize.
+- Enable serializing of color types.
+- Enable `nannou_laser` features for documentation build.
+- Update dependencies:
+    - `conrod_*` from 0.73 to 0.74.
+    - `noise` from 0.6 to 0.7 (`image` feature no longer enabled).
 
 ---
 

--- a/guide/src/getting_started/create_a_project.md
+++ b/guide/src/getting_started/create_a_project.md
@@ -31,12 +31,12 @@ create a new project with just a few small steps:
    edition = "2018"
 
    [dependencies]
-   nannou = "0.16"
+   nannou = "0.17"
    ```
 
    Note that there is a chance the nannou version above might be out of date.
    You can check the latest version by typing `cargo search nannou` in your
-   terminal.
+   terminal. Be sure to change the author to your name too!
 
 4. Replace the code in `src/main.rs` with the following to setup our nannou
    application.

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version ="0.16.0"
+version ="0.17.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"
@@ -23,8 +23,8 @@ futures = { version = "0.3", features = ["executor", "thread-pool"] }
 image = "0.23"
 instant = "0.1.9"
 lyon = "0.15"
-nannou_core = { version = "0.16.0", path = "../nannou_core", features = ["std", "serde"] }
-noise = "0.6"
+nannou_core = { version ="0.17.0", path = "../nannou_core", features = ["std", "serde"] }
+noise = "0.7"
 notosans = { version = "0.1", optional = true }
 num_cpus = "1"
 pennereq = "0.3"
@@ -35,4 +35,4 @@ serde_json = "1"
 toml = "0.5"
 walkdir = "2"
 wgpu_upstream = { version = "0.9", package = "wgpu" }
-winit = "0.24"
+winit = "0.25"

--- a/nannou_audio/Cargo.toml
+++ b/nannou_audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_audio"
-version ="0.16.0"
+version ="0.17.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The audio API for Nannou, the creative coding framework."
 readme = "README.md"

--- a/nannou_core/Cargo.toml
+++ b/nannou_core/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "nannou_core"
-version = "0.16.0"
+version ="0.17.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
+description = "The core components of nannou - a creative coding framework for Rust. Ideal for libraries and headless/embedded applications that use nannou."
+readme = "README.md"
+license = "MIT"
+repository = "https://github.com/nannou-org/nannou.git"
+homepage = "https://nannou.cc"
 edition = "2018"
 
 [dependencies]

--- a/nannou_core/README.md
+++ b/nannou_core/README.md
@@ -1,0 +1,33 @@
+# nannou_core
+
+nannou's core abstractions.
+
+This crate aims to be a stripped-down foundation for nannou projects that don't
+require windowing or wgpu graphics. These might include:
+
+- Headless applications, e.g. for LASER or lighting control.
+- Embedded applications, e.g. driving motors or LEDs in an art installation.
+- `rust-gpu` shaders which have strict requirements beyond the limitations of `no_std`.
+- Hot-loaded dynamic libraries that benefit from faster compilation times.
+
+The crate includes nannou's color, math, geometry and noise abstractions without the deep stack
+of crates required to establish an event loop, interoperate with wgpu, etc. Another way of
+describing this crate might be "nannou without the I/O".
+
+## Crate `[features]`
+
+The primary feature of this crate is support for `#![no_std]`. This means we can use the crate
+for embedded applications and in some cases rust-gpu shaders.
+
+By default, the `std` feature is enabled. For compatibility with a `#![no_std]` environment be
+sure to disable default features (i.e. `default-features = false`) and enable the `libm`
+feature. The `libm` feature provides some core functionality required by crates
+
+- `std`: Enabled by default, enables the Rust std library. One of the primary features of this
+  crate is support for `#![no_std]`. This means we can use the crate for embedded applications
+  and in some cases rust-gpu shaders. For compatibility with a `#![no_std]` environment be sure
+  to disable default features (i.e. `default-features = false`) and enable the `libm` feature.
+- `libm`: provides some core math support in the case that `std` is not enabled. This feature
+  must be enabled if `std` is disabled.
+- `serde`: enables the associated serde serialization/deserialization features in `glam`,
+  `palette` and `rand`.

--- a/nannou_isf/Cargo.toml
+++ b/nannou_isf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_isf"
-version ="0.17.0"
+version ="0.1.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 edition = "2018"
 

--- a/nannou_isf/Cargo.toml
+++ b/nannou_isf/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "nannou_isf"
-version ="0.1.0"
+version ="0.17.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 edition = "2018"
 
 [dependencies]
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 isf = { git = "https://github.com/nannou-org/isf", branch = "master" }
-nannou = { version ="0.16.0", path = "../nannou" }
+nannou = { version ="0.17.0", path = "../nannou" }
 thiserror = "1"
 threadpool = "1"
 walkdir = "2"

--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_laser"
-version ="0.16.0"
+version ="0.17.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 edition = "2018"

--- a/nannou_new/Cargo.toml
+++ b/nannou_new/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_new"
-version ="0.16.0"
+version ="0.17.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A tool for easily starting Nannou projects."
 readme = "README.md"

--- a/nannou_osc/Cargo.toml
+++ b/nannou_osc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_osc"
-version ="0.16.0"
+version ="0.17.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The OSC API for Nannou, the creative coding framework."
 readme = "README.md"

--- a/nannou_package/Cargo.toml
+++ b/nannou_package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_package"
-version ="0.16.0"
+version ="0.17.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The build packaging tool for the Nannou Creative Coding Framework."
 readme = "README.md"

--- a/nannou_timeline/Cargo.toml
+++ b/nannou_timeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_timeline"
-version ="0.16.0"
+version ="0.17.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A timeline widget, compatible with all conrod GUI projects."
 readme = "README.md"
@@ -27,6 +27,6 @@ serde1 = [
 ]
 
 [dev-dependencies]
-nannou = { version ="0.16.0", path = "../nannou" }
+nannou = { version ="0.17.0", path = "../nannou" }
 rand = "0.3.12"
 serde_json = "1.0"

--- a/nature_of_code/Cargo.toml
+++ b/nature_of_code/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-nannou = { version ="0.16.0", path = "../nannou" }
+nannou = { version ="0.17.0", path = "../nannou" }
 
 # Chapter 1 Vectors
 [[example]]


### PR DESCRIPTION
Be sure to see the updated `guide/src/changelog.md` for details on the included changes.

Updates `noise` from 0.6 to 0.7, removing a much older duplicated version of the image dependency from nannou's dependency graph.

Also adds a README to the `nannou_core` crate, the contents of which are copied from the crate's root-level documentation (mostly to satisfy the cargo.toml metadata requirements).