### PR TITLE
Add a method for fetching the main window when it might not exist

### DIFF
--- a/examples/draw/draw_capture_hi_res.rs
+++ b/examples/draw/draw_capture_hi_res.rs
@@ -187,12 +187,13 @@ fn view(_app: &App, model: &Model, frame: Frame) {
 // Wait for capture to finish.
 fn exit(app: &App, model: Model) {
     println!("Waiting for PNG writing to complete...");
-    let window = app.main_window();
-    let device = window.device();
-    model
-        .texture_capturer
-        .await_active_snapshots(&device)
-        .unwrap();
+    if let Some(window) = app.try_main_window() {
+        let device = window.device();
+        model
+            .texture_capturer
+            .await_active_snapshots(&device)
+            .unwrap();
+    }
     println!("Done!");
 }
 

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -764,6 +764,11 @@ impl App {
             .expect("called `App::window_id` but there is no window currently in focus")
     }
 
+    /// Return the **Id** of the currently focused window if it exists.
+    pub fn try_window_id(&self) -> Option<window::Id> {
+        *self.focused_window.borrow()
+    }
+
     /// Return a `Vec` containing a unique `window::Id` for each currently open window managed by
     /// the `App`.
     pub fn window_ids(&self) -> Vec<window::Id> {
@@ -782,7 +787,7 @@ impl App {
 
     /// A reference to the window currently in focus.
     ///
-    /// **Panics** if their are no windows open in the **App**.
+    /// **Panics** if there are no windows open in the **App**.
     ///
     /// Uses the **App::window** method internally.
     ///
@@ -791,6 +796,20 @@ impl App {
     pub fn main_window(&self) -> std::cell::Ref<Window> {
         self.window(self.window_id())
             .expect("no window for focused id")
+    }
+
+    /// A reference to the window currently in focus if it exists.
+    ///
+    /// Uses the **App::window** method internally.
+    ///
+    /// TODO: Currently this produces a reference to the *focused* window, but this behaviour
+    /// should be changed to track the "main" window (the first window created?).
+    pub fn try_main_window(&self) -> Option<std::cell::Ref<Window>> {
+        if let Some(id) = self.try_window_id() {
+            self.window(id)
+        } else {
+            None
+        }
     }
 
     /// Return the wgpu `Backends` in use.


### PR DESCRIPTION
I was trying to work with code similar to the `draw_captur_hi_res.rs` example that rendered to a texture, but my code was crashing when I was closing the nannou window using the Windows "X" button. It turns out that it was panicing in the exit function trying to fetch the main window which seems to have closed before the exit function had a chance to run.

I'm not sure if this is the correct solution. Ideally I would change the API of either `App::window_id` or `App::main_window` to return an `Option`. Changing `main_window` would likely not be great since it would add a lot of boilerplate to the more common case of accessing it outside of the exit function. Changing `window_id` would require us to check whether the `focused_window` still existed in `windows`. Both of these would be breaking API changes, which is why I choose to implement new methods.

Also in my particular case it would be enough to check if `window_count` was 0, though that feels a bit brittle in the general case. Additionally, a real workaround would be to check if `App::window_id` exist in `App::windows`. That would work since it looks like `App::focused_window` is set the first time a window is created. In that case I think the docs of `App::window_id` should be updated to reflect that this is something that is guaranteed.