### PR TITLE
Fix window_coordinates example crash on Linux/Wayland

### DIFF
--- a/examples/nannou_basics/window_coordinates.rs
+++ b/examples/nannou_basics/window_coordinates.rs
@@ -68,51 +68,52 @@ fn view(app: &App, frame: Frame) {
         .y(y_off);
 
     // Window and monitor details.
-    let monitor = window.current_monitor().expect("Couldn't get monitor.");
-    let w_scale_factor = window.scale_factor();
-    let m_scale_factor = monitor.scale_factor();
-    let mon_phys = monitor.size();
-    let mon = mon_phys.to_logical(w_scale_factor as f64);
-    let mon_w: f32 = mon.width;
-    let mon_h: f32 = mon.height;
-    let text = format!(
-        "
-    Window size: [{:.0}, {:.0}]
-    Window ratio: {:.2}
-    Window scale factor: {:.2}
-    Monitor size: [{:.0}, {:.0}]
-    Monitor ratio: {:.2}
-    Monitor scale factor: {:.2}
-    ",
-        win.w(),
-        win.h(),
-        win.w() / win.h(),
-        w_scale_factor,
-        mon_w,
-        mon_h,
-        mon_w / mon_h,
-        m_scale_factor
-    );
-    let pad = 6.0;
-    draw.text(&text)
-        .h(win.pad(pad).h())
-        .w(win.pad(pad).w())
-        .line_spacing(pad)
-        .font_size(14)
-        .align_text_bottom()
-        .color(crosshair_color)
-        .left_justify();
+    if let Some(monitor) = window.current_monitor() {
+        let w_scale_factor = window.scale_factor();
+        let m_scale_factor = monitor.scale_factor();
+        let mon_phys = monitor.size();
+        let mon = mon_phys.to_logical(w_scale_factor as f64);
+        let mon_w: f32 = mon.width;
+        let mon_h: f32 = mon.height;
+        let text = format!(
+            "
+        Window size: [{:.0}, {:.0}]
+        Window ratio: {:.2}
+        Window scale factor: {:.2}
+        Monitor size: [{:.0}, {:.0}]
+        Monitor ratio: {:.2}
+        Monitor scale factor: {:.2}
+        ",
+            win.w(),
+            win.h(),
+            win.w() / win.h(),
+            w_scale_factor,
+            mon_w,
+            mon_h,
+            mon_w / mon_h,
+            m_scale_factor
+        );
+        let pad = 6.0;
+        draw.text(&text)
+            .h(win.pad(pad).h())
+            .w(win.pad(pad).w())
+            .line_spacing(pad)
+            .font_size(14)
+            .align_text_bottom()
+            .color(crosshair_color)
+            .left_justify();
 
-    // Ellipse at mouse.
-    draw.ellipse().wh([5.0; 2].into()).xy(app.mouse.position());
+        // Ellipse at mouse.
+        draw.ellipse().wh([5.0; 2].into()).xy(app.mouse.position());
 
-    // Mouse position text.
-    let mouse = app.mouse.position();
-    let pos = format!("[{:.1}, {:.1}]", mouse.x, mouse.y);
-    draw.text(&pos)
-        .xy(mouse + vec2(0.0, 20.0))
-        .font_size(14)
-        .color(WHITE);
+        // Mouse position text.
+        let mouse = app.mouse.position();
+        let pos = format!("[{:.1}, {:.1}]", mouse.x, mouse.y);
+        draw.text(&pos)
+            .xy(mouse + vec2(0.0, 20.0))
+            .font_size(14)
+            .color(WHITE);
+    }
 
     draw.to_frame(app, &frame).unwrap();
 }


### PR DESCRIPTION
On Linux/Wayland, it seems that sometimes `window.current_monitor()` can
return `None` when nothing has been drawn to the screen yet. When this
happens, simply skip most of the logic and draw an empty frame to the
screen. The next time `view()` is called, the `current_monitor()`
method will then return the correct value.

(See [this issue](https://github.com/rust-windowing/winit/issues/793) for more details.).