### PR TITLE
Update wgpu and winit to the latest version

### DIFF
--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -29,8 +29,8 @@ serde_derive = "1"
 serde_json = "1"
 toml = "0.5"
 walkdir = "2"
-wgpu_upstream = { version = "0.11", package = "wgpu" }
-winit = "0.25"
+wgpu_upstream = { version = "0.11.1", package = "wgpu" }
+winit = "0.26"
 
 [features]
 default = ["notosans"]

--- a/nannou_conrod/Cargo.toml
+++ b/nannou_conrod/Cargo.toml
@@ -16,7 +16,7 @@ conrod_winit = "0.76"
 nannou = { version ="0.18.0", path = "../nannou", default-features = false }
 # Must be synchronised with the version used in the nannou dependency.
 # Required for the winit event conversion function macro to work.
-winit = "0.25"
+winit = "0.26"
 
 [features]
 default = ["notosans"]

--- a/nannou_wgpu/Cargo.toml
+++ b/nannou_wgpu/Cargo.toml
@@ -14,7 +14,7 @@ futures = { version = "0.3", features = ["executor", "thread-pool"] }
 image = { version = "0.23", optional = true }
 instant = { version = "0.1.9", optional = true }
 num_cpus = { version = "1", optional = true }
-wgpu_upstream = { version = "0.11", package = "wgpu" }
+wgpu_upstream = { version = "0.11.1", package = "wgpu" }
 
 [features]
 capturer = ["image", "instant", "num_cpus"]


### PR DESCRIPTION
This PR explicitly lifts wgpu to 0.11.1 which fixes some driver compatibility regressions and is compatible with winit 0.26.0.
winit 0.26.0 has the `web-sys` feature flag removed which I take as a commitment to builtin / reliable WASM support.

Not entirely sure about it but I think this PR also lifts the `rustflags = ["--cfg", "web_sys_unstable_apis"]` requirement of #715. As a result I propose to merge this PR before #715.