### PR TITLE
Fix #826 / Use async-std instead of futures

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,8 +14,8 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
+async-std = "1.10.0"
 audrey = "0.3"
-futures = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 hrtf = "0.2"
 nannou = { version ="0.18.0", path = "../nannou" }

--- a/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
+++ b/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
@@ -12,7 +12,6 @@ use std::sync::{Arc, Mutex};
 struct Model {
     compute: Compute,
     oscillators: Arc<Mutex<Vec<f32>>>,
-    threadpool: futures::executor::ThreadPool,
 }
 
 struct Compute {
@@ -91,13 +90,9 @@ fn model(app: &App) -> Model {
     // The vector that we will write oscillator values to.
     let oscillators = Arc::new(Mutex::new(vec![0.0; OSCILLATOR_COUNT as usize]));
 
-    // Create a thread pool capable of running our GPU buffer read futures.
-    let threadpool = futures::executor::ThreadPool::new().unwrap();
-
     Model {
         compute,
         oscillators,
-        threadpool,
     }
 }
 
@@ -175,7 +170,7 @@ fn update(app: &App, model: &mut Model, _update: Update) {
             }
         }
     };
-    model.threadpool.spawn_ok(future);
+    async_std::task::spawn(future);
 
     // Check for resource cleanups and mapping callbacks.
     //

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -11,8 +11,8 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dependencies]
+async-std = "1.10.0"
 find_folder = "0.3"
-futures = { version = "0.3", features = ["executor", "thread-pool"] }
 getrandom = "0.2.3"
 image = "0.23"
 instant = "0.1.9"
@@ -38,4 +38,4 @@ default = ["notosans"]
 # Enables SPIR-V support in the `wgpu` module.
 spirv = ["nannou_wgpu/spirv"]
 # Enables experimental WASM compilation for CI-use only
-wasm-experimental = ["getrandom/js", "wgpu_upstream/webgl"]
+wasm-experimental = ["getrandom/js", "wgpu_upstream/webgl", "async-std/unstable"]

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -451,7 +451,7 @@ where
     /// thread as some platforms require that their application event loop and windows are
     /// initialised on the main thread.
     pub fn run(self) {
-        futures::executor::block_on(self.run_async())
+        async_std::task::block_on(self.run_async())
     }
 
     pub async fn run_async(self) {

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -726,9 +726,10 @@ impl<'app> Builder<'app> {
         self
     }
 
+    #[cfg(not(target_os = "unknown"))]
     /// Builds the window, inserts it into the `App`'s display map and returns the unique ID.
     pub fn build(self) -> Result<Id, BuildError> {
-        futures::executor::block_on(self.build_async())
+        async_std::task::block_on(self.build_async())
     }
 
     pub async fn build_async(self) -> Result<Id, BuildError> {

--- a/nannou_wgpu/Cargo.toml
+++ b/nannou_wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_wgpu"
-version ="0.18.0"
+version = "0.18.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "Items related to wgpu and its integration in nannou - a creative coding framework for Rust."
 readme = "README.md"
@@ -10,7 +10,7 @@ homepage = "https://nannou.cc"
 edition = "2018"
 
 [dependencies]
-futures = { version = "0.3", features = ["executor", "thread-pool"] }
+async-std = "1.10.0"
 image = { version = "0.23", optional = true }
 instant = { version = "0.1.9", optional = true }
 num_cpus = { version = "1", optional = true }

--- a/nannou_wgpu/src/device_map.rs
+++ b/nannou_wgpu/src/device_map.rs
@@ -63,6 +63,7 @@ pub struct DeviceQueuePair {
 }
 
 impl AdapterMap {
+    #[cfg(not(target_os = "unknown"))]
     /// Check for an adaptor with the given options or request one.
     ///
     /// First checks to see if an adapter for the given set of options is active. If so, returns a
@@ -74,9 +75,10 @@ impl AdapterMap {
         options: wgpu::RequestAdapterOptions<'b>,
         instance: &'a wgpu::Instance,
     ) -> Option<Arc<ActiveAdapter>> {
-        futures::executor::block_on(self.get_or_request_async(options, instance))
+        async_std::task::block_on(self.get_or_request_async(options, instance))
     }
 
+    #[cfg(not(target_os = "unknown"))]
     /// Request an adaptor with the given options.
     ///
     /// This will always request a new adapter and will never attempt to share an existing one. The
@@ -89,7 +91,7 @@ impl AdapterMap {
         options: wgpu::RequestAdapterOptions<'b>,
         instance: &'a wgpu::Instance,
     ) -> Option<Arc<ActiveAdapter>> {
-        futures::executor::block_on(self.request_async(options, instance))
+        async_std::task::block_on(self.request_async(options, instance))
     }
 
     /// The async implementation of `get_or_request`.
@@ -167,6 +169,7 @@ impl AdapterMap {
 }
 
 impl ActiveAdapter {
+    #[cfg(not(target_os = "unknown"))]
     /// Check for a device with the given descriptor or request one.
     ///
     /// First checks for a connected device that matches the given descriptor. If one exists, it is
@@ -175,9 +178,10 @@ impl ActiveAdapter {
         &self,
         descriptor: wgpu::DeviceDescriptor<'static>,
     ) -> Arc<DeviceQueuePair> {
-        futures::executor::block_on(self.get_or_request_device_async(descriptor))
+        async_std::task::block_on(self.get_or_request_device_async(descriptor))
     }
 
+    #[cfg(not(target_os = "unknown"))]
     /// Request a device with the given descriptor.
     ///
     /// This will always request a new device connection and will never attempt to share an
@@ -187,7 +191,7 @@ impl ActiveAdapter {
         &self,
         descriptor: wgpu::DeviceDescriptor<'static>,
     ) -> Arc<DeviceQueuePair> {
-        futures::executor::block_on(self.request_device_async(descriptor))
+        async_std::task::block_on(self.request_device_async(descriptor))
     }
 
     /// Check for a device with the given descriptor or request one.


### PR DESCRIPTION
This PR fixes #826 without reverting the `async` functions.

Since I didn't manage to make the code run using the `futures` library I tried using `async-std` instead which I perceive as a very solid `async` replacement for `std`.

One problem remains: Nannou is not terminating properly. It might have something to do with daemon threads now being non-daemon threads.



