### PR TITLE
Implement nannou::geom::path::Builder `end` method

### DIFF
--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -15,6 +15,7 @@ back to the origins.
 - Move `nannou_conrod` and `nannou_timeline` into a new repository:
   https://github.com/nannou-org/nannou_conrod. Both crates are deprecated in
   favour of `nannou_egui`.
+- Add method for validated path ending with non-closed paths.
 
 ---
 

--- a/nannou/src/geom/path.rs
+++ b/nannou/src/geom/path.rs
@@ -116,6 +116,13 @@ impl Builder {
         self
     }
 
+    /// Closes the current sub path without resetting the position to the first position of the
+    /// current sub-path.
+    pub fn end(mut self) -> Self {
+        self.builder.end(false);
+        self
+    }
+
     /// Add a quadratic bezier curve to the path.
     pub fn quadratic_bezier_to(mut self, ctrl: Point2, to: Point2) -> Self {
         self.builder

--- a/nannou/tests/geom_tests.rs
+++ b/nannou/tests/geom_tests.rs
@@ -1,3 +1,7 @@
+use std::matches;
+
+use lyon::path::Event;
+use nannou::geom::path;
 use nannou::prelude::*;
 
 #[test]
@@ -12,4 +16,30 @@ fn angle_test() {
     assert_eq!(vector.angle(), -1.874531);
     let vector = vec2(70.7, -60.8);
     assert_eq!(vector.angle(), -0.7102547457375739);
+}
+
+#[test]
+fn path_builder_end_test() {
+    let mut builder = path();
+    builder = builder.begin(vec2(-50.0, 0.0));
+    builder = builder.quadratic_bezier_to(vec2(0.0, 25.0), vec2(50.0, 0.0));
+    builder = builder.end();
+    let path = builder.build();
+    assert!(matches!(
+        path.iter().last(),
+        Some(Event::End { close: false, .. })
+    ));
+}
+
+#[test]
+fn path_builder_close_test() {
+    let mut builder = path();
+    builder = builder.begin(vec2(-50.0, 0.0));
+    builder = builder.quadratic_bezier_to(vec2(0.0, 25.0), vec2(50.0, 0.0));
+    builder = builder.close();
+    let path = builder.build();
+    assert!(matches!(
+        path.iter().last(),
+        Some(Event::End { close: true, .. })
+    ));
 }


### PR DESCRIPTION
The `nannou::geom::path::Builder` doesn't expose the internal `lyon::path::path::Builder`'s `end` method, which leads to validation panics when a path is built outside of release mode. Reproducable example (must be run without `--release`, Lyon's path validator is turned off if the flag is enabled):

```rs
use nannou::prelude::*;
use nannou::geom::path;

fn main() {
    let mut builder = path();
    builder = builder.begin(vec2(-50.0, 0.0));
    builder = builder.quadratic_bezier_to(vec2(0.0, 25.0), vec2(50.0, 0.0));
    let _path = builder.build();
}
```

Since Lyon's `Builder::end` isn't exposed by Nannou, the only clearly documented way out is with `close`, but that's undesirable as it forces a closed loop. A workaround for this is to use `path.inner_mut().end(false);`, but for convenience this PR adds it to the Builder directly.

Requiring paths to be properly ended before `build` was added in Lyon v0.17. I see that an `end` method was correctly added with the version bump, but it wasn't published.

Resolves #933 