### PR TITLE
Specifying an initial, default LoopMode.

### DIFF
--- a/examples/nannou_basics/loop_mode.rs
+++ b/examples/nannou_basics/loop_mode.rs
@@ -10,14 +10,16 @@
 use nannou::prelude::*;
 
 fn main() {
-    nannou::app(model).update(update).run();
+    // Start in `Wait` mode. In other words, don't keep looping, just wait for events.
+    nannou::app(model)
+        .loop_mode(LoopMode::Wait)
+        .update(update)
+        .run();
 }
 
 struct Model;
 
 fn model(app: &App) -> Model {
-    // Start in `Wait` mode. In other words, don't keep looping, just wait for events.
-    app.set_loop_mode(LoopMode::Wait);
     let _window = app
         .new_window()
         .title(format!(

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -22,6 +22,8 @@ back to the origins.
 - Provided an user-friendly way to get the character value of a pressed keyboard key.
 - Clear swapchain background automatically when re-allocated. Can set the clear color via `WindowBuilder::clear_color()`.
 - Remove `windowsos_drag_and_drop()`, since `cpal` and `winit` can now share a thread.
+- Provided a method which allows users to specify an initial default `LoopMode` in both `SketchBuilder` and `Builder`.
+  Updated the relevant example to showcase the new functionality.
 
 ---
 

--- a/nannou_timeline/src/track/mod.rs
+++ b/nannou_timeline/src/track/mod.rs
@@ -15,7 +15,7 @@ pub trait Widget: conrod::Widget {
     /// Build the widget with the given playhead position and delta in ticks.
     ///
     /// If this method is not overridden, the playhead will be ignored.
-    fn playhead(self, (time::Ticks, time::Ticks)) -> Self {
+    fn playhead(self, _: (time::Ticks, time::Ticks)) -> Self {
         self
     }
 }


### PR DESCRIPTION
Created two methods, for `SketchBuilder` and `Builder` respectively, which allow for specifying an initial LoopMode. Updated the relevant example to showcase the new functionality and fixed an unrelated, lingering code warning.

This resolves #528.