### PR TITLE
Pass window id to event functions

### DIFF
--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -32,7 +32,7 @@ toml = "0.5"
 walkdir = "2"
 web-sys = { version = "0.3.55", optional = true }
 wgpu_upstream = { version = "0.11.1", package = "wgpu" }
-winit = "0.26"
+winit = "0.25"
 
 [features]
 default = ["notosans"]

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -1610,7 +1610,7 @@ where
             let raw_window_event_fn = raw_window_event_fn
                 .to_fn_ptr::<M>()
                 .expect("unexpected model argument given to window event function");
-            (*raw_window_event_fn)(&app, model, event);
+            (*raw_window_event_fn)(&app, model, event, window_id);
         }
 
         let (win_w, win_h, scale_factor) = {
@@ -1645,7 +1645,7 @@ where
                 let window_event_fn = window_event_fn
                     .to_fn_ptr::<M>()
                     .expect("unexpected model argument given to window event function");
-                (*window_event_fn)(&app, model, simple.clone());
+                (*window_event_fn)(&app, model, simple.clone(), window_id);
             }
 
             // A macro to simplify calling event-specific user functions.

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -101,10 +101,10 @@ pub(crate) enum View {
 }
 
 /// A function for processing raw winit window events.
-pub type RawEventFn<Model> = fn(&App, &mut Model, &winit::event::WindowEvent);
+pub type RawEventFn<Model> = fn(&App, &mut Model, &winit::event::WindowEvent, Id);
 
 /// A function for processing window events.
-pub type EventFn<Model> = fn(&App, &mut Model, WindowEvent);
+pub type EventFn<Model> = fn(&App, &mut Model, WindowEvent, Id);
 
 /// A function for processing key press events.
 pub type KeyPressedFn<Model> = fn(&App, &mut Model, Key);


### PR DESCRIPTION
This allows the `event` and `raw_event` handler functions to access the id of the window the event is being fired on. 

This is useful for supporting multiple windows and being able to handle their events separately. Unless I'm missing something I don't think there is any other way to do this.

Event handlers would look like:
```
fn raw_window_event(app: &App, model: &mut Model, event: &ui::RawWindowEvent, id: WindowId) {
       ...
}

fn window_event(app: &App, model: &mut Model, event: &ui::RawWindowEvent, id: WindowId) {
       ...
}
```

These ids can be used to index into a hash map that contains specific window information.