### PR TITLE
Expose `begin()` method in `geom::path::Builder`

### DIFF
--- a/nannou/src/geom/path.rs
+++ b/nannou/src/geom/path.rs
@@ -95,6 +95,14 @@ impl Builder {
         lyon::path::builder::Flattened::new(self, tolerance)
     }
 
+    /// Sets the position in preparation for the next sub-path.
+    ///
+    /// If the current sub-path contains edges, this ends the sub-path without closing it.
+    pub fn begin(mut self, to: Point2) -> Self {
+        self.builder.begin(to.to_array().into());
+        self
+    }
+
     /// Adds a line segment to the current sub-path and sets the current position.
     pub fn line_to(mut self, to: Point2) -> Self {
         self.builder.line_to(to.to_array().into());


### PR DESCRIPTION
As part of the lyon 0.17 upgrade, the `move_to` method got removed from
the builder. This makes it impossible to start a path/subpath without
having to access the underlying lyon Builder.

This commit exposes the `begin()` method in nannou's Builder, which is
what `move_to` got renamed to in lyon.

closes: #806