### PR TITLE
Update to wgpu 0.12, egui 0.18

### DIFF
--- a/examples/ui/egui/circle_packing.rs
+++ b/examples/ui/egui/circle_packing.rs
@@ -96,7 +96,7 @@ fn view(app: &App, model: &Model, frame: Frame) {
 
     draw.to_frame(app, &frame).unwrap();
 
-    model.egui.draw_to_frame(&frame).unwrap();
+    model.egui.draw_to_frame(&frame);
 }
 
 fn intersects(circle: &Circle, circles: &Vec<Circle>) -> bool {

--- a/examples/ui/egui/tune_color.rs
+++ b/examples/ui/egui/tune_color.rs
@@ -71,7 +71,7 @@ fn view(app: &App, model: &Model, frame: Frame) {
     draw.to_frame(app, &frame).unwrap();
 
     // Do this as the last operation on your frame.
-    model.egui.draw_to_frame(&frame).unwrap();
+    model.egui.draw_to_frame(&frame);
 }
 
 fn edit_hsv(ui: &mut egui::Ui, color: &mut Hsv) {

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1"
 toml = "0.5"
 walkdir = "2"
 web-sys = { version = "0.3.55", optional = true }
-wgpu_upstream = { version = "0.11.1", package = "wgpu" }
+wgpu_upstream = { version = "0.12.0", package = "wgpu" }
 winit = "0.26"
 
 [features]

--- a/nannou/src/draw/renderer/shaders/vs.wgsl
+++ b/nannou/src/draw/renderer/shaders/vs.wgsl
@@ -1,4 +1,3 @@
-[[block]]
 struct Data {
     proj: mat4x4<f32>;
 };

--- a/nannou_egui/Cargo.toml
+++ b/nannou_egui/Cargo.toml
@@ -12,8 +12,7 @@ repository = "https://github.com/AlexEne/nannou_egui"
 readme = "../README.md"
 
 [dependencies]
-egui_wgpu_backend = "0.17"
-egui = "0.17"
-epi = "0.17"
+egui-wgpu = "0.18"
+egui = "0.18"
 winit = "0.26"
 nannou = { version = "0.18.1", path = "../nannou" }

--- a/nannou_egui/Cargo.toml
+++ b/nannou_egui/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/AlexEne/nannou_egui"
 readme = "../README.md"
 
 [dependencies]
-egui_wgpu_backend = "0.14"
-egui = "0.15.0"
+egui_wgpu_backend = "0.17"
+egui = "0.17"
+epi = "0.17"
 winit = "0.26"
 nannou = { version = "0.18.1", path = "../nannou" }

--- a/nannou_egui_demo_app/Cargo.toml
+++ b/nannou_egui_demo_app/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 [dependencies]
 nannou_egui = { version = "0.5", path = "../nannou_egui" }
 nannou = { version = "0.18.1", path = "../nannou" }
-egui_demo_lib = "0.15"
+egui_demo_lib = "0.17"

--- a/nannou_egui_demo_app/src/main.rs
+++ b/nannou_egui_demo_app/src/main.rs
@@ -1,5 +1,5 @@
 use nannou::prelude::*;
-use nannou_egui::{egui_wgpu_backend::epi::App as EguiApp, Egui};
+use nannou_egui::{epi::App as EguiApp, Egui};
 
 fn main() {
     nannou::app(model).update(update).run();

--- a/nannou_egui_demo_app/src/main.rs
+++ b/nannou_egui_demo_app/src/main.rs
@@ -11,6 +11,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    println!("model");
     app.set_loop_mode(LoopMode::wait());
     let w_id = app
         .new_window()
@@ -36,6 +37,7 @@ fn raw_window_event(_app: &App, model: &mut Model, event: &nannou::winit::event:
 }
 
 fn update(app: &App, model: &mut Model, update: Update) {
+    println!("update");
     let Model {
         ref mut egui,
         ref mut egui_demo_app,
@@ -49,5 +51,6 @@ fn update(app: &App, model: &mut Model, update: Update) {
 }
 
 fn view(_app: &App, model: &Model, frame: Frame) {
+    println!("view");
     model.egui.draw_to_frame(&frame).unwrap();
 }

--- a/nannou_wgpu/Cargo.toml
+++ b/nannou_wgpu/Cargo.toml
@@ -14,7 +14,7 @@ async-std = "1.10.0"
 image = { version = "0.23", optional = true }
 instant = { version = "0.1.9", optional = true }
 num_cpus = { version = "1", optional = true }
-wgpu_upstream = { version = "0.11.1", package = "wgpu" }
+wgpu_upstream = { version = "0.12.0", package = "wgpu" }
 
 [features]
 capturer = ["image", "instant", "num_cpus"]

--- a/nannou_wgpu/src/bind_group_builder.rs
+++ b/nannou_wgpu/src/bind_group_builder.rs
@@ -58,24 +58,34 @@ impl LayoutBuilder {
         self.binding(visibility, ty)
     }
 
-    /// Add a sampler binding to the layout.
-    pub fn sampler(self, visibility: wgpu::ShaderStages, filtering: bool) -> Self {
-        let comparison = false;
-        let ty = wgpu::BindingType::Sampler {
-            filtering,
-            comparison,
-        };
+    /// Add a sampler binding of the given type to the layout.
+    pub fn sampler(self, visibility: wgpu::ShaderStages, ty: wgpu::SamplerBindingType) -> Self {
+        let ty = wgpu::BindingType::Sampler(ty);
         self.binding(visibility, ty)
     }
 
-    /// Add a sampler binding to the layout.
-    pub fn comparison_sampler(self, visibility: wgpu::ShaderStages, filtering: bool) -> Self {
-        let comparison = true;
-        let ty = wgpu::BindingType::Sampler {
-            filtering,
-            comparison,
-        };
-        self.binding(visibility, ty)
+    /// Add a comparison sampler binding to the layout.
+    ///
+    /// Use as a comparison sampler instead of a normal sampler. For more info take a look at the
+    /// analogous functionality in OpenGL:
+    /// https://www.khronos.org/opengl/wiki/Sampler_Object#Comparison_mode.
+    pub fn comparison_sampler(self, visibility: wgpu::ShaderStages) -> Self {
+        self.sampler(visibility, wgpu::SamplerBindingType::Comparison)
+    }
+
+    /// Add a filtering sampler binding to the layout.
+    ///
+    /// Used when the sampling result is produced based on more than a single color sample from a
+    /// texture, e.g. when bilinear interpolation is enabled.
+    pub fn filtering_sampler(self, visibility: wgpu::ShaderStages) -> Self {
+        self.sampler(visibility, wgpu::SamplerBindingType::Filtering)
+    }
+
+    /// Add a filtering sampler binding to the layout.
+    ///
+    /// The sampling result is produced based on a single color sample from a texture.
+    pub fn non_filtering_sampler(self, visibility: wgpu::ShaderStages) -> Self {
+        self.sampler(visibility, wgpu::SamplerBindingType::NonFiltering)
     }
 
     /// Add a texture binding to the layout.

--- a/nannou_wgpu/src/lib.rs
+++ b/nannou_wgpu/src/lib.rs
@@ -78,7 +78,7 @@ pub use wgpu_upstream::{
     CommandEncoder, CommandEncoderDescriptor, CompareFunction, ComputePass, ComputePassDescriptor,
     ComputePipeline, ComputePipelineDescriptor, DepthBiasState, DepthStencilState, Device,
     DeviceDescriptor, DeviceType, DownlevelCapabilities, DownlevelFlags, DynamicOffset, Error,
-    Extent3d, Face, Features, FilterMode, FragmentState, FrontFace, ImageCopyBuffer,
+    ErrorFilter, Extent3d, Face, Features, FilterMode, FragmentState, FrontFace, ImageCopyBuffer,
     ImageCopyBufferBase, ImageCopyTexture, ImageCopyTextureBase, ImageDataLayout,
     ImageSubresourceRange, IndexFormat, Instance, Label, Limits, LoadOp, Maintain, MapMode,
     MultisampleState, Operations, Origin3d, PipelineLayout, PipelineLayoutDescriptor,
@@ -88,16 +88,16 @@ pub use wgpu_upstream::{
     RenderBundleEncoderDescriptor, RenderPass, RenderPassColorAttachment,
     RenderPassDepthStencilAttachment, RenderPassDescriptor, RenderPipeline,
     RenderPipelineDescriptor, RequestAdapterOptions, RequestAdapterOptionsBase, RequestDeviceError,
-    Sampler, SamplerBorderColor, SamplerDescriptor, ShaderLocation, ShaderModel, ShaderModule,
-    ShaderModuleDescriptor, ShaderSource, ShaderStages, StencilFaceState, StencilOperation,
-    StencilState, StorageTextureAccess, Surface, SurfaceConfiguration, SurfaceError, SurfaceStatus,
-    SurfaceTexture, Texture as TextureHandle, TextureAspect, TextureDescriptor, TextureDimension,
-    TextureFormat, TextureFormatFeatureFlags, TextureFormatFeatures, TextureSampleType,
-    TextureUsages, TextureView as TextureViewHandle, TextureViewDescriptor, TextureViewDimension,
-    UncapturedErrorHandler, VertexAttribute, VertexBufferLayout, VertexFormat, VertexState,
-    VertexStepMode, COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT, MAP_ALIGNMENT,
-    PUSH_CONSTANT_ALIGNMENT, QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE,
-    VERTEX_STRIDE_ALIGNMENT,
+    Sampler, SamplerBindingType, SamplerBorderColor, SamplerDescriptor, ShaderLocation,
+    ShaderModel, ShaderModule, ShaderModuleDescriptor, ShaderModuleDescriptorSpirV, ShaderSource,
+    ShaderStages, StencilFaceState, StencilOperation, StencilState, StorageTextureAccess, Surface,
+    SurfaceConfiguration, SurfaceError, SurfaceStatus, SurfaceTexture, Texture as TextureHandle,
+    TextureAspect, TextureDescriptor, TextureDimension, TextureFormat, TextureFormatFeatureFlags,
+    TextureFormatFeatures, TextureSampleType, TextureUsages, TextureView as TextureViewHandle,
+    TextureViewDescriptor, TextureViewDimension, UncapturedErrorHandler, VertexAttribute,
+    VertexBufferLayout, VertexFormat, VertexState, VertexStepMode, COPY_BUFFER_ALIGNMENT,
+    COPY_BYTES_PER_ROW_ALIGNMENT, MAP_ALIGNMENT, PUSH_CONSTANT_ALIGNMENT,
+    QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
 };
 
 /// The default power preference used for requesting the WGPU adapter.
@@ -186,7 +186,7 @@ pub fn create_pipeline_layout<'p>(
 
 /// Whether or not the sampler descriptor describes a sampler that might perform linear filtering.
 ///
-/// This is used to determine the `filtering` field for the sampler binding type variant which
+/// This is used to determine the `SamplerBindingType` for the sampler binding variant which
 /// assists wgpu with validation.
 pub fn sampler_filtering(desc: &SamplerDescriptor) -> bool {
     match (desc.mag_filter, desc.min_filter, desc.mipmap_filter) {


### PR DESCRIPTION
Finally getting around to updating these!

The `wgpu` update is quite trivial and looks like the new validation errors might make it easier to catch bugs in the WIP `nannou_isf` crate.

The `egui` update however needs a more significant refactor. It looks like the `egui_winit_platform` and `egui_wgpu_backend` crates have recently been merged into the main `egui` repo as `egui-winit` and `egui-wgpu` respectively. Awesome to see these being maintained upstream, but both have transformed quite a bit and require some rethinking of `nannou_egui` and `nannou_egui_demo_app`.

## TODO

- [x] **Update `nannou_wgpu` to `wgpu` `0.12`.**
- [x] **Update `nannou` to `wgpu` `0.12`.**
- [x] **Update `nannou_isf` to `wgpu` `0.12`.**
- [ ] **Update `nannou_egui` to `egui` `0.18`.** Mostly done, though need to refactor eframe stuff for demo app.
- [ ] **Update `nannou_egui_demo_app`.** Changed significantly, might need to copy over quite a bit of boilerplate from `egui_demo_app`.
- [ ] **Update `wgpu` examples to `0.12`.**