### PR TITLE
 Rounded corners on rect Issue #849, absolute values on height and width

### DIFF
--- a/examples/draw/draw.rs
+++ b/examples/draw/draw.rs
@@ -41,6 +41,7 @@ fn view(app: &App, frame: Frame) {
     draw.rect()
         .x_y(app.mouse.y, app.mouse.x)
         .w(app.mouse.x * 0.25)
+        .corner_radius(app.mouse.x * 0.05)
         .hsv(t, 1.0, 1.0);
 
     // Write the result of our drawing to the window's frame.

--- a/examples/draw/draw.rs
+++ b/examples/draw/draw.rs
@@ -38,11 +38,19 @@ fn view(app: &App, frame: Frame) {
         .rotate(t);
 
     // Draw a rect that follows a different inverse of the ellipse.
-    draw.rect()
+    if app.mouse.y > 0.0 {
+        draw.rect()
         .x_y(app.mouse.y, app.mouse.x)
         .w(app.mouse.x * 0.25)
         .corner_radius(app.mouse.x * 0.05)
         .hsv(t, 1.0, 1.0);
+    } else {
+        draw.rect()
+        .x_y(app.mouse.y, app.mouse.x)
+        .w(app.mouse.x * 0.25)
+        .hsv(t, 1.0, 1.0);
+    }
+    
 
     // Write the result of our drawing to the window's frame.
     draw.to_frame(app, &frame).unwrap();

--- a/nannou/src/draw/primitive/rect.rs
+++ b/nannou/src/draw/primitive/rect.rs
@@ -8,13 +8,19 @@ use crate::draw::properties::{
 use crate::draw::{self, Drawing};
 use crate::geom;
 use crate::glam::Vec2;
+use lyon::math::Point;
 use lyon::tessellation::StrokeOptions;
+use nannou_core::geom::point;
+use nannou_core::prelude::{Vec2Rotate, abs};
+use lyon::path::builder::SvgPathBuilder;
 
 /// Properties related to drawing a **Rect**.
 #[derive(Clone, Debug)]
 pub struct Rect {
     dimensions: dimension::Properties,
     polygon: PolygonInit,
+    corner_radius: Option<f32>,
+    corner_segments: u32,
 }
 
 /// The drawing context for a Rect.
@@ -30,7 +36,50 @@ impl Rect {
     {
         self.stroke_color(color)
     }
+
+    pub fn corner_radius(mut self, radius: f32) -> Self {
+        self.corner_radius = Some(abs(radius));
+        self
+    }
+
+    pub fn corner_segments(mut self, segments: u32) -> Self {
+        self.corner_segments = segments;
+        self
+    }
+
+    fn round_vertices(self, vertices: Vec<Vec2>) -> Vec<Vec2> {
+        let corner_segments = self.corner_segments;
+        let mut rounded_rect: Vec<Vec2> = Vec::with_capacity(4 * corner_segments as usize);
+        match self.corner_radius {
+            
+            Some(radius) => {
+                // The method below is readily extensible to arbitrary polygons except for the 90 degree angle assumption.
+
+                // The segment vector is the unit vector of each segment
+                let mut segment_vector = vertices[0] - vertices[3];
+                for vertex in vertices {
+                    // The segment is the endpoint of each segment.
+                    // The segment is shortened by the radius, in the direction of the incoming segment vector.
+                    let mut segment = vertex - segment_vector * radius;
+
+                    let angle_step = std::f32::consts::PI / (2.0 * corner_segments as f32);
+
+                    for _ in 0..corner_segments {
+                        rounded_rect.push(segment);
+                        // rotate the segment vector by the angle step
+                        segment_vector = segment_vector.rotate(-angle_step);
+                        segment = segment + segment_vector * radius * angle_step;
+                    
+                    }
+                }
+                rounded_rect
+            },
+
+            None => vertices
+        }              
+    }
 }
+
 
 impl<'a> DrawingRect<'a> {
     /// Stroke the outline with the given color.
@@ -39,6 +88,15 @@ impl<'a> DrawingRect<'a> {
         C: IntoLinSrgba<ColorScalar>,
     {
         self.map_ty(|ty| ty.stroke(color))
+    }
+
+    
+    pub fn corner_radius(self, radius: f32) -> Self {
+        self.map_ty(|ty| ty.corner_radius(radius))
+    }
+
+    pub fn corner_segments(self, segments: u32) -> Self {
+        self.map_ty(|ty| ty.corner_segments(segments))
     }
 }
 
@@ -51,7 +109,11 @@ impl draw::renderer::RenderPrimitive for Rect {
         let Rect {
             polygon,
             dimensions,
+            corner_radius,
+            corner_segments: _,
         } = self;
+
+
 
         // If dimensions were specified, scale the points to those dimensions.
         let (maybe_x, maybe_y, maybe_z) = (dimensions.x, dimensions.y, dimensions.z);
@@ -59,18 +121,58 @@ impl draw::renderer::RenderPrimitive for Rect {
             maybe_z.is_none(),
             "z dimension support for rect is unimplemented"
         );
+        
         let w = maybe_x.unwrap_or(100.0);
         let h = maybe_y.unwrap_or(100.0);
-        let rect = geom::Rect::from_wh([w, h].into());
-        let points = rect.corners().vertices().map(Vec2::from);
-        polygon::render_points_themed(
-            polygon.opts,
-            points,
-            ctxt,
-            &draw::theme::Primitive::Rect,
-            mesh,
-        );
 
+        let rect = geom::Rect::from_wh([w, h].into());
+
+        match corner_radius {
+            Some(radius) => {
+                let mut builder = lyon::path::Path::svg_builder();
+
+                // unit vector parallel to segment, used for positioning arc points
+                let mut segment_vector = Vec2::from([0.0, 1.0]); 
+                let starting_point = rect.bottom_left() + segment_vector * radius;
+                // start at lower left corner.
+                builder.move_to (Point::new(starting_point.x, starting_point.y));
+                let mut rotation = lyon::geom::Angle::radians(0.0);
+
+                for vertex in rect.corners().vertices().map(Vec2::from) {
+                    let arc_start = vertex - segment_vector * radius;
+                    builder.line_to(Point::new(arc_start.x, arc_start.y));
+                    // rotate segment vector by 90 degrees to the right
+                    segment_vector = segment_vector.rotate(-std::f32::consts::PI/2.0);
+                    let arc_end = vertex + segment_vector * radius;
+                    builder.arc_to(
+                        lyon::math::Vector::from([radius, radius]), 
+                        rotation,
+                        lyon::geom::ArcFlags { large_arc: false, sweep: false },
+                        Point::new(arc_end.x, arc_end.y)
+                    );
+                    rotation += lyon::geom::Angle::frac_pi_2();
+
+                }
+                let path = builder.build();
+                polygon::render_events_themed(
+                    polygon.opts,
+                    || (&path).into_iter(),
+                    ctxt,
+                    &draw::theme::Primitive::Ellipse,
+                    mesh,
+                );
+            }
+            None => {
+                let points = rect.corners().vertices().map(Vec2::from);
+                polygon::render_points_themed(
+                    polygon.opts,
+                    points.into_iter(),
+                    ctxt,
+                    &draw::theme::Primitive::Rect,
+                    mesh,
+                );
+            }
+        }
         draw::renderer::PrimitiveRender::default()
     }
 }
@@ -89,6 +191,8 @@ impl Default for Rect {
         Rect {
             dimensions,
             polygon,
+            corner_radius: None,
+            corner_segments: 0,
         }
     }
 }
@@ -128,6 +232,7 @@ impl SetPolygon for Rect {
         SetPolygon::polygon_options_mut(&mut self.polygon)
     }
 }
+
 
 // Primitive conversions.
 

--- a/nannou/src/draw/primitive/rect.rs
+++ b/nannou/src/draw/primitive/rect.rs
@@ -20,7 +20,6 @@ pub struct Rect {
     dimensions: dimension::Properties,
     polygon: PolygonInit,
     corner_radius: Option<f32>,
-    corner_segments: u32,
 }
 
 /// The drawing context for a Rect.
@@ -42,42 +41,6 @@ impl Rect {
         self
     }
 
-    pub fn corner_segments(mut self, segments: u32) -> Self {
-        self.corner_segments = segments;
-        self
-    }
-
-    fn round_vertices(self, vertices: Vec<Vec2>) -> Vec<Vec2> {
-        let corner_segments = self.corner_segments;
-        let mut rounded_rect: Vec<Vec2> = Vec::with_capacity(4 * corner_segments as usize);
-        match self.corner_radius {
-            
-            Some(radius) => {
-                // The method below is readily extensible to arbitrary polygons except for the 90 degree angle assumption.
-
-                // The segment vector is the unit vector of each segment
-                let mut segment_vector = vertices[0] - vertices[3];
-                for vertex in vertices {
-                    // The segment is the endpoint of each segment.
-                    // The segment is shortened by the radius, in the direction of the incoming segment vector.
-                    let mut segment = vertex - segment_vector * radius;
-
-                    let angle_step = std::f32::consts::PI / (2.0 * corner_segments as f32);
-
-                    for _ in 0..corner_segments {
-                        rounded_rect.push(segment);
-                        // rotate the segment vector by the angle step
-                        segment_vector = segment_vector.rotate(-angle_step);
-                        segment = segment + segment_vector * radius * angle_step;
-                    
-                    }
-                }
-                rounded_rect
-            },
-
-            None => vertices
-        }              
-    }
 }
 
 
@@ -95,9 +58,6 @@ impl<'a> DrawingRect<'a> {
         self.map_ty(|ty| ty.corner_radius(radius))
     }
 
-    pub fn corner_segments(self, segments: u32) -> Self {
-        self.map_ty(|ty| ty.corner_segments(segments))
-    }
 }
 
 impl draw::renderer::RenderPrimitive for Rect {
@@ -110,7 +70,6 @@ impl draw::renderer::RenderPrimitive for Rect {
             polygon,
             dimensions,
             corner_radius,
-            corner_segments: _,
         } = self;
 
 
@@ -192,7 +151,6 @@ impl Default for Rect {
             dimensions,
             polygon,
             corner_radius: None,
-            corner_segments: 0,
         }
     }
 }

--- a/nannou/src/draw/properties/spatial/dimension.rs
+++ b/nannou/src/draw/properties/spatial/dimension.rs
@@ -1,4 +1,7 @@
+use nannou_core::prelude::abs;
+
 use crate::glam::{Vec2, Vec3};
+
 
 /// Dimension properties for **Drawing** a **Primitive**.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -15,13 +18,13 @@ pub trait SetDimensions: Sized {
 
     /// Set the absolute width for the primitive.
     fn width(mut self, w: f32) -> Self {
-        self.properties().x = Some(w);
+        self.properties().x = Some(abs(w));
         self
     }
 
     /// Set the absolute height for the primitive.
     fn height(mut self, h: f32) -> Self {
-        self.properties().y = Some(h);
+        self.properties().y = Some(abs(h));
         self
     }
 


### PR DESCRIPTION
Implemented rounded corners on rects with the addition of a corner_radius option attribute on the rect struct in [rect.rs](https://github.com/nannou-org/nannou/blob/master/nannou/src/draw/primitive/rect.rs).  If the corner_radius is None, this reduces to the same code as the base version.

Added the necessary boilerplate for mapping the corner_radius to the drawing attributes.

The approach for producing the rounded vertices used was similar to that employed in the ellipse primitive, where a SvgBuilder was implemented to construct the rectangle path.

In the course of this I found that the height and width properties on Dimensions were specified to be absolute values, but this was not being enforced, which led to unpredictable operation.  (The example provided in draw.rs, link below, for instance, provides a negative value to the w function).  I applied abs to each of these properties.

The [draw.rs](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw.rs) example was modified to demonstrate the new functionality, with the final rect demonstrating dynamic updates of the corner_radius, including setting radius to None (which produces results identical to the original behavior).

Project built and all examples ran successfully with 1.63.0 on Mac OS.

I am new to this library and to rust, so don't hesitate to give additional guidance.

