### PR TITLE
Speedup CI jobs using rust-cache action

### DIFF
--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -34,6 +34,7 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    - uses: Swatinem/rust-cache@v1
     - name: Run default features
       uses: actions-rs/cargo@v1
       with:
@@ -61,6 +62,7 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    - uses: Swatinem/rust-cache@v1
     - name: Run all features
       uses: actions-rs/cargo@v1
       with:
@@ -86,6 +88,7 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    - uses: Swatinem/rust-cache@v1
     - name: Text no_std
       uses: actions-rs/cargo@v1
       with:
@@ -114,6 +117,7 @@ jobs:
         toolchain: stable
         override: true
         target: wasm32-unknown-unknown
+    - uses: Swatinem/rust-cache@v1
     - name: Run check
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
This should help to re-use build artifacts from previous CI passes for each job when possible.