### PR TITLE
Add  `Grayscale` arm in `generative_design/color/p_1_2_2_01.rs`

### DIFF
--- a/generative_design/color/p_1_2_2_01.rs
+++ b/generative_design/color/p_1_2_2_01.rs
@@ -224,9 +224,14 @@ fn sort_colors(colors: &mut Vec<Rgba>, mode: &SortMode) {
                 a.lightness.partial_cmp(&b.lightness).unwrap()
             });
         }
+        SortMode::Grayscale => {
+            colors.sort_by(|a, b| {
+                let gray = |c: &Rgba| c.red * 0.222 + c.green * 0.707 + c.blue * 0.071;
+                gray(a).partial_cmp(&gray(b)).unwrap()
+            });
+        }
         SortMode::Alpha => {
             colors.sort_by(|a, b| a.alpha.partial_cmp(&b.alpha).unwrap());
         }
-        _ => (),
     }
 }


### PR DESCRIPTION
"Generative Design" example "p_1_2_2_01" lacks `Grayscale` arm.

The params of the added code is based on original "Generative Gestaltung" book.