### PR TITLE
Make Nannou run in WASM environment

### DIFF
--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version ="0.18.0"
+version = "0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"
@@ -30,6 +30,7 @@ serde_derive = "1"
 serde_json = "1"
 toml = "0.5"
 walkdir = "2"
+web-sys = { version = "0.3.55", optional = true }
 wgpu_upstream = { version = "0.11.1", package = "wgpu" }
 winit = "0.26"
 
@@ -38,4 +39,4 @@ default = ["notosans"]
 # Enables SPIR-V support in the `wgpu` module.
 spirv = ["nannou_wgpu/spirv"]
 # Enables experimental WASM compilation for CI-use only
-wasm-experimental = ["getrandom/js", "wgpu_upstream/webgl", "async-std/unstable"]
+wasm-experimental = ["getrandom/js", "web-sys", "wgpu_upstream/webgl", "async-std/unstable"]

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -862,6 +862,21 @@ impl<'app> Builder<'app> {
             window.build(window_target)?
         };
 
+        #[cfg(target_arch = "wasm32")]
+        {
+            use winit::platform::web::WindowExtWebSys;
+            let canvas = window.canvas();
+
+            web_sys::window()
+                .expect("window")
+                .document()
+                .expect("document")
+                .body()
+                .expect("body")
+                .append_child(&canvas)
+                .expect("append_child");
+        }
+
         // Build the wgpu surface.
         let surface = unsafe { app.instance().create_surface(&window) };
 


### PR DESCRIPTION
I managed to execute my synthesizer [microwave](https://github.com/Woyten/tune/tree/master/microwave) in Firefox using WGPU's WebGL2 backend. A running demo can be tested [here](https://woyten.github.io/microwave/). The graphics is super fast but the audio (without any parameter tuning) is surprisingly slow and underruns on my Firefox. As a side note, audio has always been a problem during my WASM experiments and seems to be a weak point of CPAL.

The path to WASM via WebGL seems straightforward:
- Adapt the code s.t. it can be compiled to WASM (#702 and #715)
- Expose some `async` Nannou functions since blocking is unsupported in browsers (#815)
- Use `wgpu`'s `webgl` feature (#822)
- Add `Backends::GL` to the list of default backends (#812)
- Reduce the device limits to `Limits::downlevel_webgl2_defaults()` (See https://github.com/Woyten/tune/commits/wasm)
- Attach the created windows to the DOM (this PR)