### PR TITLE
Update to winit 0.27. Handle new window events (IME and Occluded)

### DIFF
--- a/examples/nannou_basics/all_functions.rs
+++ b/examples/nannou_basics/all_functions.rs
@@ -33,6 +33,7 @@ fn model(app: &App) -> Model {
         .focused(window_focused)
         .unfocused(window_unfocused)
         .closed(window_closed)
+        .occluded(occluded)
         .build()
         .unwrap();
     Model {}
@@ -79,6 +80,7 @@ fn window_event(_app: &App, _model: &mut Model, event: WindowEvent) {
         Focused => {}
         Unfocused => {}
         Closed => {}
+        Occluded(_val) => {}
     }
 }
 
@@ -119,3 +121,5 @@ fn hovered_file(_app: &App, _model: &mut Model, _path: std::path::PathBuf) {}
 fn hovered_file_cancelled(_app: &App, _model: &mut Model) {}
 
 fn dropped_file(_app: &App, _model: &mut Model, _path: std::path::PathBuf) {}
+
+fn occluded(_app: &App, _model: &mut Model, _val: bool) {}

--- a/examples/offline/tree.rs
+++ b/examples/offline/tree.rs
@@ -122,6 +122,7 @@ fn window_event(_app: &App, _model: &mut Model, event: WindowEvent) {
         Focused => {}
         Unfocused => {}
         Closed => {}
+        Occluded(_val) => {}
     }
 }
 

--- a/examples/rust_basics/1_nannou_events.rs
+++ b/examples/rust_basics/1_nannou_events.rs
@@ -54,6 +54,7 @@ fn event(_app: &App, _model: &mut Model, event: WindowEvent) {
         Focused => {}
         Unfocused => {}
         Closed => {}
+        Occluded(_val) => {}
     }
 }
 

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -7,6 +7,8 @@ back to the origins.
 
 # Unreleased
 
+- Handle `winit::window::WindowEvent::Occluded` events. 
+- Update winit to `0.27`. 
 - Add GL backend to default backends for better WASM support.
 - Add CI for testing the `wasm32-unknown-unknown` target.
 - Enable `wgpu/webgl` when `wasm` feature is enabled.

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -32,7 +32,7 @@ toml = "0.5"
 walkdir = "2"
 web-sys = { version = "0.3.55", optional = true }
 wgpu_upstream = { version = "0.11.1", package = "wgpu" }
-winit = "0.26"
+winit = "0.27"
 
 [features]
 default = ["notosans"]

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -1708,6 +1708,7 @@ where
                 event::WindowEvent::Focused => call_user_function!(focused),
                 event::WindowEvent::Unfocused => call_user_function!(unfocused),
                 event::WindowEvent::Closed => call_user_function!(closed),
+                event::WindowEvent::Occluded(val) => call_user_function!(occluded, val),
             }
         }
     }

--- a/nannou/src/event.rs
+++ b/nannou/src/event.rs
@@ -172,6 +172,13 @@ pub enum WindowEvent {
 
     /// The window was closed and is no longer stored in the `App`.
     Closed,
+
+    /// The window has been hidden from view. This event could be used to
+    /// optimize rendering.
+    ///
+    /// Currently supported on macOS, unsupported on iOS / Android / Web /
+    /// Wayland / Windows.
+    Occluded(bool),
 }
 
 impl WindowEvent {
@@ -307,6 +314,14 @@ impl WindowEvent {
             | winit::event::WindowEvent::ScaleFactorChanged { .. } => {
                 return None;
             }
+
+            // These events will never happen as long as
+            // `Window::set_ime_allowed` is not called.
+            winit::event::WindowEvent::Ime(_) => {
+                return None;
+            }
+
+            winit::event::WindowEvent::Occluded(occluded) => Occluded(*occluded),
         };
 
         Some(event)

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -80,6 +80,7 @@ pub(crate) struct UserFunctions {
     pub(crate) focused: Option<FocusedFnAny>,
     pub(crate) unfocused: Option<UnfocusedFnAny>,
     pub(crate) closed: Option<ClosedFnAny>,
+    pub(crate) occluded: Option<OccludedFnAny>,
 }
 
 /// The user function type for drawing their model to the surface of a single window.
@@ -167,6 +168,9 @@ pub type UnfocusedFn<Model> = fn(&App, &mut Model);
 /// A function for processing window closed events.
 pub type ClosedFn<Model> = fn(&App, &mut Model);
 
+/// A function for processing window occluded events.
+pub type OccludedFn<Model> = fn(&App, &mut Model, bool);
+
 /// Errors that might occur while building the window.
 #[derive(Debug)]
 pub enum BuildError {
@@ -234,6 +238,7 @@ fn_any!(DroppedFileFn<M>, DroppedFileFnAny);
 fn_any!(FocusedFn<M>, FocusedFnAny);
 fn_any!(UnfocusedFn<M>, UnfocusedFnAny);
 fn_any!(ClosedFn<M>, ClosedFnAny);
+fn_any!(OccludedFn<M>, OccludedFnAny);
 
 /// A nannou window.
 ///
@@ -696,6 +701,16 @@ impl<'app> Builder<'app> {
         M: 'static,
     {
         self.user_functions.closed = Some(ClosedFnAny::from_fn_ptr(f));
+        self
+    }
+
+    /// A function for processing the occluded event associated with this
+    /// window.
+    pub fn occluded<M>(mut self, f: OccludedFn<M>) -> Self
+    where
+        M: 'static,
+    {
+        self.user_functions.occluded = Some(OccludedFnAny::from_fn_ptr(f));
         self
     }
 

--- a/nannou_egui/Cargo.toml
+++ b/nannou_egui/Cargo.toml
@@ -14,5 +14,5 @@ readme = "../README.md"
 [dependencies]
 egui_wgpu_backend = "0.14"
 egui = "0.15.0"
-winit = "0.26"
+winit = "0.27"
 nannou = { version = "0.18.1", path = "../nannou" }


### PR DESCRIPTION
## Motivation
This pull request addresses issue #903 and updates the nannou and nannou_egui libraries to be compatible with winit version 0.27+. 

One breaking change in winit 0.27 is the removal of the `WindowAttributes` field on `WindowBuilder.` As a result, additional fields were added to `nannou::window::Builder` to track properties such as `inner_size` and `min_inner_size` before building the window. 

The winit update also introduces two new events: IME and Occluded. 
- The IME event corresponds to a "composition event" (e.g., a series of keyboard events that should be combined in a single produced character, like accented characters) and will only be created if `Window::set_ime_allowed` is called. I ignored the event because the added complexity would outweigh the benefits, but I may be wrong.
- The Occluded event is a macOS-only (for now) event that fires only when the current window is completely hidden from view. It contains a `bool` which I believe indicates if the window is hidden or not (this is not documented in winit). This event can be useful to save computations when the window is not visible.

## Summary of changes: 
- Update to winit 0.27. Update window.rs to deal with a few breaking changes.
- Handle new events IME (ignored) and Occluded (handled).
- Update examples to handle new Occluded events.
- Update changelog.