### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/nannou_egui/Cargo.toml
+++ b/nannou_egui/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
 ]
 edition = "2018"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "egui integration for nannou"
 repository = "https://github.com/AlexEne/nannou_egui"
 readme = "../README.md"


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields