### PR TITLE
Enable wgpu/webgl when WASM feature is enabled

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.wasm32-unknown-unknown]
-rustflags = ["--cfg", "web_sys_unstable_apis"]

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -38,4 +38,4 @@ default = ["notosans"]
 # Enables SPIR-V support in the `wgpu` module.
 spirv = ["nannou_wgpu/spirv"]
 # Enables experimental WASM compilation for CI-use only
-wasm-experimental = ["getrandom/js"]
+wasm-experimental = ["getrandom/js", "wgpu_upstream/webgl"]


### PR DESCRIPTION
This PR is another split-off of #811. It enables `wgpu/webgl` when the `nannou/wasm-experimental` is active. It also removes the strange `.cargo/config.toml` file which seems not to be required when using `winit 0.26.0`.