### PR TITLE
Port old conrod example "simple_ui" to egui

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -193,6 +193,9 @@ path = "ui/egui/circle_packing.rs"
 [[example]]
 name = "tune_color"
 path = "ui/egui/tune_color.rs"
+[[example]]
+name = "simple_ui"
+path = "ui/egui/simple_ui.rs"
 
 # WebGPU
 [[example]]

--- a/examples/ui/egui/simple_ui.rs
+++ b/examples/ui/egui/simple_ui.rs
@@ -82,7 +82,7 @@ fn view(app: &App, model: &Model, frame: Frame) {
     let draw = app.draw();
     draw.background().color(BLACK);
 
-    let rotation_radians = settings.rotation / 360.0 * 2.0 * std::f32::consts::PI;
+    let rotation_radians = deg_to_rad(settings.rotation);
     draw.ellipse()
         .resolution(settings.resolution as f32)
         .xy(settings.position)

--- a/examples/ui/egui/simple_ui.rs
+++ b/examples/ui/egui/simple_ui.rs
@@ -2,9 +2,7 @@ use nannou::prelude::*;
 use nannou_egui::{self, egui, Egui};
 
 fn main() {
-    nannou::app(model)
-        .update(update) 
-        .run();
+    nannou::app(model).update(update).run();
 }
 
 struct Settings {
@@ -16,13 +14,14 @@ struct Settings {
 }
 
 struct Model {
-    settings: Settings, 
-    egui: Egui
+    settings: Settings,
+    egui: Egui,
 }
 
 fn model(app: &App) -> Model {
     // Create window
-    let window_id = app.new_window()
+    let window_id = app
+        .new_window()
         .view(view)
         .raw_event(raw_window_event)
         .build()
@@ -30,7 +29,7 @@ fn model(app: &App) -> Model {
     let window = app.window(window_id).unwrap();
 
     let egui = Egui::from_window(&window);
-    
+
     Model {
         egui,
         settings: Settings {
@@ -38,8 +37,8 @@ fn model(app: &App) -> Model {
             scale: 200.0,
             rotation: 0.0,
             color: WHITE,
-            position: vec2(0.0, 0.0)
-        }
+            position: vec2(0.0, 0.0),
+        },
     }
 }
 
@@ -64,8 +63,7 @@ fn update(_app: &App, model: &mut Model, update: Update) {
         ui.add(egui::Slider::new(&mut settings.rotation, 0.0..=360.0));
 
         // Random color button
-        let clicked = ui.add(egui::Button::new("Random color"))
-            .clicked();
+        let clicked = ui.add(egui::Button::new("Random color")).clicked();
 
         if clicked {
             settings.color = rgb(random(), random(), random());
@@ -79,7 +77,7 @@ fn raw_window_event(_app: &App, model: &mut Model, event: &nannou::winit::event:
 }
 
 fn view(app: &App, model: &Model, frame: Frame) {
-    let settings = &model.settings;    
+    let settings = &model.settings;
 
     let draw = app.draw();
     draw.background().color(BLACK);
@@ -91,7 +89,7 @@ fn view(app: &App, model: &Model, frame: Frame) {
         .color(settings.color)
         .rotate(-rotation_radians)
         .radius(settings.scale);
-    
+
     draw.to_frame(app, &frame).unwrap();
     model.egui.draw_to_frame(&frame).unwrap();
 }

--- a/examples/ui/egui/simple_ui.rs
+++ b/examples/ui/egui/simple_ui.rs
@@ -7,44 +7,90 @@ fn main() {
         .run();
 }
 
+struct Settings {
+    resolution: u32,
+    scale: f32,
+    rotation: f32,
+    color: Srgb<u8>,
+    position: Vec2,
+}
+
 struct Model {
+    settings: Settings, 
     egui: Egui
 }
 
 fn model(app: &App) -> Model {
+    // Create window
     let window_id = app.new_window()
         .view(view)
         .raw_event(raw_window_event)
         .build()
         .unwrap();
-
     let window = app.window(window_id).unwrap();
 
     let egui = Egui::from_window(&window);
     
     Model {
-        egui
+        egui,
+        settings: Settings {
+            resolution: 10,
+            scale: 200.0,
+            rotation: 0.0,
+            color: WHITE,
+            position: vec2(0.0, 0.0)
+        }
     }
 }
 
 fn update(_app: &App, model: &mut Model, update: Update) {
     let egui = &mut model.egui;
+    let settings = &mut model.settings;
 
     egui.set_elapsed_time(update.since_start);
     let ctx = egui.begin_frame();
 
-    egui::Window::new("Test").show(&ctx, |ui| {
-        ui.add(egui::Checkbox::new(&mut true, "test"));
+    egui::Window::new("Settings").show(&ctx, |ui| {
+        // Resolution slider
+        ui.add(egui::Label::new("Resolution:"));
+        ui.add(egui::Slider::new(&mut settings.resolution, 1..=40));
+
+        // Scale slider
+        ui.add(egui::Label::new("Scale:"));
+        ui.add(egui::Slider::new(&mut settings.scale, 0.0..=1000.0));
+
+        // Rotation slider
+        ui.add(egui::Label::new("Rotation:"));
+        ui.add(egui::Slider::new(&mut settings.rotation, 0.0..=360.0));
+
+        // Random color button
+        let clicked = ui.add(egui::Button::new("Random color"))
+            .clicked();
+
+        if clicked {
+            settings.color = rgb(random(), random(), random());
+        }
     });
 }
 
 fn raw_window_event(_app: &App, model: &mut Model, event: &nannou::winit::event::WindowEvent) {
+    // Let egui handle things like keyboard and mouse input.
     model.egui.handle_raw_event(event);
 }
 
 fn view(app: &App, model: &Model, frame: Frame) {
+    let settings = &model.settings;    
+
     let draw = app.draw();
     draw.background().color(BLACK);
+
+    let rotation_radians = settings.rotation / 360.0 * 2.0 * std::f32::consts::PI;
+    draw.ellipse()
+        .resolution(settings.resolution as f32)
+        .xy(settings.position)
+        .color(settings.color)
+        .rotate(-rotation_radians)
+        .radius(settings.scale);
     
     draw.to_frame(app, &frame).unwrap();
     model.egui.draw_to_frame(&frame).unwrap();

--- a/examples/ui/egui/simple_ui.rs
+++ b/examples/ui/egui/simple_ui.rs
@@ -51,15 +51,15 @@ fn update(_app: &App, model: &mut Model, update: Update) {
 
     egui::Window::new("Settings").show(&ctx, |ui| {
         // Resolution slider
-        ui.add(egui::Label::new("Resolution:"));
+        ui.label("Resolution:");
         ui.add(egui::Slider::new(&mut settings.resolution, 1..=40));
 
         // Scale slider
-        ui.add(egui::Label::new("Scale:"));
+        ui.label("Scale:");
         ui.add(egui::Slider::new(&mut settings.scale, 0.0..=1000.0));
 
         // Rotation slider
-        ui.add(egui::Label::new("Rotation:"));
+        ui.label("Rotation:");
         ui.add(egui::Slider::new(&mut settings.rotation, 0.0..=360.0));
 
         // Random color button

--- a/examples/ui/egui/simple_ui.rs
+++ b/examples/ui/egui/simple_ui.rs
@@ -63,7 +63,7 @@ fn update(_app: &App, model: &mut Model, update: Update) {
         ui.add(egui::Slider::new(&mut settings.rotation, 0.0..=360.0));
 
         // Random color button
-        let clicked = ui.add(egui::Button::new("Random color")).clicked();
+        let clicked = ui.button("Random color").clicked();
 
         if clicked {
             settings.color = rgb(random(), random(), random());

--- a/examples/ui/egui/simple_ui.rs
+++ b/examples/ui/egui/simple_ui.rs
@@ -1,0 +1,51 @@
+use nannou::prelude::*;
+use nannou_egui::{self, egui, Egui};
+
+fn main() {
+    nannou::app(model)
+        .update(update) 
+        .run();
+}
+
+struct Model {
+    egui: Egui
+}
+
+fn model(app: &App) -> Model {
+    let window_id = app.new_window()
+        .view(view)
+        .raw_event(raw_window_event)
+        .build()
+        .unwrap();
+
+    let window = app.window(window_id).unwrap();
+
+    let egui = Egui::from_window(&window);
+    
+    Model {
+        egui
+    }
+}
+
+fn update(_app: &App, model: &mut Model, update: Update) {
+    let egui = &mut model.egui;
+
+    egui.set_elapsed_time(update.since_start);
+    let ctx = egui.begin_frame();
+
+    egui::Window::new("Test").show(&ctx, |ui| {
+        ui.add(egui::Checkbox::new(&mut true, "test"));
+    });
+}
+
+fn raw_window_event(_app: &App, model: &mut Model, event: &nannou::winit::event::WindowEvent) {
+    model.egui.handle_raw_event(event);
+}
+
+fn view(app: &App, model: &Model, frame: Frame) {
+    let draw = app.draw();
+    draw.background().color(BLACK);
+    
+    draw.to_frame(app, &frame).unwrap();
+    model.egui.draw_to_frame(&frame).unwrap();
+}


### PR DESCRIPTION
This PR will add a new example: `examples/ui/egui/simple_ui.rs`, it's the egui version of an old example found here: https://github.com/nannou-org/nannou_conrod/blob/main/examples/simple_ui.rs. As requested in #856.

I'm relatively new to nannou and this is my first contribution so don't be afraid to tell me how I can do better!

Closes #856



