### PR TITLE
Create rect with ratio

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -107,6 +107,9 @@ path = "draw/draw_textured_polygon.rs"
 [[example]]
 name = "draw_transform"
 path = "draw/draw_transform.rs"
+[[example]]
+name = "draw_with_ratio"
+path = "draw/draw_with_ratio.rs"
 
 # Interactive Shader Format
 [[example]]

--- a/examples/draw/draw_with_ratio.rs
+++ b/examples/draw/draw_with_ratio.rs
@@ -1,0 +1,38 @@
+use nannou::prelude::*;
+
+fn main() {
+    nannou::sketch(view).run()
+}
+
+fn view(app: &App, frame: Frame) {
+    let draw = app.draw();
+    draw.background().color(BLACK);
+
+    // Get the window rect and ensure it's ratio is 16/9.
+    let window_rect = app.window_rect().with_ratio(16.0 / 9.0);
+
+    // Draw the boundaries.
+    draw.rect()
+        .xy(window_rect.xy())
+        .wh(window_rect.wh())
+        .no_fill()
+        .stroke(WHITE)
+        .stroke_weight(2.0);
+
+    // Example from draw_arrow.rs
+    let r = window_rect;
+    for r in r.subdivisions_iter() {
+        for r in r.subdivisions_iter() {
+            for r in r.subdivisions_iter() {
+                let side = r.w().min(r.h());
+                let start = r.xy();
+                let start_to_mouse = app.mouse.position() - start;
+                let target_mag = start_to_mouse.length().min(side * 0.5);
+                let end = start + start_to_mouse.normalize() * target_mag;
+                draw.arrow().weight(5.0).points(start, end);
+            }
+        }
+    }
+
+    draw.to_frame(app, &frame).unwrap();
+}

--- a/nannou_core/src/geom/rect.rs
+++ b/nannou_core/src/geom/rect.rs
@@ -255,6 +255,18 @@ where
     pub fn subdivisions_iter(&self) -> Subdivisions<S> {
         self.subdivision_ranges().rects_iter()
     }
+
+    /// Creates a rect with the specified ratio that fit in `self`.
+    ///
+    /// ratio = width / height
+    pub fn with_ratio(&self, ratio: S) -> Self {
+        let (w, h) = self.w_h();
+        if w < h * ratio {
+            Rect::from_w_h(w, w / ratio)
+        } else {
+            Rect::from_w_h(h * ratio, h)
+        }
+    }
 }
 
 impl<S> Rect<S>


### PR DESCRIPTION
Add a method to create a `Rect` with a specific ratio that fit inside another `Rect`.

Check the `draw_with_ratio` example for example of usage.