### PR TITLE
Remove daggy (unused dependency)

### DIFF
--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -11,7 +11,6 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dependencies]
-daggy = "0.6"
 find_folder = "0.3"
 futures = { version = "0.3", features = ["executor", "thread-pool"] }
 image = "0.23"

--- a/nannou/src/lib.rs
+++ b/nannou/src/lib.rs
@@ -13,7 +13,6 @@
 //! examples](https://github.com/nannou-org/nannou/tree/master/examples) to get an idea of how
 //! nannou applications are structured and how the API works.
 
-pub use daggy;
 pub use find_folder;
 pub use lyon;
 pub use winit;


### PR DESCRIPTION
Since daggy isn't used anywhere in the crate, this just bumps the version number in `nannou/Cargo.toml`.