### PR TITLE
Publish version 0.18. Includes wgpu 0.11, lyon 0.17 and more

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,13 +18,13 @@ audrey = "0.3"
 futures = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 hrtf = "0.2"
-nannou = { version ="0.17.0", path = "../nannou" }
-nannou_audio = { version ="0.17.0", path = "../nannou_audio" }
-nannou_conrod = { version ="0.17.0", path = "../nannou_conrod" }
+nannou = { version ="0.18.0", path = "../nannou" }
+nannou_audio = { version ="0.18.0", path = "../nannou_audio" }
+nannou_conrod = { version ="0.18.0", path = "../nannou_conrod" }
 nannou_isf = { version = "0.1.0", path = "../nannou_isf" }
-nannou_laser = { version ="0.17.0", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
-nannou_osc = { version ="0.17.0", path = "../nannou_osc" }
-nannou_timeline = { version ="0.17.0", features = ["serde1"], path =  "../nannou_timeline" }
+nannou_laser = { version ="0.18.0", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
+nannou_osc = { version ="0.18.0", path = "../nannou_osc" }
+nannou_timeline = { version ="0.18.0", features = ["serde1"], path =  "../nannou_timeline" }
 pitch_calc = { version = "0.12", features = ["serde"] }
 time_calc = { version= "0.13", features = ["serde"] }
 walkdir = "2"

--- a/generative_design/Cargo.toml
+++ b/generative_design/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-nannou = { version ="0.17.0", path = "../nannou" }
+nannou = { version ="0.18.0", path = "../nannou" }
 usvg = "0.4"
 wikipedia = "0.3"
 

--- a/guide/book_tests/Cargo.toml
+++ b/guide/book_tests/Cargo.toml
@@ -16,6 +16,6 @@ skeptic = { git = "https://github.com/mitchmindtree/rust-skeptic", branch = "1.4
 # https://github.com/budziq/rust-skeptic/pull/121
 skeptic = { git = "https://github.com/mitchmindtree/rust-skeptic", branch = "1.45-extern" }
 #skeptic = "0.13"
-nannou = { version ="0.17.0", path = "../../nannou" }
-nannou_osc = { version ="0.17.0", path = "../../nannou_osc" }
+nannou = { version ="0.18.0", path = "../../nannou" }
+nannou_osc = { version ="0.18.0", path = "../../nannou_osc" }
 

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -7,10 +7,33 @@ back to the origins.
 
 # Unreleased
 
+*No unreleased changes yet!*
+
+---
+
+# Version 0.18.0 (2021-11-15)
+
 ### wgpu 0.9 -> 0.11
 
-- `resolver = "2"` is now required in the top-level cargo manifest. See the
-  nannou workspace's `Cargo.toml` for an example.
+**Note:** As of wgpu 0.10, all nannou projects now require either:
+
+1. The following line in their top-level cargo manifest:
+   ```toml
+   resolver = "2"
+   ```
+   OR
+2. All packages must use the 2021 edition (or later) of Rust, e.g.
+   ```toml
+   edition = "2021"
+   ```
+
+This requirement is due to wgpu 0.10's reliance on the new version of cargo's
+dependency resolver and how it unifies features. Without either of the above
+amendments, you will likely run into strange upstream compilation errors. You
+can read more about the cargo dependency resolver versions here:
+
+https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
+
 - As of wgpu 0.10, it is now pure Rust! No more SPIR-V cross.
 - The concept of the wgpu `SwapChain` has been removed by merging it into the
   `Surface`, simplifying internals and improving approachability.
@@ -32,7 +55,7 @@ For more details, see the wgpu CHANGELOG:
 - 0.10: https://github.com/gfx-rs/wgpu/blob/master/CHANGELOG.md#v010-2021-08-18
 - 0.11: https://github.com/gfx-rs/wgpu/blob/master/CHANGELOG.md#wgpu-011-2021-10-07
 
-### Other
+### General
 
 - Update `lyon` to version `0.17`.
 - Refactor the `nannou::mesh` module into a `nannou_mesh` crate, re-exported to

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version ="0.17.1"
+version ="0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"
@@ -16,9 +16,9 @@ futures = { version = "0.3", features = ["executor", "thread-pool"] }
 image = "0.23"
 instant = "0.1.9"
 lyon = "0.17"
-nannou_core = { version ="0.17.0", path = "../nannou_core", features = ["std", "serde"] }
-nannou_mesh = { version ="0.17.0", path = "../nannou_mesh", features = ["serde1"] }
-nannou_wgpu = { version ="0.17.0", path = "../nannou_wgpu", features = ["capturer"] }
+nannou_core = { version ="0.18.0", path = "../nannou_core", features = ["std", "serde"] }
+nannou_mesh = { version ="0.18.0", path = "../nannou_mesh", features = ["serde1"] }
+nannou_wgpu = { version ="0.18.0", path = "../nannou_wgpu", features = ["capturer"] }
 noise = "0.7"
 notosans = { version = "0.1", optional = true }
 num_cpus = "1"

--- a/nannou_audio/Cargo.toml
+++ b/nannou_audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_audio"
-version ="0.17.0"
+version ="0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The audio API for Nannou, the creative coding framework."
 readme = "README.md"

--- a/nannou_conrod/Cargo.toml
+++ b/nannou_conrod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_conrod"
-version = "0.17.0"
+version ="0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "Simplifies creating conrod GUIs in nannou apps."
 readme = "README.md"
@@ -13,7 +13,7 @@ edition = "2018"
 conrod_core = "0.76"
 conrod_wgpu = "0.76"
 conrod_winit = "0.76"
-nannou = { version = "0.17.0", path = "../nannou", default-features = false }
+nannou = { version ="0.18.0", path = "../nannou", default-features = false }
 # Must be synchronised with the version used in the nannou dependency.
 # Required for the winit event conversion function macro to work.
 winit = "0.25"

--- a/nannou_core/Cargo.toml
+++ b/nannou_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_core"
-version ="0.17.0"
+version ="0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The core components of nannou - a creative coding framework for Rust. Ideal for libraries and headless/embedded applications that use nannou."
 readme = "README.md"

--- a/nannou_isf/Cargo.toml
+++ b/nannou_isf/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "nannou_isf"
-version ="0.1.0"
+version = "0.1.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 edition = "2018"
 
 [dependencies]
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 isf = { git = "https://github.com/nannou-org/isf", branch = "master" }
-nannou = { version ="0.17.0", path = "../nannou", features = ["spirv"] }
+nannou = { version ="0.18.0", path = "../nannou", features = ["spirv"] }
 thiserror = "1"
 threadpool = "1"
 walkdir = "2"

--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_laser"
-version ="0.17.0"
+version ="0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 edition = "2018"

--- a/nannou_mesh/Cargo.toml
+++ b/nannou_mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_mesh"
-version = "0.17.0"
+version ="0.18.0"
 authors = ["mitchmindtree <mail@mitchellnordine.com>"]
 description = "The mesh abstraction shared between nannou's `Draw` and `Ui` abstractions."
 readme = "README.md"
@@ -10,7 +10,7 @@ homepage = "https://nannou.cc"
 edition = "2018"
 
 [dependencies]
-nannou_core = { version = "0.17.0", path = "../nannou_core" }
+nannou_core = { version ="0.18.0", path = "../nannou_core" }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [features]

--- a/nannou_new/Cargo.toml
+++ b/nannou_new/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_new"
-version ="0.17.0"
+version ="0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A tool for easily starting Nannou projects."
 readme = "README.md"

--- a/nannou_osc/Cargo.toml
+++ b/nannou_osc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_osc"
-version ="0.17.0"
+version ="0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The OSC API for Nannou, the creative coding framework."
 readme = "README.md"

--- a/nannou_package/Cargo.toml
+++ b/nannou_package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_package"
-version ="0.17.0"
+version ="0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "The build packaging tool for the Nannou Creative Coding Framework."
 readme = "README.md"

--- a/nannou_timeline/Cargo.toml
+++ b/nannou_timeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_timeline"
-version ="0.17.0"
+version ="0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A timeline widget, compatible with all conrod GUI projects."
 readme = "README.md"
@@ -27,6 +27,6 @@ serde1 = [
 ]
 
 [dev-dependencies]
-nannou = { version ="0.17.0", path = "../nannou" }
+nannou = { version ="0.18.0", path = "../nannou" }
 rand = "0.3.12"
 serde_json = "1.0"

--- a/nannou_wgpu/Cargo.toml
+++ b/nannou_wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_wgpu"
-version = "0.17.0"
+version ="0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "Items related to wgpu and its integration in nannou - a creative coding framework for Rust."
 readme = "README.md"

--- a/nature_of_code/Cargo.toml
+++ b/nature_of_code/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-nannou = { version ="0.17.0", path = "../nannou" }
+nannou = { version ="0.18.0", path = "../nannou" }
 
 # Chapter 1 Vectors
 [[example]]


### PR DESCRIPTION
This contains the update from `wgpu` version `0.9` to `0.11`, the new
`lyon` version `0.17`, the release of some newly refactored `nannou_*`
crates and many other fixes and tweaks.

See the updated changelog for details!

In particular:

> 
> **Note:** As of wgpu 0.10, all nannou projects now require either:
> 
> 1. The following line in their top-level cargo manifest:
>    ```toml
>    resolver = "2"
>    ```
>    OR
> 2. All packages must use the 2021 edition (or later) of Rust, e.g.
>    ```toml
>    edition = "2021"
>    ```
> 
> This requirement is due to wgpu 0.10's reliance on the new version of cargo's
> dependency resolver and how it unifies features. Without either of the above
> amendments, you will likely run into strange upstream compilation errors. You
> can read more about the cargo dependency resolver versions here:
> 
> https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions