### PR TITLE
Try upgrade

### DIFF
--- a/examples/laser/laser_frame_stream_gui.rs
+++ b/examples/laser/laser_frame_stream_gui.rs
@@ -534,7 +534,7 @@ fn fonts() -> egui::FontDefinitions {
             (egui::FontFamily::Monospace, 14.0),
         ),
     ];
-    fonts.family_and_size.extend(entries.iter().cloned());
+    // fonts.family_and_size.extend(entries.iter().cloned());
     fonts
 }
 
@@ -542,7 +542,7 @@ fn style() -> egui::Style {
     let mut style = egui::Style::default();
     style.spacing = egui::style::Spacing {
         item_spacing: egui::Vec2::splat(8.0),
-        window_padding: egui::Vec2::new(6.0, 6.0),
+        // window_padding: egui::Vec2::new(6.0, 6.0),
         button_padding: egui::Vec2::new(4.0, 2.0),
         interact_size: egui::Vec2::new(56.0, 24.0),
         indent: 10.0,

--- a/examples/ui/egui/tune_color.rs
+++ b/examples/ui/egui/tune_color.rs
@@ -75,7 +75,7 @@ fn view(app: &App, model: &Model, frame: Frame) {
 }
 
 fn edit_hsv(ui: &mut egui::Ui, color: &mut Hsv) {
-    let mut egui_hsv = egui::color::Hsva::new(
+    let mut egui_hsv = egui::epaint::ecolor::Hsva::new(
         color.hue.to_positive_radians() as f32 / (std::f32::consts::PI * 2.0),
         color.saturation,
         color.value,

--- a/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
+++ b/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
@@ -43,7 +43,7 @@ fn model(app: &App) -> Model {
 
     // Create the compute shader module.
     let cs_desc = wgpu::include_wgsl!("shaders/cs.wgsl");
-    let cs_mod = device.create_shader_module(&cs_desc);
+    let cs_mod = device.create_shader_module(cs_desc);
 
     // Create the buffer that will store the result of our compute operation.
     let oscillator_buffer_size =
@@ -140,7 +140,8 @@ fn update(app: &App, model: &mut Model, _update: Update) {
         let mut cpass = encoder.begin_compute_pass(&pass_desc);
         cpass.set_pipeline(&compute.pipeline);
         cpass.set_bind_group(0, &compute.bind_group, &[]);
-        cpass.dispatch(OSCILLATOR_COUNT as u32, 1, 1);
+        // cpass.dis
+        cpass.dispatch_workgroups(OSCILLATOR_COUNT as u32, 1, 1);
     }
     encoder.copy_buffer_to_buffer(
         &compute.oscillator_buffer,

--- a/examples/wgpu/wgpu_image/wgpu_image.rs
+++ b/examples/wgpu/wgpu_image/wgpu_image.rs
@@ -54,8 +54,8 @@ fn model(app: &App) -> Model {
 
     let vs_desc = wgpu::include_wgsl!("shaders/vs.wgsl");
     let fs_desc = wgpu::include_wgsl!("shaders/fs.wgsl");
-    let vs_mod = device.create_shader_module(&vs_desc);
-    let fs_mod = device.create_shader_module(&fs_desc);
+    let vs_mod = device.create_shader_module(vs_desc);
+    let fs_mod = device.create_shader_module(fs_desc);
 
     // Load the image as a texture.
     let texture = wgpu::Texture::from_image(&window, &image);

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -32,8 +32,8 @@ toml = "0.5"
 walkdir = "2"
 wasm-bindgen = "*"
 web-sys = { version = "0.3", optional = true }
-wgpu_upstream = { version = "0.15", package = "wgpu" }
-winit = "0.27"
+wgpu_upstream = { version = "0.16", package = "wgpu" }
+winit = "0.28"
 
 [features]
 default = ["notosans"]

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -30,9 +30,10 @@ serde_derive = "1"
 serde_json = "1"
 toml = "0.5"
 walkdir = "2"
-web-sys = { version = "0.3.55", optional = true }
-wgpu_upstream = { version = "0.11.1", package = "wgpu" }
-winit = "0.26"
+wasm-bindgen = "*"
+web-sys = { version = "0.3", optional = true }
+wgpu_upstream = { version = "0.15", package = "wgpu" }
+winit = "0.27"
 
 [features]
 default = ["notosans"]

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -32,8 +32,8 @@ toml = "0.5"
 walkdir = "2"
 wasm-bindgen = "*"
 web-sys = { version = "0.3", optional = true }
-wgpu_upstream = { version = "0.16", package = "wgpu" }
-winit = "0.28"
+wgpu_upstream = { version = "0.15", package = "wgpu" }
+winit = "0.27"
 
 [features]
 default = ["notosans"]

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -637,7 +637,7 @@ impl App {
         capture_frame_timeout: Option<Duration>,
         backends: wgpu::Backends,
     ) -> Self {
-        let instance = wgpu::Instance::new(backends);
+        let instance = wgpu::Instance::default();
         let adapters = Default::default();
         let windows = RefCell::new(HashMap::new());
         let draw = RefCell::new(draw::Draw::default());

--- a/nannou/src/draw/renderer/mod.rs
+++ b/nannou/src/draw/renderer/mod.rs
@@ -387,8 +387,8 @@ impl Renderer {
         // Load shader modules.
         let vs_desc = wgpu::include_wgsl!("shaders/vs.wgsl");
         let fs_desc = wgpu::include_wgsl!("shaders/fs.wgsl");
-        let vs_mod = device.create_shader_module(&vs_desc);
-        let fs_mod = device.create_shader_module(&fs_desc);
+        let vs_mod = device.create_shader_module(vs_desc);
+        let fs_mod = device.create_shader_module(fs_desc);
 
         // Create the glyph cache texture.
         let text_sampler_desc = wgpu::SamplerBuilder::new().into_descriptor();

--- a/nannou/src/draw/renderer/shaders/fs.wgsl
+++ b/nannou/src/draw/renderer/shaders/fs.wgsl
@@ -1,21 +1,21 @@
 struct FragmentOutput {
-    [[location(0)]] color: vec4<f32>;
+    @location(0) color: vec4<f32>,
 };
 
-[[group(1), binding(0)]]
+@group(1) @binding(0)
 var text_sampler: sampler;
-[[group(1), binding(1)]]
+@group(1) @binding(1)
 var text: texture_2d<f32>;
-[[group(2), binding(0)]]
+@group(2) @binding(0)
 var tex_sampler: sampler;
-[[group(2), binding(1)]]
+@group(2) @binding(1)
 var tex: texture_2d<f32>;
 
-[[stage(fragment)]]
+@fragment
 fn main(
-    [[location(0)]] color: vec4<f32>,
-    [[location(1)]] tex_coords: vec2<f32>,
-    [[location(2)]] mode: u32,
+    @location(0) color: vec4<f32>,
+    @location(1) tex_coords: vec2<f32>,
+    @location(2) mode: u32,
 ) -> FragmentOutput {
     let tex_color: vec4<f32> = textureSample(tex, tex_sampler, tex_coords);
     let text_color: vec4<f32> = textureSample(text, text_sampler, tex_coords);

--- a/nannou/src/draw/renderer/shaders/vs.wgsl
+++ b/nannou/src/draw/renderer/shaders/vs.wgsl
@@ -1,24 +1,23 @@
-[[block]]
 struct Data {
-    proj: mat4x4<f32>;
+    proj: mat4x4<f32>,
 };
 
 struct VertexOutput {
-    [[location(0)]] color: vec4<f32>;
-    [[location(1)]] tex_coords: vec2<f32>;
-    [[location(2)]] mode: u32;
-    [[builtin(position)]] pos: vec4<f32>;
+    @location(0) color: vec4<f32>,
+    @location(1) tex_coords: vec2<f32>,
+    @location(2) mode: u32,
+    @builtin(position) pos: vec4<f32>,
 };
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<uniform> uniforms: Data;
 
-[[stage(vertex)]]
+@vertex
 fn main(
-    [[location(0)]] position: vec3<f32>,
-    [[location(1)]] color: vec4<f32>,
-    [[location(2)]] tex_coords: vec2<f32>,
-    [[location(3)]] mode: u32,
+    @location(0) position: vec3<f32>,
+    @location(1) color: vec4<f32>,
+    @location(2) tex_coords: vec2<f32>,
+    @location(3) mode: u32,
 ) -> VertexOutput {
     let out_pos: vec4<f32> = uniforms.proj * vec4<f32>(position, 1.0);
     return VertexOutput(color, tex_coords, mode, out_pos);

--- a/nannou/src/event.rs
+++ b/nannou/src/event.rs
@@ -307,6 +307,11 @@ impl WindowEvent {
             | winit::event::WindowEvent::ScaleFactorChanged { .. } => {
                 return None;
             }
+
+            _ => {
+                // TODO: some unhandled variants?
+                return None;
+            }
         };
 
         Some(event)

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -21,6 +21,7 @@ use std::{env, fmt};
 use winit::dpi::{LogicalSize, PhysicalSize};
 
 pub use winit::window::Fullscreen;
+use winit::window::WindowAttributes;
 pub use winit::window::WindowId as Id;
 
 /// The default dimensions used for a window in the case that none are specified.
@@ -330,7 +331,7 @@ impl SurfaceConfigurationBuilder {
         let usage = self.usage.unwrap_or(Self::DEFAULT_USAGE);
         let format = self
             .format
-            .or_else(|| surface.get_preferred_format(&adapter))
+            // .or_else(|| surface.get_preferred_format(&adapter))
             .unwrap_or(Self::DEFAULT_FORMAT);
         let present_mode = self.present_mode.unwrap_or(Self::DEFAULT_PRESENT_MODE);
         wgpu::SurfaceConfiguration {
@@ -339,6 +340,7 @@ impl SurfaceConfigurationBuilder {
             width: width_px,
             height: height_px,
             present_mode,
+            alpha_mode: wgpu::CompositeAlphaMode::Auto
         }
     }
 }
@@ -775,12 +777,10 @@ impl<'app> Builder<'app> {
         }
 
         // Set default dimensions in the case that none were given.
-        let initial_window_size = window
-            .window
+        let initial_window_size = WindowAttributes::default()
             .inner_size
             .or_else(|| {
-                window
-                    .window
+                WindowAttributes::default()
                     .fullscreen
                     .as_ref()
                     .and_then(|fullscreen| match fullscreen {
@@ -803,7 +803,7 @@ impl<'app> Builder<'app> {
             })
             .unwrap_or_else(|| {
                 let mut dim = DEFAULT_DIMENSIONS;
-                if let Some(min) = window.window.min_inner_size {
+                if let Some(min) = window.window_attributes().min_inner_size {
                     match min {
                         winit::dpi::Size::Logical(min) => {
                             dim.width = dim.width.max(min.width as _);
@@ -816,7 +816,7 @@ impl<'app> Builder<'app> {
                         }
                     }
                 }
-                if let Some(max) = window.window.max_inner_size {
+                if let Some(max) = window.window_attributes().max_inner_size {
                     match max {
                         winit::dpi::Size::Logical(max) => {
                             dim.width = dim.width.min(max.width as _);
@@ -834,13 +834,15 @@ impl<'app> Builder<'app> {
 
         // Use the `initial_window_size` as the default dimensions for the window if none
         // were specified.
-        if window.window.inner_size.is_none() && window.window.fullscreen.is_none() {
-            window.window.inner_size = Some(initial_window_size);
+        if window.window_attributes().inner_size.is_none() && window.window_attributes().fullscreen.is_none() {
+            // TODO: how to mutate this in new API?
+            // window.window_attributes().inner_size = Some(initial_window_size);
         }
 
         // Set a default minimum window size for configuring the surface.
-        if window.window.min_inner_size.is_none() && window.window.fullscreen.is_none() {
-            window.window.min_inner_size = Some(winit::dpi::Size::Physical(MIN_SC_PIXELS));
+        if window.window_attributes().min_inner_size.is_none() && window.window_attributes().fullscreen.is_none() {
+            // TODO: how to mutate this in new API?
+            // window.window_attributes().min_inner_size = Some(winit::dpi::Size::Physical(MIN_SC_PIXELS));
         }
 
         // Background must be initially cleared
@@ -848,7 +850,7 @@ impl<'app> Builder<'app> {
 
         let clear_color = clear_color.unwrap_or_else(|| {
             let mut color: wgpu::Color = Default::default();
-            color.a = if window.window.transparent { 0.0 } else { 1.0 };
+            color.a = if window.window_attributes().transparent { 0.0 } else { 1.0 };
             color
         });
 
@@ -1070,9 +1072,10 @@ impl<'app> Builder<'app> {
     }
 
     /// Sets whether or not the window will always be on top of other windows.
-    pub fn always_on_top(self, always_on_top: bool) -> Self {
-        self.map_window(|w| w.with_always_on_top(always_on_top))
-    }
+    /// TODO: this seems to no longer apply in new API?
+    // pub fn always_on_top(self, always_on_top: bool) -> Self {
+    //     self.map_window(|w| w.with_always_on_top(always_on_top))
+    // }
 
     /// Sets the window icon.
     pub fn window_icon(self, window_icon: Option<winit::window::Icon>) -> Self {
@@ -1315,7 +1318,8 @@ impl Window {
 
     /// Change whether or not the window will always be on top of other windows.
     pub fn set_always_on_top(&self, always_on_top: bool) {
-        self.window.set_always_on_top(always_on_top)
+        // TODO: this seems to no longer apply in new API?
+        // self.window.set_always_on_top(always_on_top)
     }
 
     /// Sets the window icon. On Windows and X11, this is typically the small icon in the top-left
@@ -1380,7 +1384,7 @@ impl Window {
     /// - **iOS:** Always returns an Err.
     /// - **Web:** Has no effect.
     pub fn set_cursor_grab(&self, grab: bool) -> Result<(), winit::error::ExternalError> {
-        self.window.set_cursor_grab(grab)
+        self.window.set_cursor_grab({ if grab { winit::window::CursorGrabMode::Confined } else { winit::window::CursorGrabMode::None}})
     }
 
     /// Set the cursor's visibility.

--- a/nannou_egui/Cargo.toml
+++ b/nannou_egui/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/AlexEne/nannou_egui"
 readme = "../README.md"
 
 [dependencies]
-eframe = "0.21.3"
-egui-wgpu = { version ="0.21", features=["winit"]}
-egui = "0.21.0"
-winit = "0.28"
+eframe = "0.20"
+egui = "0.20" 
+egui_wgpu_backend = "0.21"
+winit = "0.27"
 nannou = { version = "0.18.1", path = "../nannou" }

--- a/nannou_egui/Cargo.toml
+++ b/nannou_egui/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/AlexEne/nannou_egui"
 readme = "../README.md"
 
 [dependencies]
-egui_wgpu_backend = "0.22"
-egui = "0.15.0"
-winit = "0.26"
+eframe = "0.21.3"
+egui-wgpu = "0.21"
+egui = "0.21.0"
+winit = "0.28"
 nannou = { version = "0.18.1", path = "../nannou" }

--- a/nannou_egui/Cargo.toml
+++ b/nannou_egui/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 eframe = "0.21.3"
-egui-wgpu = "0.21"
+egui-wgpu = { version ="0.21", features=["winit"]}
 egui = "0.21.0"
 winit = "0.28"
 nannou = { version = "0.18.1", path = "../nannou" }

--- a/nannou_egui/Cargo.toml
+++ b/nannou_egui/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/AlexEne/nannou_egui"
 readme = "../README.md"
 
 [dependencies]
-egui_wgpu_backend = "0.14"
+egui_wgpu_backend = "0.22"
 egui = "0.15.0"
 winit = "0.26"
 nannou = { version = "0.18.1", path = "../nannou" }

--- a/nannou_egui_demo_app/src/main.rs
+++ b/nannou_egui_demo_app/src/main.rs
@@ -1,5 +1,5 @@
 use nannou::prelude::*;
-use nannou_egui::{egui_wgpu_backend::epi::App as EguiApp, Egui};
+use nannou_egui::Egui;
 
 fn main() {
     nannou::app(model).update(update).run();
@@ -22,9 +22,9 @@ fn model(app: &App) -> Model {
     let mut egui = Egui::from_window(&window);
     let mut egui_demo_app = egui_demo_lib::WrapApp::default();
     let proxy = app.create_proxy();
-    egui.do_frame_with_epi_frame(proxy, |ctx, epi_frame| {
-        egui_demo_app.setup(&ctx, epi_frame, None);
-    });
+    // egui.do_frame_with_epi_frame(proxy, |ctx, epi_frame| {
+    //     egui_demo_app.setup(&ctx, epi_frame, None);
+    // });
     Model {
         egui,
         egui_demo_app,
@@ -43,9 +43,9 @@ fn update(app: &App, model: &mut Model, update: Update) {
     } = *model;
     egui.set_elapsed_time(update.since_start);
     let proxy = app.create_proxy();
-    egui.do_frame_with_epi_frame(proxy, |ctx, frame| {
-        egui_demo_app.update(&ctx, frame);
-    });
+    // egui.do_frame_with_epi_frame(proxy, |ctx, frame| {
+    //     egui_demo_app.update(&ctx, frame);
+    // });
 }
 
 fn view(_app: &App, model: &Model, frame: Frame) {

--- a/nannou_wgpu/Cargo.toml
+++ b/nannou_wgpu/Cargo.toml
@@ -14,7 +14,7 @@ async-std = "1.10.0"
 image = { version = "0.23", optional = true }
 instant = { version = "0.1.9", optional = true }
 num_cpus = { version = "1", optional = true }
-wgpu_upstream = { version = "0.11.1", package = "wgpu" }
+wgpu_upstream = { version = "0.14", package = "wgpu" }
 
 [features]
 capturer = ["image", "instant", "num_cpus"]

--- a/nannou_wgpu/Cargo.toml
+++ b/nannou_wgpu/Cargo.toml
@@ -14,7 +14,7 @@ async-std = "1.10.0"
 image = { version = "0.23", optional = true }
 instant = { version = "0.1.9", optional = true }
 num_cpus = { version = "1", optional = true }
-wgpu_upstream = { version = "0.14", package = "wgpu" }
+wgpu_upstream = { version = "0.15", package = "wgpu" }
 
 [features]
 capturer = ["image", "instant", "num_cpus"]

--- a/nannou_wgpu/src/bind_group_builder.rs
+++ b/nannou_wgpu/src/bind_group_builder.rs
@@ -60,21 +60,15 @@ impl LayoutBuilder {
 
     /// Add a sampler binding to the layout.
     pub fn sampler(self, visibility: wgpu::ShaderStages, filtering: bool) -> Self {
-        let comparison = false;
-        let ty = wgpu::BindingType::Sampler {
-            filtering,
-            comparison,
-        };
+        // let comparison = false;
+        let ty = wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering);
         self.binding(visibility, ty)
     }
 
     /// Add a sampler binding to the layout.
     pub fn comparison_sampler(self, visibility: wgpu::ShaderStages, filtering: bool) -> Self {
-        let comparison = true;
-        let ty = wgpu::BindingType::Sampler {
-            filtering,
-            comparison,
-        };
+        // let comparison = true;
+        let ty = wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering);
         self.binding(visibility, ty)
     }
 

--- a/nannou_wgpu/src/device_map.rs
+++ b/nannou_wgpu/src/device_map.rs
@@ -163,7 +163,7 @@ impl AdapterMap {
             .lock()
             .expect("failed to acquire `AdapterMap` lock");
         for adapter in map.values() {
-            adapter._poll_all_devices(maintain);
+            adapter._poll_all_devices(maintain.clone());
         }
     }
 }
@@ -277,7 +277,7 @@ impl ActiveAdapter {
             .expect("failed to acquire `DeviceMap` lock");
         for weak in map.values() {
             if let Some(pair) = weak.upgrade() {
-                pair.device().poll(maintain);
+                pair.device().poll(maintain.clone());
             }
         }
     }

--- a/nannou_wgpu/src/lib.rs
+++ b/nannou_wgpu/src/lib.rs
@@ -94,7 +94,7 @@ pub use wgpu_upstream::{
     SurfaceTexture, Texture as TextureHandle, TextureAspect, TextureDescriptor, TextureDimension,
     TextureFormat, TextureFormatFeatureFlags, TextureFormatFeatures, TextureSampleType,
     TextureUsages, TextureView as TextureViewHandle, TextureViewDescriptor, TextureViewDimension,
-    UncapturedErrorHandler, VertexAttribute, VertexBufferLayout, VertexFormat, VertexState,
+    UncapturedErrorHandler, VertexAttribute, VertexBufferLayout, VertexFormat, VertexState,SamplerBindingType,CompositeAlphaMode,
     VertexStepMode, COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT, MAP_ALIGNMENT,
     PUSH_CONSTANT_ALIGNMENT, QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE,
     VERTEX_STRIDE_ALIGNMENT,

--- a/nannou_wgpu/src/lib.rs
+++ b/nannou_wgpu/src/lib.rs
@@ -117,7 +117,7 @@ pub fn shader_from_spirv_bytes(
         label: Some("nannou_shader_module"),
         source,
     };
-    device.create_shader_module(&desc)
+    device.create_shader_module(desc)
 }
 
 /// Adds a simple render pass command to the given encoder that simply clears the given texture

--- a/nannou_wgpu/src/render_pass.rs
+++ b/nannou_wgpu/src/render_pass.rs
@@ -3,7 +3,7 @@ use crate::{self as wgpu, Color, LoadOp};
 /// A builder type to simplify the process of creating a render pass descriptor.
 #[derive(Debug, Default)]
 pub struct Builder<'a> {
-    color_attachments: Vec<wgpu::RenderPassColorAttachment<'a>>,
+    color_attachments: Option<wgpu::RenderPassColorAttachment<'a>>,
     depth_stencil_attachment: Option<wgpu::RenderPassDepthStencilAttachment<'a>>,
 }
 
@@ -168,7 +168,7 @@ impl<'a> Builder<'a> {
     {
         let builder = ColorAttachmentDescriptorBuilder::new(attachment);
         let descriptor = color_builder(builder).descriptor;
-        self.color_attachments.push(descriptor);
+        self.color_attachments = Some(descriptor);
         self
     }
 
@@ -196,7 +196,7 @@ impl<'a> Builder<'a> {
     pub fn into_inner(
         self,
     ) -> (
-        Vec<wgpu::RenderPassColorAttachment<'a>>,
+        Option<wgpu::RenderPassColorAttachment<'a>>,
         Option<wgpu::RenderPassDepthStencilAttachment<'a>>,
     ) {
         let Builder {
@@ -211,7 +211,7 @@ impl<'a> Builder<'a> {
         let (color_attachments, depth_stencil_attachment) = self.into_inner();
         let descriptor = wgpu::RenderPassDescriptor {
             label: Some("nannou_render_pass"),
-            color_attachments: &color_attachments,
+            color_attachments: &[color_attachments],
             depth_stencil_attachment,
         };
         encoder.begin_render_pass(&descriptor)

--- a/nannou_wgpu/src/render_pipeline_builder.rs
+++ b/nannou_wgpu/src/render_pipeline_builder.rs
@@ -57,7 +57,7 @@ impl<'a> RenderPipelineBuilder<'a> {
     };
 
     // Color state defaults.
-    pub const DEFAULT_COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
+    pub const DEFAULT_COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
     pub const DEFAULT_COLOR_BLEND: wgpu::BlendComponent = wgpu::BlendComponent {
         src_factor: wgpu::BlendFactor::SrcAlpha,
         dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,

--- a/nannou_wgpu/src/sampler_builder.rs
+++ b/nannou_wgpu/src/sampler_builder.rs
@@ -15,7 +15,7 @@ impl<'b> SamplerBuilder {
     pub const DEFAULT_MAG_FILTER: wgpu::FilterMode = wgpu::FilterMode::Linear;
     pub const DEFAULT_MIN_FILTER: wgpu::FilterMode = wgpu::FilterMode::Linear;
     pub const DEFAULT_MIPMAP_FILTER: wgpu::FilterMode = wgpu::FilterMode::Nearest;
-    pub const DEFAULT_LOD_MIN_CLAMP: f32 = -100.0;
+    pub const DEFAULT_LOD_MIN_CLAMP: f32 = 0.;
     pub const DEFAULT_LOD_MAX_CLAMP: f32 = 100.0;
     pub const DEFAULT_COMPARE: Option<wgpu::CompareFunction> = None;
     pub const DEFAULT_ANISOTROPY_CLAMP: Option<NonZeroU8> = None;

--- a/nannou_wgpu/src/texture/image.rs
+++ b/nannou_wgpu/src/texture/image.rs
@@ -311,7 +311,7 @@ impl wgpu::RowPaddedBuffer {
     /// polled. You should *not* rely on the being ready immediately.
     pub async fn read<'b>(&'b self) -> Result<ImageReadMapping<'b>, wgpu::BufferAsyncError> {
         let slice = self.buffer.slice(..);
-        slice.map_async(wgpu::MapMode::Read).await?;
+        slice.map_async(wgpu::MapMode::Read, |res| {});
         Ok(wgpu::ImageReadMapping {
             buffer: self,
             // fun exercise:

--- a/nannou_wgpu/src/texture/mod.rs
+++ b/nannou_wgpu/src/texture/mod.rs
@@ -1,3 +1,5 @@
+use wgpu_upstream::TextureFormat;
+
 use crate::{self as wgpu, RowPaddedBuffer, TextureHandle, TextureViewHandle};
 use std::ops::Deref;
 use std::sync::Arc;
@@ -432,6 +434,7 @@ impl Builder {
         dimension: Self::DEFAULT_DIMENSION,
         format: Self::DEFAULT_FORMAT,
         usage: Self::DEFAULT_USAGE,
+        view_formats: &[]
     };
 
     /// Creates a new `Default` builder
@@ -532,6 +535,7 @@ impl Builder {
     pub fn into_descriptor(self) -> wgpu::TextureDescriptor<'static> {
         self.into()
     }
+
 }
 
 impl<'a> ViewBuilder<'a> {

--- a/nannou_wgpu/src/texture/reshaper/mod.rs
+++ b/nannou_wgpu/src/texture/reshaper/mod.rs
@@ -50,8 +50,8 @@ impl Reshaper {
             16 => wgpu::include_wgsl!("shaders/fs_msaa16.wgsl"),
             _ => wgpu::include_wgsl!("shaders/fs_msaa.wgsl"),
         };
-        let vs_mod = device.create_shader_module(&vs_desc);
-        let fs_mod = device.create_shader_module(&fs_desc);
+        let vs_mod = device.create_shader_module(vs_desc);
+        let fs_mod = device.create_shader_module(fs_desc);
 
         // Create the sampler for sampling from the source texture.
         let sampler_desc = wgpu::SamplerBuilder::new().into_descriptor();

--- a/nannou_wgpu/src/texture/reshaper/shaders/fs.wgsl
+++ b/nannou_wgpu/src/texture/reshaper/shaders/fs.wgsl
@@ -1,15 +1,15 @@
 struct FragmentOutput {
-    [[location(0)]] out_color: vec4<f32>;
+    @location(0) out_color: vec4<f32>,
 };
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var tex: texture_2d<f32>;
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var tex_sampler: sampler;
 
-[[stage(fragment)]]
+@fragment
 fn main(
-    [[location(0)]] tex_coords: vec2<f32>,
+    @location(0) tex_coords: vec2<f32>,
 ) -> FragmentOutput {
     let out_color: vec4<f32> = textureSample(tex, tex_sampler, tex_coords);
     return FragmentOutput(out_color);

--- a/nannou_wgpu/src/texture/reshaper/shaders/vs.wgsl
+++ b/nannou_wgpu/src/texture/reshaper/shaders/vs.wgsl
@@ -1,11 +1,11 @@
 struct VertexOutput {
-    [[location(0)]] tex_coords: vec2<f32>;
-    [[builtin(position)]] out_pos: vec4<f32>;
+    @location(0) tex_coords: vec2<f32>,
+    @builtin(position) out_pos: vec4<f32>,
 };
 
-[[stage(vertex)]]
+@vertex
 fn main(
-    [[location(0)]] pos: vec2<f32>,
+    @location(0) pos: vec2<f32>,
 ) -> VertexOutput {
     let out_pos: vec4<f32> = vec4<f32>(pos, 0.0, 1.0);
     let tex_coords: vec2<f32> = vec2<f32>(pos.x * 0.5 + 0.5, 1.0 - (pos.y * 0.5 + 0.5));


### PR DESCRIPTION
This is a messy attempt to get Nannou up to WGPU v0.15 (from 0.11).

After messing around with dependencies (particularly for egui) and adjusting WGSL shader code (the syntax has changed somewhat in the last few years) I have got to the point where Nannou compiles at least for a simple example like `draw` 

But I think I'm missing some understanding of the details of how Nannou translates WGPU textures, etc. so I get the following error message:

```
Caused by:
    In a RenderPass
      note: encoder = `nannou_raw_frame`
    In a set_pipeline command
      note: render pipeline = `nannou render pipeline`
    Render pipeline targets are incompatible with render pass
    Incompatible color attachment: the renderpass expected [Some(Rgba8Unorm)] but was given []

', /Users/stephen/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.15.1/src/backend/direct.rs:3024:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In a CommandEncoder
    command encoder is invalid
```
Any help from more experienced Rust+Nannou devs would be much appreciated.