### PR TITLE
Add community tutorials, disable warnings in conditional compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ It is still early days and there is a lot of work to be done. Feel free to help 
   - [**Create A Project**](https://www.guide.nannou.cc/getting_started/create_a_project.html)
   - [**Upgrading to a New Release**](https://guide.nannou.cc/getting_started/upgrading.html)
 - [**Tutorials**](https://www.guide.nannou.cc/tutorials.html)
+- [**Community Tutorials**](https://www.guide.nannou.cc/community_tutorials.html)
 - [**Developer Reference**](https://www.guide.nannou.cc/developer_reference.html)
 - [**API Reference**](https://www.guide.nannou.cc/api_reference.html)
 - [**Showcases**](https://www.guide.nannou.cc/showcases.html)

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -20,6 +20,7 @@
     - [Draw - Drawing Images](./tutorials/draw/drawing-images.md)
     - [OSC - Introduction](./tutorials/osc/osc-introduction.md)
     - [OSC - Sending OSC](./tutorials/osc/osc-sender.md)
+- [Community Tutorials](./community_tutorials.md)
 - [Contributing](./contributing.md)
     - [About the Codebase](./contributing/about-the-codebase.md)
     - [PR Checklist](./contributing/pr-checklist.md)

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -17,6 +17,8 @@ back to the origins.
   automatically by the nannou `App`. The easiest approach is to register a
   `raw_event` function with the `Ui`'s window. Refer to the updated examples for
   demonstration.
+- Fix audio examples on Windows by adding `WindowBuilder` method `windowsos_drag_and_drop`. Disabling this allows `cpal` and `winit` to coexist on the same thread.
+- Add community tutorials section to the guide.
 
 ---
 

--- a/guide/src/community_tutorials.md
+++ b/guide/src/community_tutorials.md
@@ -1,0 +1,5 @@
+# Community Tutorials
+
+This is a collection of tutorials by the community.
+
++ **["Schotter Four Ways"](https://github.com/sidwellr/schotter).**	A comprehensive generative art tutorial by Rick Sidwell introducing Rust workspaces, sketches vs. apps, multiple windows, image capture, keyboard input, and user interfaces.

--- a/guide/src/welcome.md
+++ b/guide/src/welcome.md
@@ -31,6 +31,8 @@ A suite of tutorials demonstrating how to do different things with Nannou. For
 example, "How do I output sounds?", "How do I draw shapes?", "How can I connect
 to my laser?"
 
+> You can find more tutorials by the community [here](/community_tutorials.md).
+
 ### [Developer Reference](/developer_reference.md)
 
 Learn more about the design philosophy behind Nannou, how the project is

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -995,12 +995,13 @@ impl<'app> Builder<'app> {
         self.map_window(|w| w.with_window_icon(window_icon))
     }
 
-    /// On Windows only, enables or disables drag and drop onto the window.
-    /// On non-Windows, drag and drop is enabled and this function has no effect.
-    /// To use `nannou_audio` on Windows on the same thread, disable drag and drop.
+    /// On Windows only, enables or disables drag & drop onto the window.
+    /// On non-Windows, drag & drop is enabled and this function has no effect.
+    /// To use `nannou_audio` on Windows on the same thread, disable this.
     ///
-    /// NOTE: Drag and drop requires multi-threaded COM, which can interfere with
+    /// NOTE: Drag & drop requires multi-threaded COM, which can interfere with
     /// other crates such as `cpal` and `nannou_audio` on the same thread.
+    #[allow(unused_variables)]
     pub fn windowsos_drag_and_drop(self, drag_and_drop: bool) -> Self {
         #[cfg(target_os = "windows")]
         {


### PR DESCRIPTION
- Add community tutorials section to guide.
- Disable conditional compilation warning (to resolve unused variable warning on non-Windows from #773).
- Update changelog.