### PR TITLE
Expose nannou::wgpu::texture::image::Pixel from wgpu module

### DIFF
--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -15,6 +15,7 @@ back to the origins.
 - Move `nannou_conrod` and `nannou_timeline` into a new repository:
   https://github.com/nannou-org/nannou_conrod. Both crates are deprecated in
   favour of `nannou_egui`.
+- Expose `nannou::wgpu::texture::image::Pixel` in `nannou::wgpu`.
 
 ---
 

--- a/nannou_wgpu/src/lib.rs
+++ b/nannou_wgpu/src/lib.rs
@@ -56,7 +56,7 @@ pub use self::texture::capturer::{
 #[cfg(feature = "image")]
 pub use self::texture::image::{
     format_from_image_color_type as texture_format_from_image_color_type, ImageHolder,
-    ImageReadMapping, WithDeviceQueuePair,
+    ImageReadMapping, Pixel, WithDeviceQueuePair,
 };
 pub use self::texture::reshaper::Reshaper as TextureReshaper;
 pub use self::texture::row_padded_buffer::RowPaddedBuffer;


### PR DESCRIPTION
Motivation
Close https://github.com/nannou-org/nannou/issues/595.

Summary
Exposed `Pixel` in the `wgpu` crate.

4 examples failed (judging by cmd+f "panicked"), but I assume those are unrelated to this change? For example:
```
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
      note: label = `nannou render pipeline`
    error matching FRAGMENT shader requirements against the pipeline
    shader global ResourceBinding { group: 2, binding: 1 } is not available in the layout pipeline layout
    binding is missing from the pipeline layout
```