### PR TITLE
Remove Windows drag-and-drop method

### DIFF
--- a/examples/audio/feedback.rs
+++ b/examples/audio/feedback.rs
@@ -26,7 +26,6 @@ struct OutputModel {
 fn model(app: &App) -> Model {
     // Create a window to receive key pressed events.
     app.new_window()
-        .windowsos_drag_and_drop(false) // Required for Windows (no effect otherwise)
         .key_pressed(key_pressed)
         .view(view)
         .build()

--- a/examples/audio/hrtf-noise.rs
+++ b/examples/audio/hrtf-noise.rs
@@ -66,7 +66,6 @@ impl HrtfData {
 
 fn model(app: &App) -> Model {
     app.new_window()
-        .windowsos_drag_and_drop(false) // Required for Windows (no effect otherwise)
         .size(WINDOW_SIDE, WINDOW_SIDE)
         .key_pressed(key_pressed)
         .mouse_moved(mouse_moved)

--- a/examples/audio/record_wav.rs
+++ b/examples/audio/record_wav.rs
@@ -25,7 +25,6 @@ struct CaptureModel {
 fn model(app: &App) -> Model {
     // Create a window to receive key pressed events.
     app.new_window()
-        .windowsos_drag_and_drop(false) // Required for Windows (no effect otherwise)
         .key_pressed(key_pressed)
         .view(view)
         .build()

--- a/examples/audio/simple_audio.rs
+++ b/examples/audio/simple_audio.rs
@@ -19,7 +19,6 @@ struct Audio {
 fn model(app: &App) -> Model {
     // Create a window to receive key pressed events.
     app.new_window()
-        .windowsos_drag_and_drop(false) // Required for Windows (no effect otherwise)
         .key_pressed(key_pressed)
         .view(view)
         .build()

--- a/examples/audio/simple_audio_file.rs
+++ b/examples/audio/simple_audio_file.rs
@@ -17,7 +17,6 @@ struct Audio {
 fn model(app: &App) -> Model {
     // Create a window to receive key pressed events.
     app.new_window()
-        .windowsos_drag_and_drop(false) // Required for Windows (no effect otherwise)
         .key_pressed(key_pressed)
         .view(view)
         .build()

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -20,6 +20,8 @@ back to the origins.
 - Fix audio examples on Windows by adding `WindowBuilder` method `windowsos_drag_and_drop`. Disabling this allows `cpal` and `winit` to coexist on the same thread.
 - Add community tutorials section to the guide.
 - Provided an user-friendly way to get the character value of a pressed keyboard key.
+- Clear swapchain background automatically when re-allocated. Can set the clear color via `WindowBuilder::clear_color()`.
+- Remove `windowsos_drag_and_drop()`, since `cpal` and `winit` can now share a thread.
 
 ---
 

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -23,9 +23,6 @@ use winit::dpi::{LogicalSize, PhysicalSize};
 pub use winit::window::Fullscreen;
 pub use winit::window::WindowId as Id;
 
-#[cfg(target_os = "windows")]
-use winit::platform::windows::WindowBuilderExtWindows;
-
 /// The default dimensions used for a window in the case that none are specified.
 pub const DEFAULT_DIMENSIONS: LogicalSize<geom::scalar::Default> = LogicalSize {
     width: 1024.0,
@@ -1039,24 +1036,6 @@ impl<'app> Builder<'app> {
     /// Sets the window icon.
     pub fn window_icon(self, window_icon: Option<winit::window::Icon>) -> Self {
         self.map_window(|w| w.with_window_icon(window_icon))
-    }
-
-    /// On Windows only, enables or disables drag & drop onto the window.
-    /// On non-Windows, drag & drop is enabled and this function has no effect.
-    /// To use `nannou_audio` on Windows on the same thread, disable this.
-    ///
-    /// NOTE: Drag & drop requires multi-threaded COM, which can interfere with
-    /// other crates such as `cpal` and `nannou_audio` on the same thread.
-    #[allow(unused_variables)]
-    pub fn windowsos_drag_and_drop(self, drag_and_drop: bool) -> Self {
-        #[cfg(target_os = "windows")]
-        {
-            self.map_window(|w| w.with_drag_and_drop(drag_and_drop))
-        }
-        #[cfg(not(target_os = "windows"))]
-        {
-            self
-        }
     }
 }
 


### PR DESCRIPTION
Removes Windows-specific option to disable drag-and-drop.

This function was originally included to allow `cpal` and `winit` to co-exist on the same thread. However, [`cpal` now uses a compatible threading model](https://github.com/RustAudio/cpal/pull/597).