### PR TITLE
Fix broken example link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ by Processing, OpenFrameworks and Cinder, but for Rust. <sup>Named after
 
 |     |     |     |
 | --- |:---:| ---:|
-| [![1](https://i.imgur.com/kPn91tW.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_polygon.rs) | [![2](https://i.imgur.com/gaiWHZX.gif)](https://github.com/nannou-org/nannou/blob/master/examples/ui/conrod/simple_ui.rs) | [![3](https://i.imgur.com/lm4RI4N.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_polyline.rs) |
+| [![1](https://i.imgur.com/kPn91tW.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_polygon.rs) | [![2](https://i.imgur.com/gaiWHZX.gif)](https://github.com/nannou-org/nannou/blob/master/examples/ui/egui/simple_ui.rs) | [![3](https://i.imgur.com/lm4RI4N.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_polyline.rs) |
 
 ### A Quick Note
 


### PR DESCRIPTION
The second GIF in the README was leading to a non-existing page