### PR TITLE
Add disable drag-and-drop method for cpal+winit Windows compatibility

### DIFF
--- a/examples/audio/feedback.rs
+++ b/examples/audio/feedback.rs
@@ -26,6 +26,7 @@ struct OutputModel {
 fn model(app: &App) -> Model {
     // Create a window to receive key pressed events.
     app.new_window()
+        .windowsos_drag_and_drop(false) // Required for Windows (no effect otherwise)
         .key_pressed(key_pressed)
         .view(view)
         .build()
@@ -59,6 +60,9 @@ fn model(app: &App) -> Model {
         .render(pass_out)
         .build()
         .unwrap();
+
+    in_stream.play().unwrap();
+    out_stream.play().unwrap();
 
     Model {
         in_stream,

--- a/examples/audio/hrtf-noise.rs
+++ b/examples/audio/hrtf-noise.rs
@@ -66,6 +66,7 @@ impl HrtfData {
 
 fn model(app: &App) -> Model {
     app.new_window()
+        .windowsos_drag_and_drop(false) // Required for Windows (no effect otherwise)
         .size(WINDOW_SIDE, WINDOW_SIDE)
         .key_pressed(key_pressed)
         .mouse_moved(mouse_moved)
@@ -101,6 +102,9 @@ fn model(app: &App) -> Model {
         .frames_per_buffer(BUFFER_LEN_FRAMES)
         .build()
         .unwrap();
+
+    stream.play().unwrap();
+
     Model {
         stream,
         source_position,

--- a/examples/audio/record_wav.rs
+++ b/examples/audio/record_wav.rs
@@ -25,6 +25,7 @@ struct CaptureModel {
 fn model(app: &App) -> Model {
     // Create a window to receive key pressed events.
     app.new_window()
+        .windowsos_drag_and_drop(false) // Required for Windows (no effect otherwise)
         .key_pressed(key_pressed)
         .view(view)
         .build()
@@ -43,6 +44,8 @@ fn model(app: &App) -> Model {
         .capture(capture_fn)
         .build()
         .unwrap();
+
+    stream.play().unwrap();
 
     Model { stream }
 }

--- a/examples/audio/simple_audio.rs
+++ b/examples/audio/simple_audio.rs
@@ -19,22 +19,29 @@ struct Audio {
 fn model(app: &App) -> Model {
     // Create a window to receive key pressed events.
     app.new_window()
+        .windowsos_drag_and_drop(false) // Required for Windows (no effect otherwise)
         .key_pressed(key_pressed)
         .view(view)
         .build()
         .unwrap();
+
     // Initialise the audio API so we can spawn an audio stream.
     let audio_host = audio::Host::new();
+
     // Initialise the state that we want to live on the audio thread.
     let model = Audio {
         phase: 0.0,
         hz: 440.0,
     };
+
     let stream = audio_host
         .new_output_stream(model)
         .render(audio)
         .build()
         .unwrap();
+
+    stream.play().unwrap();
+
     Model { stream }
 }
 

--- a/examples/audio/simple_audio_file.rs
+++ b/examples/audio/simple_audio_file.rs
@@ -17,6 +17,7 @@ struct Audio {
 fn model(app: &App) -> Model {
     // Create a window to receive key pressed events.
     app.new_window()
+        .windowsos_drag_and_drop(false) // Required for Windows (no effect otherwise)
         .key_pressed(key_pressed)
         .view(view)
         .build()
@@ -33,6 +34,9 @@ fn model(app: &App) -> Model {
         .render(audio)
         .build()
         .unwrap();
+
+    stream.play().unwrap();
+
     Model { stream }
 }
 

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -22,6 +22,9 @@ use winit::dpi::{LogicalSize, PhysicalSize};
 pub use winit::window::Fullscreen;
 pub use winit::window::WindowId as Id;
 
+#[cfg(target_os = "windows")]
+use winit::platform::windows::WindowBuilderExtWindows;
+
 /// The default dimensions used for a window in the case that none are specified.
 pub const DEFAULT_DIMENSIONS: LogicalSize<geom::scalar::Default> = LogicalSize {
     width: 1024.0,
@@ -990,6 +993,23 @@ impl<'app> Builder<'app> {
     /// Sets the window icon.
     pub fn window_icon(self, window_icon: Option<winit::window::Icon>) -> Self {
         self.map_window(|w| w.with_window_icon(window_icon))
+    }
+
+    /// On Windows only, enables or disables drag and drop onto the window.
+    /// On non-Windows, drag and drop is enabled and this function has no effect.
+    /// To use `nannou_audio` on Windows on the same thread, disable drag and drop.
+    ///
+    /// NOTE: Drag and drop requires multi-threaded COM, which can interfere with
+    /// other crates such as `cpal` and `nannou_audio` on the same thread.
+    pub fn windowsos_drag_and_drop(self, drag_and_drop: bool) -> Self {
+        #[cfg(target_os = "windows")]
+        {
+            self.map_window(|w| w.with_drag_and_drop(drag_and_drop))
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            self
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #652 
Fixes #483 

**Rationale**
Currently, Windows audio examples crash, because on Windows [`winit` drag and drop requires multi-threaded COM](https://github.com/rust-windowing/winit/issues/1185). This interferes with other crates such as `cpal` and `nannou_audio` on the same thread. This PR allows Windows users to use `nannou_audio` easily on the same thread by disabling `winit` drag and drop. Unfortunately, this solution will not work for Windows users who want both audio and drag and drop.

**Alternatives**
The most common alternative is [spawning `cpal` on another thread](https://github.com/RustAudio/rodio/issues/214#issuecomment-643640535). Other libraries have taken this approach [such as `ruffle`](https://github.com/ruffle-rs/ruffle/blob/master/desktop/src/audio.rs#L77). However, upon comparison it does not  seem as feasible for `nannou`, which attempts to wrap `cpal` much more comprehensively. In my opinion, `nannou`'s existing `Device`/`Host` API would have to be restructured to either allow batching of device queries (and spawn new `cpal` threads each time), or have a continual `cpal` thread with messaging to query devices (which seems overly complex).

**Changes**
- Disables drag and drop in audio examples.
    - **_Alternatively, drag and drop could be disabled by default on Windows -- would this be preferred?_**
- Adds new `WindowBuilder` method `windowsos_drag_and_drop(bool)`. 
    - I prefixed this with `windowsos_`, since `windows_` might be confused with a regular window.
    - The method does nothing on non-Windows OS.
- Adds `stream.play()` to each stream upon initialization.
    - This is required for the examples to work on Windows, since it [allows the callbacks to be called](https://github.com/RustAudio/cpal/issues/516#issuecomment-745238626).
