### PR TITLE
Fix nature_of_code/chp_01_vectors example

### DIFF
--- a/nature_of_code/chp_01_vectors/1_10_motion101_acceleration.rs
+++ b/nature_of_code/chp_01_vectors/1_10_motion101_acceleration.rs
@@ -38,7 +38,7 @@ impl Mover {
         // Computer a vector that points from position to mouse
         self.acceleration = mouse - self.position;
         // Set magnitude of acceleration
-        self.acceleration = self.acceleration.normalize() * 0.2;
+        self.acceleration = self.acceleration.normalize_or_zero() * 0.2;
         // Velocity chages according to acceleration
         self.velocity += self.acceleration;
         // Limit the velocity by top_speed

--- a/nature_of_code/chp_01_vectors/1_11_motion101_acceleration_array.rs
+++ b/nature_of_code/chp_01_vectors/1_11_motion101_acceleration_array.rs
@@ -45,7 +45,7 @@ impl Mover {
         // Computer a vector that points from position to mouse
         self.acceleration = mouse - self.position;
         // Set magnitude of acceleration
-        self.acceleration = self.acceleration.normalize() * 0.2;
+        self.acceleration = self.acceleration.normalize_or_zero() * 0.2;
         // Velocity chages according to acceleration
         self.velocity += self.acceleration;
         // Limit the velocity by top_speed


### PR DESCRIPTION
When the distance vector between the mouse coordinates and Mover is zero, the calculation results in `NaN` as it tries to `normalize()` it. (Blank screen is displayed.)

I found `normalize_or_zero()` in the docs and this would be great alternative for the case. 