### PR TITLE
Update glam to 0.17

### DIFF
--- a/nannou_core/Cargo.toml
+++ b/nannou_core/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://nannou.cc"
 edition = "2018"
 
 [dependencies]
-glam = { version = "0.16", default-features = false, features = ["num-traits", "rand"] }
+glam = { version = "0.17", default-features = false, features = ["num-traits", "rand"] }
 # TODO: Awaiting `no-std` to be published.
 # noise = 0.6
 num-traits = { version = "0.2.14", default-features = false }


### PR DESCRIPTION
See changelog [here](https://github.com/bitshifter/glam-rs/blob/1da7d6459c5f9890275c7fc1871e6c33c825b6b9/CHANGELOG.md).

I need this for the Add and Sub implementations on scalar types, eg Vec2 + f32 