### PR TITLE
Update lyon to version 0.17

### DIFF
--- a/generative_design/data_trees/m_5_1_01.rs
+++ b/generative_design/data_trees/m_5_1_01.rs
@@ -24,6 +24,7 @@
  * 0-9                 : recursion level
  * s                   : save png
  */
+use nannou::lyon;
 use nannou::prelude::*;
 
 fn main() {
@@ -70,9 +71,14 @@ fn view(app: &App, model: &Model, frame: Frame) {
 // Recursive function
 fn draw_branch(draw: &Draw, x: f32, y: f32, radius: f32, level: u8, mx: f32, my: f32) {
     use nannou::geom::path::Builder;
-    let mut builder = Builder::new();
-    builder = builder.move_to(pt2(x - radius, y));
-    builder = builder.arc(pt2(x, y), vec2(radius, radius), -PI, 0.0);
+    let mut builder = Builder::new().with_svg();
+    builder.move_to(lyon::math::point(x - radius, y));
+    builder.arc(
+        lyon::math::point(x, y),
+        lyon::math::vector(radius, radius),
+        -lyon::math::Angle::pi(),
+        lyon::math::Angle::radians(0.0),
+    );
     let arc_path = builder.build();
 
     // draw arc

--- a/generative_design/shape/p_2_2_3_01.rs
+++ b/generative_design/shape/p_2_2_3_01.rs
@@ -30,6 +30,7 @@
  * Delete/Backspace    : clear display
  * s                   : save png
  */
+use nannou::lyon;
 use nannou::prelude::*;
 
 fn main() {
@@ -97,33 +98,32 @@ fn view(app: &App, model: &Model, frame: Frame) {
         draw.background().color(WHITE);
     }
 
-    let mut builder = nannou::geom::path::Builder::new();
+    let mut builder = nannou::geom::path::Builder::new().with_svg();
 
     // TODO implement the Catmull–Rom spline algo in lyon, see curveVertex() in Processing
     // first control point
-    builder = builder.move_to(pt2(
+    builder.move_to(lyon::math::point(
         model.x[model.form_resolution - 1] + model.center_x,
         model.y[model.form_resolution - 1] + model.center_y,
     ));
     // only these points are drawn
     for i in 0..model.form_resolution {
-        builder = builder.quadratic_bezier_to(
-            pt2(model.x[i] + model.center_x, model.y[i] + model.center_y),
-            pt2(model.x[i] + model.center_x, model.y[i] + model.center_y),
+        builder.quadratic_bezier_to(
+            lyon::math::point(model.x[i] + model.center_x, model.y[i] + model.center_y),
+            lyon::math::point(model.x[i] + model.center_x, model.y[i] + model.center_y),
         );
     }
-    let path = builder
-        .quadratic_bezier_to(
-            pt2(model.x[0] + model.center_x, model.y[0] + model.center_y),
-            pt2(model.x[0] + model.center_x, model.y[0] + model.center_y),
-        )
-        // end control point
-        .move_to(pt2(
-            model.x[1] + model.center_x,
-            model.y[1] + model.center_y,
-        ))
-        .close()
-        .build();
+    builder.quadratic_bezier_to(
+        lyon::math::point(model.x[0] + model.center_x, model.y[0] + model.center_y),
+        lyon::math::point(model.x[0] + model.center_x, model.y[0] + model.center_y),
+    );
+    // end control point
+    builder.move_to(lyon::math::point(
+        model.x[1] + model.center_x,
+        model.y[1] + model.center_y,
+    ));
+    builder.close();
+    let path = builder.build();
 
     if model.filled {
         let gray = random_f32();

--- a/generative_design/type/p_3_2_1_01.rs
+++ b/generative_design/type/p_3_2_1_01.rs
@@ -32,7 +32,6 @@ use nannou::lyon;
 use nannou::lyon::algorithms::path::math::Point;
 use nannou::lyon::algorithms::path::PathSlice;
 use nannou::lyon::algorithms::walk::{walk_along_path, RepeatedPattern};
-use nannou::lyon::path::builder::PathBuilder;
 use nannou::lyon::path::iterator::*;
 use nannou::prelude::*;
 
@@ -72,7 +71,6 @@ fn view(app: &App, model: &Model, frame: Frame) {
     for e in text.path_events() {
         builder.path_event(e);
     }
-    builder.close();
     let path = builder.build();
 
     let mut path_points: Vec<lyon::path::math::Point> = Vec::new();

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -16,7 +16,7 @@ find_folder = "0.3"
 futures = { version = "0.3", features = ["executor", "thread-pool"] }
 image = "0.23"
 instant = "0.1.9"
-lyon = "0.15"
+lyon = "0.17"
 nannou_core = { version ="0.17.0", path = "../nannou_core", features = ["std", "serde"] }
 nannou_mesh = { version ="0.17.0", path = "../nannou_mesh", features = ["serde1"] }
 nannou_wgpu = { version ="0.17.0", path = "../nannou_wgpu", features = ["capturer"] }

--- a/nannou/src/draw/mesh/builder.rs
+++ b/nannou/src/draw/mesh/builder.rs
@@ -11,7 +11,7 @@ use crate::glam::Mat4;
 use lyon::tessellation::geometry_builder::{
     self, FillGeometryBuilder, GeometryBuilder, StrokeGeometryBuilder,
 };
-use lyon::tessellation::{FillAttributes, GeometryBuilderError, StrokeAttributes, VertexId};
+use lyon::tessellation::{FillVertex, GeometryBuilderError, StrokeVertex, VertexId};
 
 pub struct MeshBuilder<'a, A> {
     /// The mesh that is to be extended.
@@ -93,13 +93,11 @@ impl<'a, A> GeometryBuilder for MeshBuilder<'a, A> {
 }
 
 impl<'a> FillGeometryBuilder for MeshBuilder<'a, SingleColor> {
-    fn add_fill_vertex(
-        &mut self,
-        position: lyon::math::Point,
-        _attrs: FillAttributes,
-    ) -> Result<VertexId, GeometryBuilderError> {
+    fn add_fill_vertex(&mut self, vertex: FillVertex) -> Result<VertexId, GeometryBuilderError> {
         // Retrieve the index.
         let id = VertexId::from_usize(self.mesh.points().len());
+
+        let position = vertex.position();
 
         // Construct and insert the point
         let p = Point2::new(position.x, position.y).extend(0.0);
@@ -117,11 +115,12 @@ impl<'a> FillGeometryBuilder for MeshBuilder<'a, SingleColor> {
 impl<'a> StrokeGeometryBuilder for MeshBuilder<'a, SingleColor> {
     fn add_stroke_vertex(
         &mut self,
-        position: lyon::math::Point,
-        _attrs: StrokeAttributes,
+        vertex: StrokeVertex,
     ) -> Result<VertexId, GeometryBuilderError> {
         // Retrieve the index.
         let id = VertexId::from_usize(self.mesh.points().len());
+
+        let position = vertex.position();
 
         // Construct and insert the point
         let p = Point2::new(position.x, position.y).extend(0.0);
@@ -139,16 +138,17 @@ impl<'a> StrokeGeometryBuilder for MeshBuilder<'a, SingleColor> {
 impl<'a> FillGeometryBuilder for MeshBuilder<'a, ColorPerPoint> {
     fn add_fill_vertex(
         &mut self,
-        position: lyon::math::Point,
-        mut attrs: FillAttributes,
+        mut vertex: FillVertex,
     ) -> Result<VertexId, GeometryBuilderError> {
         // Retrieve the index.
         let id = VertexId::from_usize(self.mesh.points().len());
 
+        let position = vertex.position();
+
         // Construct and insert the point
         let p = Point2::new(position.x, position.y).extend(0.0);
         let point = self.transform.transform_point3(p);
-        let col = &attrs.interpolated_attributes();
+        let col = vertex.interpolated_attributes();
         let color: draw::mesh::vertex::Color = (col[0], col[1], col[2], col[3]).into();
         let tex_coords = draw::mesh::vertex::default_tex_coords();
         let vertex = draw::mesh::vertex::new(point, color, tex_coords);
@@ -162,16 +162,17 @@ impl<'a> FillGeometryBuilder for MeshBuilder<'a, ColorPerPoint> {
 impl<'a> StrokeGeometryBuilder for MeshBuilder<'a, ColorPerPoint> {
     fn add_stroke_vertex(
         &mut self,
-        position: lyon::math::Point,
-        mut attrs: StrokeAttributes,
+        mut vertex: StrokeVertex,
     ) -> Result<VertexId, GeometryBuilderError> {
         // Retrieve the index.
         let id = VertexId::from_usize(self.mesh.points().len());
 
+        let position = vertex.position();
+
         // Construct and insert the point
         let p = Point2::new(position.x, position.y).extend(0.0);
         let point = self.transform.transform_point3(p);
-        let col = &attrs.interpolated_attributes();
+        let col = vertex.interpolated_attributes();
         let color: draw::mesh::vertex::Color = (col[0], col[1], col[2], col[3]).into();
         let tex_coords = draw::mesh::vertex::default_tex_coords();
         let vertex = draw::mesh::vertex::new(point, color, tex_coords);
@@ -185,16 +186,17 @@ impl<'a> StrokeGeometryBuilder for MeshBuilder<'a, ColorPerPoint> {
 impl<'a> FillGeometryBuilder for MeshBuilder<'a, TexCoordsPerPoint> {
     fn add_fill_vertex(
         &mut self,
-        position: lyon::math::Point,
-        mut attrs: FillAttributes,
+        mut vertex: FillVertex,
     ) -> Result<VertexId, GeometryBuilderError> {
         // Retrieve the index.
         let id = VertexId::from_usize(self.mesh.points().len());
 
+        let position = vertex.position();
+
         // Construct and insert the point
         let p = Point2::new(position.x, position.y).extend(0.0);
         let point = self.transform.transform_point3(p);
-        let tc = &attrs.interpolated_attributes();
+        let tc = vertex.interpolated_attributes();
         let tex_coords: draw::mesh::vertex::TexCoords = (tc[0], tc[1]).into();
         let color = draw::mesh::vertex::DEFAULT_VERTEX_COLOR;
         let vertex = draw::mesh::vertex::new(point, color, tex_coords);
@@ -208,16 +210,17 @@ impl<'a> FillGeometryBuilder for MeshBuilder<'a, TexCoordsPerPoint> {
 impl<'a> StrokeGeometryBuilder for MeshBuilder<'a, TexCoordsPerPoint> {
     fn add_stroke_vertex(
         &mut self,
-        position: lyon::math::Point,
-        mut attrs: StrokeAttributes,
+        mut vertex: StrokeVertex,
     ) -> Result<VertexId, GeometryBuilderError> {
         // Retrieve the index.
         let id = VertexId::from_usize(self.mesh.points().len());
 
+        let position = vertex.position();
+
         // Construct and insert the point
         let p = Point2::new(position.x, position.y).extend(0.0);
         let point = self.transform.transform_point3(p);
-        let tc = &attrs.interpolated_attributes();
+        let tc = vertex.interpolated_attributes();
         let tex_coords: draw::mesh::vertex::TexCoords = (tc[0], tc[1]).into();
         let color = draw::mesh::vertex::DEFAULT_VERTEX_COLOR;
         let vertex = draw::mesh::vertex::new(point, color, tex_coords);

--- a/nannou/src/draw/primitive/ellipse.rs
+++ b/nannou/src/draw/primitive/ellipse.rs
@@ -78,7 +78,7 @@ impl draw::renderer::RenderPrimitive for Ellipse {
                 let radii = lyon::math::vector(w * 0.5, h * 0.5);
                 if radii.square_length() > 0.0 {
                     let centre = lyon::math::point(0.0, 0.0);
-                    let mut builder = lyon::path::Path::builder();
+                    let mut builder = lyon::path::Path::svg_builder();
                     let sweep_angle = lyon::math::Angle::radians(std::f32::consts::PI * 2.0);
                     let x_rotation = lyon::math::Angle::radians(0.0);
                     let start = lyon::math::point(w * 0.5, 0.0);

--- a/nannou/src/draw/primitive/path.rs
+++ b/nannou/src/draw/primitive/path.rs
@@ -604,7 +604,7 @@ where
     let (first_point, first_color) = iter.next()?;
     let p = first_point.to_array().into();
     let (r, g, b, a) = first_color.into();
-    path_builder.move_to(p, &[r, g, b, a]);
+    path_builder.begin(p, &[r, g, b, a]);
 
     // Add the lines, keeping track of the last
     for (point, color) in iter {
@@ -613,10 +613,8 @@ where
         path_builder.line_to(p, &[r, g, b, a]);
     }
 
-    // Close if necessary.
-    if close {
-        path_builder.close();
-    }
+    // End the path, closing if necessary.
+    path_builder.end(close);
 
     // Build it!
     Some(path_builder.build())
@@ -636,7 +634,7 @@ where
     let (first_point, first_tex_coords) = iter.next()?;
     let p = first_point.to_array().into();
     let (tc_x, tc_y) = first_tex_coords.into();
-    path_builder.move_to(p, &[tc_x, tc_y]);
+    path_builder.begin(p, &[tc_x, tc_y]);
 
     // Add the lines, keeping track of the last
     for (point, tex_coords) in iter {
@@ -645,10 +643,8 @@ where
         path_builder.line_to(p, &[tc_x, tc_y]);
     }
 
-    // Close if necessary.
-    if close {
-        path_builder.close();
-    }
+    // End the path, closing if necessary.
+    path_builder.end(close);
 
     // Build it!
     Some(path_builder.build())


### PR DESCRIPTION
The bug in #799 has been fixed in lyon 0.17.10. This PR updates to the latest version of lyon, updating the affected code. However, this restricts the functionality of the `nannou::geom::path::Builder` since much of its interface has been moved to SVG-only builders. In particular functions like `move_to` and `arc` can only be used through a `lyon::path::builder::WithSvg<nannou::geom::path::Builder>` with the lyon-specific types, making them less user-friendly.

It would be possible to store a `WithSvg<Builder` directly in `nannou::geom::path::Builder` and implement the `SvgPathBuilder` trait instead of `PathBuilder` to restore much of the lost functionality. Although, I don't know if the added convenience is worth the added complexity, since the `Builder` API seems to be pretty low-level already. It might be better to just remove the `nannou::geom::path::Builder` entirely and just use the lyon types directly.

TODO:
- [ ] Add to changelog.