### PR TITLE
Merge missing "publish nannou version 0.18.1" commit into master

### DIFF
--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A Creative Coding Framework for Rust."
 readme = "README.md"


### PR DESCRIPTION
I just noticed that while `0.18.1` is published, it isn't updated on master! I must have opened the `publish-nannou-0.18.1` branch but forgot to merge it into master too. Doing so now!