### PR TITLE
Add GL backend to default backends for better WASM support

### DIFF
--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -431,7 +431,7 @@ where
 
     /// Specify the set of preferred WGPU backends.
     ///
-    /// By default, this is `wgpu::Backends::PRIMARY`.
+    /// By default, this is `wgpu::Backends::PRIMARY | wgpu::Backends::GL`.
     pub fn backends(mut self, backends: wgpu::Backends) -> Self {
         self.backends = backends;
         self

--- a/nannou_wgpu/src/lib.rs
+++ b/nannou_wgpu/src/lib.rs
@@ -104,7 +104,7 @@ pub use wgpu_upstream::{
 pub const DEFAULT_POWER_PREFERENCE: PowerPreference = PowerPreference::HighPerformance;
 
 /// Nannou's default WGPU backend preferences.
-pub const DEFAULT_BACKENDS: Backends = Backends::PRIMARY;
+pub const DEFAULT_BACKENDS: Backends = Backends::PRIMARY.union(Backends::GL);
 
 /// Create a wgpu shader module from the given slice of SPIR-V bytes.
 #[cfg(feature = "spirv")]


### PR DESCRIPTION
To enable WASM support in Nannou we should aim for WPGU's WebGL2 backend first since WebGPU support in browsers is still very experimental.

This PR proposes to add `Backends::GL` to the list of default backends s.t. running a Nannou app in the browser does not fail with `BuildError::NoAvailableAdapter`.