### PR TITLE
Set window class for X11 running apps

### DIFF
--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -758,11 +758,11 @@ impl<'app> Builder<'app> {
         // Set the class type for X11 if WindowExtUnix trait is compiled in winit
         // (see lines https://docs.rs/winit/0.26.0/src/winit/platform/unix.rs.html#1-7)
         #[cfg(any(
-                target_os = "linux",
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "netbsd",
-                target_os = "openbsd"
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
         ))]
         {
             use winit::platform::unix::WindowBuilderExtUnix;

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -755,9 +755,11 @@ impl<'app> Builder<'app> {
             }
         }
 
-        // Set the class type for X11
-        use winit::platform::unix::WindowBuilderExtUnix;
-        window = window.with_class("nannou".to_string(), "nannou".to_string());
+        // Set the class type for X11 if running unix family.
+        if cfg!(unix) {
+            use winit::platform::unix::WindowBuilderExtUnix;
+            window = window.with_class("nannou".to_string(), "nannou".to_string());
+        }
 
         // Set default dimensions in the case that none were given.
         let initial_window_size = window

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -755,8 +755,16 @@ impl<'app> Builder<'app> {
             }
         }
 
-        // Set the class type for X11 if running unix family.
-        if cfg!(unix) {
+        // Set the class type for X11 if WindowExtUnix trait is compiled in winit
+        // (see lines https://docs.rs/winit/0.26.0/src/winit/platform/unix.rs.html#1-7)
+        #[cfg(any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+        ))]
+        {
             use winit::platform::unix::WindowBuilderExtUnix;
             window = window.with_class("nannou".to_string(), "nannou".to_string());
         }

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -755,6 +755,10 @@ impl<'app> Builder<'app> {
             }
         }
 
+        // Set the class type for X11
+        use winit::platform::unix::WindowBuilderExtUnix;
+        window = window.with_class("nannou".to_string(), "nannou".to_string());
+
         // Set default dimensions in the case that none were given.
         let initial_window_size = window
             .window


### PR DESCRIPTION
When running window managers such `i3`, it is nice to be able to specify rules for certain classes of windows. Currently, `nannou` doesn't set this attribute when making a X11 window, thus the `class` attribute in X11 is set to the window title by default.

This PR adds `nannou` as the window class, so that you can for example in `i3` put this in your config file to open all nannou windows as floating windows:
```
for_window [class="nannou"] floating enabled
```

Since `X` is running on multiple OSes, I have not added any config check for this. This will only have effect on systems actually running `X`.

