### PR TITLE
Add async twin functions for WASM support

### DIFF
--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -728,6 +728,10 @@ impl<'app> Builder<'app> {
 
     /// Builds the window, inserts it into the `App`'s display map and returns the unique ID.
     pub fn build(self) -> Result<Id, BuildError> {
+        futures::executor::block_on(self.build_async())
+    }
+
+    pub async fn build_async(self) -> Result<Id, BuildError> {
         let Builder {
             app,
             mut window,
@@ -854,12 +858,13 @@ impl<'app> Builder<'app> {
         };
         let adapter = app
             .wgpu_adapters()
-            .get_or_request(request_adapter_opts, app.instance())
+            .get_or_request_async(request_adapter_opts, app.instance())
+            .await
             .ok_or(BuildError::NoAvailableAdapter)?;
 
         // Instantiate the logical device.
         let device_desc = device_desc.unwrap_or_else(wgpu::default_device_descriptor);
-        let device_queue_pair = adapter.get_or_request_device(device_desc);
+        let device_queue_pair = adapter.get_or_request_device_async(device_desc).await;
 
         // Configure the surface.
         let win_physical_size = window.inner_size();


### PR DESCRIPTION
This PR exposes a set of `async` functions that are sufficient to run a Nannou app on WASM. The change is conservative i.e. it only exposes a minimal set of functions and it preserves the behavior of the old non-`async` functions.