### PR TITLE
Add a Nix flake along with a package derivation (default.nix) and dev shell (shell.nix). Update hotglsl.

### DIFF
--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -8,15 +8,6 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@main
     - run: nix fmt -- --check ./
 
-  cargo-audit:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v3
-      - uses: rustsec/audit-check@v1.4.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   cargo-fmt-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
-    - run: nix develop --command cargo fmt --verbose --workspace -- --check
+    - run: nix develop --command cargo fmt --verbose --all -- --check
 
   cargo-check:
     runs-on: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: Swatinem/rust-cache@v2
     - run: nix develop --command cargo check --locked --workspace
-    - run: nix develop --command cargo check --examples --workspace
+    - run: nix develop --command cargo check --locked --examples --workspace
 
   cargo-test:
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: Swatinem/rust-cache@v2
-    - run: nix develop --command cargo test --locked --workspace
+    - run: nix develop --command cargo test --locked --lib --bins --workspace
 
   cargo-test-all-features:
     runs-on: ubuntu-latest
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: Swatinem/rust-cache@v2
-    - run: nix develop --command cargo test --locked --all-features --workspace
+    - run: nix develop --command cargo test --locked --lib --bins --all-features --workspace
 
   cargo-doc-all-features:
     runs-on: ubuntu-latest

--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -1,194 +1,125 @@
 name: nannou
 on: [push, pull_request]
 jobs:
-  rustfmt-check:
+  nix-fmt-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt
-    - name: Run rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - run: nix fmt -- --check ./
+
+  cargo-audit:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  cargo-fmt-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - run: nix develop --command cargo fmt --verbose --workspace -- --check
+
+  cargo-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: Swatinem/rust-cache@v2
+    - run: nix develop --command cargo check --locked --workspace
+    - run: nix develop --command cargo check --examples --workspace
 
   cargo-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Update apt
-      run: sudo apt update
-    - name: Install alsa dev tools
-      run: sudo apt-get install libasound2-dev
-    - name: Install libxcb dev tools
-      run: sudo apt-get install libxcb-composite0-dev
-    - name: Install libuv dev tools
-      run: sudo apt-get install libudev-dev
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: Swatinem/rust-cache@v1
-    - name: Run default features
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --lib --bins --verbose
-    - name: Test docs
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --doc --verbose
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: Swatinem/rust-cache@v2
+    - run: nix develop --command cargo test --locked --workspace
 
   cargo-test-all-features:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Update apt
-      run: sudo apt update
-    - name: Install alsa dev tools
-      run: sudo apt-get install libasound2-dev
-    - name: Install libxcb dev tools
-      run: sudo apt-get install libxcb-composite0-dev
-    - name: Install libuv dev tools
-      run: sudo apt-get install libudev-dev
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: Swatinem/rust-cache@v1
-    - name: Run all features
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --lib --bins --all-features --verbose
-    - name: Test docs all features
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --doc --all-features --verbose
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: Swatinem/rust-cache@v2
+    - run: nix develop --command cargo test --locked --all-features --workspace
 
-  cargo-test-core-no-std:
+  cargo-doc-all-features:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Update apt
-      run: sudo apt update
-    - name: Install libxcb dev tools
-      run: sudo apt-get install libxcb-composite0-dev
-    - name: Install libuv dev tools
-      run: sudo apt-get install libudev-dev
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: Swatinem/rust-cache@v1
-    - name: Text no_std
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: -p nannou_core --no-default-features --features "libm" --verbose
-    - name: Test no_std serde
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: -p nannou_core --no-default-features --features "libm serde" --verbose
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: Swatinem/rust-cache@v2
+    - run: nix develop --command cargo doc --locked --all-features --workspace
 
-  cargo-check-examples:
+  cargo-test-nannou-core-no-std:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Update apt
-      run: sudo apt update
-    - name: Install alsa dev tools
-      run: sudo apt-get install libasound2-dev
-    - name: Install libxcb dev tools
-      run: sudo apt-get install libxcb-composite0-dev
-    - name: Install libuv dev tools
-      run: sudo apt-get install libudev-dev
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        target: wasm32-unknown-unknown
-    - uses: Swatinem/rust-cache@v1
-    - name: Run check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --examples --verbose
-    - name: Check nannou package builds against wasm32-unknown-unknown
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: -p nannou --features wasm-experimental --target wasm32-unknown-unknown
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: Swatinem/rust-cache@v2
+    - run: nix develop --command cargo test --locked -p nannou_core --no-default-features --features "libm serde"
+
+  cargo-build-nannou-wasm32:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: Swatinem/rust-cache@v2
+    - run: nix develop --command cargo build --locked -p nannou --features "wasm-experimental" --target wasm32-unknown-unknown
+
+  verifications:
+    needs:
+      [
+        cargo-build-nannou-wasm32,
+        cargo-check,
+        cargo-doc-all-features,
+        cargo-fmt-check,
+        cargo-test,
+        cargo-test-all-features,
+        cargo-test-nannou-core-no-std,
+        nix-fmt-check,
+      ]
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "Verifications complete"
 
   cargo-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [ verifications ]
     env:
       CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Update apt
-      run: sudo apt update
-    - name: Install alsa dev tools
-      run: sudo apt-get install libasound2-dev
-    - name: Install libxcb dev tools
-      run: sudo apt-get install libxcb-composite0-dev
-    - name: Install libuv dev tools
-      run: sudo apt-get install libudev-dev
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: Swatinem/rust-cache@v2
     - name: Cargo publish nannou_core
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_core/Cargo.toml
     - name: Cargo publish nannou_wgpu
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_wgpu/Cargo.toml
-    - name: Wait for crates.io
-      run: sleep 30
     - name: Cargo publish nannou_mesh
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_mesh/Cargo.toml
-    - name: Wait for crates.io
-      run: sleep 30
     - name: Cargo publish nannou
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou/Cargo.toml
     - name: Cargo publish nannou_audio
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_audio/Cargo.toml
-    # TODO: Add this once `nannou_isf` is ready.
-    # - name: Cargo publish nannou_isf
-    #   continue-on-error: true
-    #   run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_isf/Cargo.toml
     - name: Cargo publish nannou_laser
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_laser/Cargo.toml
     - name: Cargo publish nannou_osc
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_osc/Cargo.toml
-    - name: Wait for crates.io
-      run: sleep 15
     - name: Cargo publish nannou_egui
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_egui/Cargo.toml
@@ -196,67 +127,26 @@ jobs:
   guide-build-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Update apt
-      run: sudo apt update
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: Swatinem/rust-cache@v1
-    - name: Install mdbook
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: mdbook
-    - name: Build book
-      run: mdbook build guide/
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - run: nix develop --command mdbook build guide/
 
   guide-test-code:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Update apt
-      run: sudo apt update
-    - name: Install alsa dev tools
-      run: sudo apt-get install libasound2-dev
-    - name: Install libxcb dev tools
-      run: sudo apt-get install libxcb-composite0-dev
-    - name: Install libuv dev tools
-      run: sudo apt-get install libudev-dev
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: Swatinem/rust-cache@v1
-    - name: Run guide tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: -p book_tests --verbose
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: Swatinem/rust-cache@v2
+    - run: nix develop --command cargo test --locked -p book_tests
 
   guide-push-to-deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install rust stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Install mdbook
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: mdbook
-    - name: Build book
-      run: mdbook build guide/
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: Swatinem/rust-cache@v2
+    - run: nix develop --command mdbook build guide/
     - name: Commit book to deploy branch
       run: |
         git config user.email "action@github.com"

--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -1,6 +1,7 @@
 name: nannou
 on: [push, pull_request]
 jobs:
+  # Check the nix code is formatted.
   nix-fmt-check:
     runs-on: ubuntu-latest
     steps:
@@ -8,7 +9,20 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@main
     - run: nix fmt -- --check ./
 
-  cargo-verifications:
+  # Check the nix flake is valid on macos and linux.
+  nix-flake-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - run: nix flake check
+
+  # A colleciton of cargo verifications that should pass before landing PRs.
+  cargo:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -29,12 +43,20 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: nix develop --command ${{ matrix.command }}
 
+  # Synchronise the verification jobs under one that we can depend on for publish jobs.
   verifications:
-    needs: [ cargo-verifications, nix-fmt-check ]
+    needs:
+      [
+        cargo,
+        nix-flake-check,
+        nix-fmt-check,
+      ]
     runs-on: ubuntu-latest
     steps:
     - run: echo "Verifications complete"
 
+  # Publish all the crates.
+  # TODO: There's probs a single action out there for publishing a whole workspacce?
   cargo-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: [ verifications ]
@@ -70,8 +92,10 @@ jobs:
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_egui/Cargo.toml
 
+  # Publish the guide by pushing it to `deploy` branch.
   guide-push-to-deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [ verifications ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -69,28 +69,28 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Cargo publish nannou_core
       continue-on-error: true
-      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_core/Cargo.toml
+      run: nix develop --command cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_core/Cargo.toml
     - name: Cargo publish nannou_wgpu
       continue-on-error: true
-      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_wgpu/Cargo.toml
+      run: nix develop --command cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_wgpu/Cargo.toml
     - name: Cargo publish nannou_mesh
       continue-on-error: true
-      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_mesh/Cargo.toml
+      run: nix develop --command cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_mesh/Cargo.toml
     - name: Cargo publish nannou
       continue-on-error: true
-      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou/Cargo.toml
+      run: nix develop --command cargo publish --token $CRATESIO_TOKEN --manifest-path nannou/Cargo.toml
     - name: Cargo publish nannou_audio
       continue-on-error: true
-      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_audio/Cargo.toml
+      run: nix develop --command cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_audio/Cargo.toml
     - name: Cargo publish nannou_laser
       continue-on-error: true
-      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_laser/Cargo.toml
+      run: nix develop --command cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_laser/Cargo.toml
     - name: Cargo publish nannou_osc
       continue-on-error: true
-      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_osc/Cargo.toml
+      run: nix develop --command cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_osc/Cargo.toml
     - name: Cargo publish nannou_egui
       continue-on-error: true
-      run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_egui/Cargo.toml
+      run: nix develop --command cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_egui/Cargo.toml
 
   # Publish the guide by pushing it to `deploy` branch.
   guide-push-to-deploy:

--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -8,74 +8,29 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@main
     - run: nix fmt -- --check ./
 
-  cargo-fmt-check:
+  cargo-verifications:
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: DeterminateSystems/nix-installer-action@main
-    - run: nix develop --command cargo fmt --verbose --all -- --check
-
-  cargo-check:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: Swatinem/rust-cache@v2
-    - run: nix develop --command cargo check --locked --workspace
-    - run: nix develop --command cargo check --locked --examples --workspace
-
-  cargo-test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: Swatinem/rust-cache@v2
-    - run: nix develop --command cargo test --locked --lib --bins --workspace
-
-  cargo-test-all-features:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - command: cargo fmt --verbose --all -- --check
+          - command: cargo check --locked --workspace
+          - command: cargo check --locked --examples --workspace
+          - command: cargo test --locked --lib --bins --all-features --workspace
+          - command: cargo doc --locked --all-features --workspace
+          - command: cargo test --locked -p nannou_core --no-default-features --features "libm serde"
+          - command: cargo build --locked -p nannou --features "wasm-experimental" --target wasm32-unknown-unknown
+          - command: mdbook build guide/
+          - command: cargo test --locked -p book_tests
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: Swatinem/rust-cache@v2
-    - run: nix develop --command cargo test --locked --lib --bins --all-features --workspace
-
-  cargo-doc-all-features:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: Swatinem/rust-cache@v2
-    - run: nix develop --command cargo doc --locked --all-features --workspace
-
-  cargo-test-nannou-core-no-std:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: Swatinem/rust-cache@v2
-    - run: nix develop --command cargo test --locked -p nannou_core --no-default-features --features "libm serde"
-
-  cargo-build-nannou-wasm32:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: Swatinem/rust-cache@v2
-    - run: nix develop --command cargo build --locked -p nannou --features "wasm-experimental" --target wasm32-unknown-unknown
+    - run: nix develop --command ${{ matrix.command }}
 
   verifications:
-    needs:
-      [
-        cargo-build-nannou-wasm32,
-        cargo-check,
-        cargo-doc-all-features,
-        cargo-fmt-check,
-        cargo-test,
-        cargo-test-all-features,
-        cargo-test-nannou-core-no-std,
-        nix-fmt-check,
-      ]
+    needs: [ cargo-verifications, nix-fmt-check ]
     runs-on: ubuntu-latest
     steps:
     - run: echo "Verifications complete"
@@ -114,21 +69,6 @@ jobs:
     - name: Cargo publish nannou_egui
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path nannou_egui/Cargo.toml
-
-  guide-build-book:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: DeterminateSystems/nix-installer-action@main
-    - run: nix develop --command mdbook build guide/
-
-  guide-test-code:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: Swatinem/rust-cache@v2
-    - run: nix develop --command cargo test --locked -p book_tests
 
   guide-push-to-deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ checksum = "cd3b6ae1eabbfbced10e840fd3fce8a93ae84f174b3e4ba892ab7bcb42e477a7"
 dependencies = [
  "accesskit 0.12.2",
  "accesskit_consumer",
- "objc2 0.3.0-beta.3.patch-leaks.3",
+ "objc2",
  "once_cell",
 ]
 
@@ -71,15 +71,14 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.17.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f8f7c9f66d454d5fd8e344c8c8c7324b57194e1041b955519fc58a01e77a25"
+checksum = "88e39fcec2e10971e188730b7a76bab60647dacc973d4591855ebebcadfaa738"
 dependencies = [
  "accesskit 0.12.2",
  "accesskit_macos",
  "accesskit_windows",
- "raw-window-handle",
- "winit 0.29.10",
+ "winit",
 ]
 
 [[package]]
@@ -194,27 +193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-activity"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b801912a977c3fd52d80511fe1c0c8480c6f957f21ae2ce1b92ffe970cf4b9"
-dependencies = [
- "android-properties",
- "bitflags 2.4.2",
- "cc",
- "cesu8",
- "jni 0.21.1",
- "jni-sys",
- "libc",
- "log",
- "ndk 0.8.0",
- "ndk-context",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum 0.7.2",
- "thiserror",
-]
-
-[[package]]
 name = "android-properties"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,12 +277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "as-raw-xcb-connection"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
-
-[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +317,17 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
@@ -362,23 +345,33 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock",
+ "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
- "fastrand",
- "futures-lite",
+ "fastrand 2.0.1",
+ "futures-lite 2.2.0",
  "slab",
 ]
 
 [[package]]
 name = "async-fs"
-version = "2.1.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1f344136bad34df1f83a47f3fd7f2ab85d75cb8a940af4ccf6d482a84ea01b"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
 dependencies = [
- "async-lock",
+ "async-lock 2.8.0",
+ "autocfg 1.1.0",
  "blocking",
- "futures-lite",
+ "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -487,22 +480,30 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bevy"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4bc7e09282a82a48d70ade0c4c1154b0fd7882a735a39c66766a5d0f4718ea9"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68080288c932634f6563d3a8299efe0ddc9ea6787539c4c771ba250d089a94f0"
 dependencies = [
  "accesskit 0.12.2",
  "bevy_app",
@@ -512,8 +513,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa37683b1281e1ba8cf285644e6e3f0704f14b3901c5ee282067ff7ff6f4a56"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -530,8 +532,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41731817993f92e4363dd3335558e779e290bc71eefc0b5547052b85810907e"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -545,12 +548,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "935984568f75867dd7357133b06f4b1502cd2be55e4642d483ce597e46e63bff"
 dependencies = [
  "async-broadcast",
  "async-fs",
- "async-lock",
+ "async-lock 2.8.0",
  "bevy_app",
  "bevy_asset_macros",
  "bevy_ecs",
@@ -563,7 +567,7 @@ dependencies = [
  "crossbeam-channel",
  "downcast-rs",
  "futures-io",
- "futures-lite",
+ "futures-lite 1.13.0",
  "js-sys",
  "parking_lot 0.12.1",
  "ron",
@@ -576,8 +580,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f48b9bbe4ec605e4910b5cd1e1a0acbfbe0b80af5f3bcc4489a9fdd1e80058c"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2 1.0.76",
@@ -587,8 +592,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a69889e1bfa4dbac4e641536b94f91c441da55796ad9832e77836b8264688b"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -604,8 +610,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3daa24502a14839509f02407bc7e48299fe84d260877de23b60662de0f4f4b6c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -618,8 +625,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b77c4fca6e90edbe2e72da7bc9aa7aed7dfdfded0920ae0a0c845f5e11084a"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -639,8 +647,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f484318350462c58ba3942a45a656c1fd6b6e484a6b6b7abc3a787ad1a51e500"
 dependencies = [
  "bevy_macro_utils",
  "quote 1.0.35",
@@ -649,8 +658,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa38ca5967d335cc1006a0e0f1a86c350e2f15fd1878449f61d04cd57a7c4060"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -663,16 +673,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7709fbd22f81fb681534cd913c41e1cd18b17143368743281195d7f024b61aea"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "bevy_ecs_macros",
  "bevy_ptr",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
  "downcast-rs",
+ "event-listener 2.5.3",
  "fixedbitset 0.4.2",
  "rustc-hash",
  "serde",
@@ -682,8 +694,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8843aa489f159f25cdcd9fee75cd7d221a7098a71eaa72cb2d6b40ac4e3f1ba"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2 1.0.76",
@@ -693,17 +706,19 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5328a3715e933ebbff07d0e99528dc423c4f7a53590ed1ac19a120348b028990"
 dependencies = [
  "bevy_macro_utils",
- "encase_derive_impl 0.6.1",
+ "encase_derive_impl",
 ]
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b81ca2ebf66cbc7f998f1f142b15038ffe3c4ae1d51f70adda26dcf51b0c4ca"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -717,15 +732,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db232274ddca2ae452eb2731b98267b795d133ddd14013121bc7daddde1c7491"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_core",
  "bevy_core_pipeline",
  "bevy_ecs",
- "bevy_log",
  "bevy_math",
  "bevy_pbr",
  "bevy_reflect",
@@ -737,10 +752,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85adc6b1fc86687bf67149e0bafaa4d6da432232fa956472d1b37f19121d3ace"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.13.1",
  "bevy_animation",
  "bevy_app",
  "bevy_asset",
@@ -766,8 +782,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_hierarchy"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06bd477152ce2ae1430f5e0a4f19216e5785c22fee1ab23788b5982dc59d1a55"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -775,12 +792,14 @@ dependencies = [
  "bevy_log",
  "bevy_reflect",
  "bevy_utils",
+ "smallvec 1.12.0",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab9a599189b2a694c182d60cd52219dd9364f9892ff542d87799b8e45d9e6dc"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -792,8 +811,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f124bece9831afd80897815231072d51bfe3ac58c6bb58eca8880963b6d0487c"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -830,8 +850,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc10ba1d225a8477b9e80a1bf797d8a8b8274e83c9b24fb4d9351aec9229755"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -845,31 +866,34 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e566640c6b6dced73d2006c764c2cffebe1a82be4809486c4a5d7b4b50efed4d"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "rustc-hash",
  "syn 2.0.48",
- "toml_edit 0.21.0",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ddc2b76783939c530178f88e5711a1b01044d7b02db4033e2eb8b43b6cf4ec"
 dependencies = [
- "glam 0.25.0",
+ "glam 0.24.2",
  "serde",
 ]
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec4962977a746d870170532fc92759e04d3dbcae8b7b82e7ca3bb83b1d75277"
 dependencies = [
- "glam 0.25.0",
+ "glam 0.24.2",
 ]
 
 [[package]]
@@ -904,8 +928,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_pbr"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520bfd2a898c74f84ea52cfb8eb061f37373ad15e623489d5f75d27ebd6138fe"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -923,18 +948,21 @@ dependencies = [
  "fixedbitset 0.4.2",
  "naga_oil",
  "radsort",
+ "smallvec 1.12.0",
  "thread_local",
 ]
 
 [[package]]
 name = "bevy_ptr"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77ec20c8fafcdc196508ef5ccb4f0400a8d193cb61f7b14a36ed9a25ad423cf"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7921f15fc944c9c8ad01d7dbcea6505b8909c6655cd9382bab1407181556038"
 dependencies = [
  "bevy_math",
  "bevy_ptr",
@@ -942,16 +970,18 @@ dependencies = [
  "bevy_utils",
  "downcast-rs",
  "erased-serde",
- "glam 0.25.0",
+ "glam 0.24.2",
  "serde",
+ "smallvec 1.12.0",
  "smol_str",
  "thiserror",
 ]
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a8c5475f216e751ef4452a1306b00711f33d2d04d9f149e4c845dfeb6753a0"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2 1.0.76",
@@ -962,10 +992,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdefdd3737125b0d94a6ff20bb70fa8cfe9d7d5dcd72ba4dfe6c5f1d30d9f6e4"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "bevy_app",
  "bevy_asset",
  "bevy_core",
@@ -988,26 +1019,28 @@ dependencies = [
  "codespan-reporting",
  "downcast-rs",
  "encase",
- "futures-lite",
+ "futures-lite 1.13.0",
  "hexasphere",
  "image 0.24.8",
  "js-sys",
  "ktx2",
- "naga 0.14.2",
+ "naga 0.13.0",
  "naga_oil",
  "ruzstd",
  "serde",
+ "smallvec 1.12.0",
  "thiserror",
  "thread_local",
  "wasm-bindgen",
  "web-sys",
- "wgpu 0.18.0",
+ "wgpu",
 ]
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d86bfc5a1e7fbeeaec0c4ceab18155530f5506624670965db3415f75826bea"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2 1.0.76",
@@ -1017,8 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7df078b5e406e37c8a1c6ba0d652bf105fde713ce3c3efda7263fe27467eee5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1029,6 +1063,7 @@ dependencies = [
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
+ "ron",
  "serde",
  "thiserror",
  "uuid 1.6.1",
@@ -1036,8 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7cc0c9d946e17e3e0aaa202f182837bc796c4f862b2e5a805134f873f21cf7f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1061,21 +1097,23 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fefa7fe0da8923525f7500e274f1bd60dbd79918a25cf7d0dfa0a6ba15c1cf"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-executor",
  "async-task",
  "concurrent-queue",
- "futures-lite",
+ "futures-lite 1.13.0",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "bevy_text"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9a79d49ca06170d69149949b134c14e8b99ace1444c1ca2cd4743b19d5b055"
 dependencies = [
  "ab_glyph",
  "bevy_app",
@@ -1095,8 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6250d76eed3077128b6a3d004f9f198b01107800b9824051e32bb658054e837"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1108,8 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d541e0c292edbd96afae816ee680e02247422423ccd5dc635c1e211a20ed64be"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1121,8 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d785e3b75dabcb2a8ad0d50933f8f3446d59e512cabc2d2a145e28c2bb8792ba"
 dependencies = [
  "bevy_a11y",
  "bevy_app",
@@ -1142,32 +1183,35 @@ dependencies = [
  "bevy_utils",
  "bevy_window",
  "bytemuck",
+ "serde",
+ "smallvec 1.12.0",
  "taffy",
  "thiserror",
 ]
 
 [[package]]
 name = "bevy_utils"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7915222f4a08ccc782e08d10b751b42e5f9d786e697d0cb3fd09333cb7e8b6ea"
 dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
  "getrandom 0.2.12",
  "hashbrown 0.14.3",
+ "instant",
  "nonmax",
  "petgraph 0.6.4",
- "smallvec 1.12.0",
  "thiserror",
  "tracing",
  "uuid 1.6.1",
- "web-time",
 ]
 
 [[package]]
 name = "bevy_utils_proc_macros"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aafecc952b6b8eb1a93c12590bd867d25df2f4ae1033a01dfdfc3c35ebccfff"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -1176,8 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ee72bf7f974000e9b31bb971a89387f1432ba9413f35c4fef59fef49767260"
 dependencies = [
  "bevy_a11y",
  "bevy_app",
@@ -1187,13 +1232,13 @@ dependencies = [
  "bevy_reflect",
  "bevy_utils",
  "raw-window-handle",
- "smol_str",
 ]
 
 [[package]]
 name = "bevy_winit"
-version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb71f287eca9006dda998784c7b931e400ae2cc4c505da315882a8b082f21ad"
 dependencies = [
  "accesskit_winit",
  "approx 0.5.1",
@@ -1211,7 +1256,7 @@ dependencies = [
  "raw-window-handle",
  "wasm-bindgen",
  "web-sys",
- "winit 0.29.10",
+ "winit",
 ]
 
 [[package]]
@@ -1330,16 +1375,7 @@ version = "0.1.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa55741ee90902547802152aaf3f8e5248aab7e21468089560d4c8840561146"
 dependencies = [
- "objc-sys 0.2.0-beta.2",
-]
-
-[[package]]
-name = "block-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
-dependencies = [
- "objc-sys 0.3.2",
+ "objc-sys",
 ]
 
 [[package]]
@@ -1348,18 +1384,8 @@ version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
 dependencies = [
- "block-sys 0.1.0-beta.1",
- "objc2-encode 2.0.0-pre.2",
-]
-
-[[package]]
-name = "block2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
-dependencies = [
- "block-sys 0.2.1",
- "objc2 0.4.1",
+ "block-sys",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -1368,12 +1394,12 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
- "async-channel",
- "async-lock",
+ "async-channel 2.1.1",
+ "async-lock 3.3.0",
  "async-task",
- "fastrand",
+ "fastrand 2.0.1",
  "futures-io",
- "futures-lite",
+ "futures-lite 2.2.0",
  "piper",
  "tracing",
 ]
@@ -1506,20 +1532,6 @@ dependencies = [
  "slotmap",
  "thiserror",
  "vec_map",
-]
-
-[[package]]
-name = "calloop"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
-dependencies = [
- "bitflags 2.4.2",
- "log",
- "polling",
- "rustix",
- "slab",
- "thiserror",
 ]
 
 [[package]]
@@ -1903,19 +1915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-graphics"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-graphics-types",
- "foreign-types 0.5.0",
- "libc",
-]
-
-[[package]]
 name = "core-graphics-types"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,12 +2157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cursor-icon"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
-
-[[package]]
 name = "d3d12"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,7 +2294,7 @@ dependencies = [
  "log",
  "thiserror",
  "type-map",
- "wgpu 0.17.1",
+ "wgpu",
 ]
 
 [[package]]
@@ -2357,23 +2350,23 @@ dependencies = [
 
 [[package]]
 name = "encase"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ed933078d2e659745df651f4c180511cd582e5b9414ff896e7d50d207e3103"
+checksum = "8fce2eeef77fd4a293a54b62aa00ac9daebfbcda4bf8998c5a815635b004aa1c"
 dependencies = [
  "const_panic",
  "encase_derive",
- "glam 0.25.0",
+ "glam 0.24.2",
  "thiserror",
 ]
 
 [[package]]
 name = "encase_derive"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ce1449c7d19eba6cc0abd231150ad81620a8dce29601d7f8d236e5d431d72a"
+checksum = "0e520cde08cbf4f7cc097f61573ec06ce467019803de8ae82fb2823fa1554a0e"
 dependencies = [
- "encase_derive_impl 0.7.0",
+ "encase_derive_impl",
 ]
 
 [[package]]
@@ -2381,17 +2374,6 @@ name = "encase_derive_impl"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe2568f851fd6144a45fa91cfed8fe5ca8fc0b56ba6797bfc1ed2771b90e37c"
-dependencies = [
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "encase_derive_impl"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92959a9e8d13eaa13b8ae8c7b583c3bf1669ca7a8e7708a088d12587ba86effc"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -2628,6 +2610,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
@@ -2698,18 +2689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
 ]
 
 [[package]]
@@ -2876,11 +2855,26 @@ checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
 dependencies = [
- "fastrand",
+ "fastrand 2.0.1",
  "futures-core",
  "futures-io",
  "parking",
@@ -2945,16 +2939,6 @@ dependencies = [
  "nannou",
  "usvg",
  "wikipedia",
-]
-
-[[package]]
-name = "gethostname"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
-dependencies = [
- "libc",
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3059,17 +3043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gl_generator"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
-dependencies = [
- "khronos_api",
- "log",
- "xml-rs",
-]
-
-[[package]]
 name = "glam"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.25.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
 dependencies = [
  "bytemuck",
  "serde",
@@ -3114,18 +3087,6 @@ name = "glow"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glow"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -3170,15 +3131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glutin_wgl_sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
-dependencies = [
- "gl_generator",
-]
-
-[[package]]
 name = "glyph_brush_layout"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,20 +3171,6 @@ dependencies = [
  "thiserror",
  "winapi 0.3.9",
  "windows 0.44.0",
-]
-
-[[package]]
-name = "gpu-allocator"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fe17c8a05d60c38c0a4e5a3c802f2f1ceb66b76c67d96ffb34bef0475a7fad"
-dependencies = [
- "backtrace",
- "log",
- "presser",
- "thiserror",
- "winapi 0.3.9",
- "windows 0.51.1",
 ]
 
 [[package]]
@@ -3350,12 +3288,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexasphere"
-version = "10.0.0"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33ddb7f7143d9e703c072e88b98cd8b9719f174137a671429351bd2ee43c02a"
+checksum = "7cb3df16a7bcb1b5bc092abd55e14f77ca70aea14445026e264586fc62889a10"
 dependencies = [
  "constgebra",
- "glam 0.25.0",
+ "glam 0.24.2",
 ]
 
 [[package]]
@@ -3500,7 +3438,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -3510,17 +3448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "icrate"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
-dependencies = [
- "block2 0.3.0",
- "dispatch",
- "objc2 0.4.1",
 ]
 
 [[package]]
@@ -3774,22 +3701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if 1.0.0",
- "combine 4.6.6",
- "jni-sys",
- "log",
- "thiserror",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3842,23 +3753,6 @@ dependencies = [
  "libloading 0.7.4",
  "pkg-config",
 ]
-
-[[package]]
-name = "khronos-egl"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
-dependencies = [
- "libc",
- "libloading 0.8.1",
- "pkg-config",
-]
-
-[[package]]
-name = "khronos_api"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kqueue"
@@ -4242,21 +4136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
-dependencies = [
- "bitflags 2.4.2",
- "block",
- "core-graphics-types",
- "foreign-types 0.5.0",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4395,6 +4274,7 @@ dependencies = [
  "log",
  "num-traits",
  "petgraph 0.6.4",
+ "pp-rs",
  "rustc-hash",
  "serde",
  "spirv",
@@ -4411,30 +4291,26 @@ checksum = "ae585df4b6514cf8842ac0f1ab4992edc975892704835b549cf818dc0191249e"
 dependencies = [
  "bit-set",
  "bitflags 2.4.2",
- "codespan-reporting",
- "hexf-parse",
  "indexmap 2.1.0",
  "log",
  "num-traits",
  "pp-rs",
  "rustc-hash",
  "spirv",
- "termcolor",
  "thiserror",
- "unicode-xid 0.2.4",
 ]
 
 [[package]]
 name = "naga_oil"
-version = "0.11.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff3f369dd665ee365daeab786466a6f70ff53e4a95a76117363b1077e1b0492"
+checksum = "4ac54c77b3529887f9668d3dd81e955e58f252b31a333f836e3548c06460b958"
 dependencies = [
  "bit-set",
  "codespan-reporting",
  "data-encoding",
- "indexmap 2.1.0",
- "naga 0.14.2",
+ "indexmap 1.9.3",
+ "naga 0.13.0",
  "once_cell",
  "regex",
  "regex-syntax 0.7.5",
@@ -4478,8 +4354,8 @@ dependencies = [
  "toml",
  "walkdir",
  "web-sys",
- "wgpu 0.17.1",
- "winit 0.28.7",
+ "wgpu",
+ "winit",
 ]
 
 [[package]]
@@ -4508,7 +4384,7 @@ dependencies = [
  "egui",
  "egui-wgpu",
  "nannou",
- "winit 0.28.7",
+ "winit",
 ]
 
 [[package]]
@@ -4585,16 +4461,7 @@ dependencies = [
  "instant",
  "num_cpus",
  "tokio 1.35.1",
- "wgpu 0.17.1",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.12",
+ "wgpu",
 ]
 
 [[package]]
@@ -4650,21 +4517,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
-dependencies = [
- "bitflags 2.4.2",
- "jni-sys",
- "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum 0.7.2",
- "raw-window-handle",
- "thiserror",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4692,7 +4544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
 dependencies = [
  "darling",
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "syn 1.0.109",
@@ -4712,15 +4564,6 @@ name = "ndk-sys"
 version = "0.4.1+23.1.7779620"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
-dependencies = [
- "jni-sys",
-]
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys",
 ]
@@ -5017,21 +4860,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
-dependencies = [
- "num_enum_derive 0.7.2",
-]
-
-[[package]]
 name = "num_enum_derive"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "syn 1.0.109",
@@ -5043,19 +4877,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
-dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "syn 2.0.48",
@@ -5078,30 +4900,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
 
 [[package]]
-name = "objc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459"
-
-[[package]]
 name = "objc2"
 version = "0.3.0-beta.3.patch-leaks.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e01640f9f2cb1220bbe80325e179e532cb3379ebcd1bf2279d703c19fe3a468"
 dependencies = [
- "block2 0.2.0-alpha.6",
- "objc-sys 0.2.0-beta.2",
- "objc2-encode 2.0.0-pre.2",
-]
-
-[[package]]
-name = "objc2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
-dependencies = [
- "objc-sys 0.3.2",
- "objc2-encode 3.0.0",
+ "block2",
+ "objc-sys",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -5110,14 +4916,8 @@ version = "2.0.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abfcac41015b00a120608fdaa6938c44cb983fee294351cc4bac7638b4e50512"
 dependencies = [
- "objc-sys 0.2.0-beta.2",
+ "objc-sys",
 ]
-
-[[package]]
-name = "objc2-encode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "objc_exception"
@@ -5486,7 +5286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
 dependencies = [
  "atomic-waker",
- "fastrand",
+ "fastrand 2.0.1",
  "futures-io",
 ]
 
@@ -5539,20 +5339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
 
 [[package]]
-name = "polling"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545c980a3880efd47b2e262f6a4bb6daad6555cf3367aa9c4e52895f69537a41"
-dependencies = [
- "cfg-if 1.0.0",
- "concurrent-queue",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "pp-rs"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5568,12 +5354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "presser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5581,15 +5361,6 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
-dependencies = [
- "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -6554,7 +6325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "870427e30b8f2cbe64bf43ec4b86e88fe39b0a84b3f15efd9c9c2d020bc86eb9"
 dependencies = [
  "bitflags 1.3.2",
- "calloop 0.10.6",
+ "calloop",
  "dlib",
  "lazy_static",
  "log",
@@ -6593,15 +6364,6 @@ checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api 0.4.11",
 ]
 
 [[package]]
@@ -6753,16 +6515,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.5"
+version = "0.29.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
+checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys 0.8.6",
  "libc",
  "ntapi",
  "once_cell",
- "windows 0.52.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6810,7 +6572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if 1.0.0",
- "fastrand",
+ "fastrand 2.0.1",
  "redox_syscall 0.4.1",
  "rustix",
  "windows-sys 0.52.0",
@@ -7168,9 +6930,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.1.0",
  "toml_datetime",
@@ -7499,6 +7261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+
+[[package]]
 name = "walkdir"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7687,16 +7455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7722,34 +7480,9 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core 0.17.1",
- "wgpu-hal 0.17.2",
- "wgpu-types 0.17.0",
-]
-
-[[package]]
-name = "wgpu"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e7d227c9f961f2061c26f4cb0fbd4df0ef37e056edd0931783599d6c94ef24"
-dependencies = [
- "arrayvec 0.7.4",
- "cfg-if 1.0.0",
- "flume",
- "js-sys",
- "log",
- "naga 0.14.2",
- "parking_lot 0.12.1",
- "profiling",
- "raw-window-handle",
- "smallvec 1.12.0",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core 0.18.1",
- "wgpu-hal 0.18.1",
- "wgpu-types 0.18.0",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -7773,31 +7506,8 @@ dependencies = [
  "smallvec 1.12.0",
  "thiserror",
  "web-sys",
- "wgpu-hal 0.17.2",
- "wgpu-types 0.17.0",
-]
-
-[[package]]
-name = "wgpu-core"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef91c1d62d1e9e81c79e600131a258edf75c9531cbdbde09c44a011a47312726"
-dependencies = [
- "arrayvec 0.7.4",
- "bit-vec",
- "bitflags 2.4.2",
- "codespan-reporting",
- "log",
- "naga 0.14.2",
- "parking_lot 0.12.1",
- "profiling",
- "raw-window-handle",
- "rustc-hash",
- "smallvec 1.12.0",
- "thiserror",
- "web-sys",
- "wgpu-hal 0.18.1",
- "wgpu-types 0.18.0",
+ "wgpu-hal",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -7814,17 +7524,17 @@ dependencies = [
  "block",
  "core-graphics-types",
  "d3d12",
- "glow 0.12.3",
+ "glow",
  "gpu-alloc",
- "gpu-allocator 0.22.0",
+ "gpu-allocator",
  "gpu-descriptor",
  "hassle-rs",
  "js-sys",
- "khronos-egl 4.1.0",
+ "khronos-egl",
  "libc",
  "libloading 0.8.1",
  "log",
- "metal 0.26.0",
+ "metal",
  "naga 0.13.0",
  "objc",
  "parking_lot 0.12.1",
@@ -7837,50 +7547,7 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types 0.17.0",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84ecc802da3eb67b4cf3dd9ea6fe45bbb47ef13e6c49c5c3240868a9cc6cdd9"
-dependencies = [
- "android_system_properties",
- "arrayvec 0.7.4",
- "ash",
- "bit-set",
- "bitflags 2.4.2",
- "block",
- "core-graphics-types",
- "d3d12",
- "glow 0.13.1",
- "glutin_wgl_sys",
- "gpu-alloc",
- "gpu-allocator 0.23.0",
- "gpu-descriptor",
- "hassle-rs",
- "js-sys",
- "khronos-egl 6.0.0",
- "libc",
- "libloading 0.8.1",
- "log",
- "metal 0.27.0",
- "naga 0.14.2",
- "objc",
- "once_cell",
- "parking_lot 0.12.1",
- "profiling",
- "range-alloc",
- "raw-window-handle",
- "renderdoc-sys",
- "rustc-hash",
- "smallvec 1.12.0",
- "thiserror",
- "wasm-bindgen",
- "web-sys",
- "wgpu-types 0.18.0",
+ "wgpu-types",
  "winapi 0.3.9",
 ]
 
@@ -7893,17 +7560,6 @@ dependencies = [
  "bitflags 2.4.2",
  "js-sys",
  "serde",
- "web-sys",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5ed5f0edf0de351fe311c53304986315ce866f394a2e6df0c4b3c70774bcdd"
-dependencies = [
- "bitflags 2.4.2",
- "js-sys",
  "web-sys",
 ]
 
@@ -8008,31 +7664,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
-dependencies = [
- "windows-core 0.51.1",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core 0.52.0",
+ "windows-core",
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -8270,18 +7907,18 @@ version = "0.28.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9596d90b45384f5281384ab204224876e8e8bf7d58366d9b795ad99aa9894b94"
 dependencies = [
- "android-activity 0.4.3",
+ "android-activity",
  "bitflags 1.3.2",
  "cfg_aliases",
  "core-foundation 0.9.4",
- "core-graphics 0.22.3",
+ "core-graphics",
  "dispatch",
  "instant",
  "libc",
  "log",
  "mio 0.8.10",
  "ndk 0.7.0",
- "objc2 0.3.0-beta.3.patch-leaks.3",
+ "objc2",
  "once_cell",
  "orbclient",
  "percent-encoding 2.3.1",
@@ -8297,46 +7934,6 @@ dependencies = [
  "web-sys",
  "windows-sys 0.45.0",
  "x11-dl",
-]
-
-[[package]]
-name = "winit"
-version = "0.29.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c824f11941eeae66ec71111cc2674373c772f482b58939bb4066b642aa2ffcf"
-dependencies = [
- "android-activity 0.5.1",
- "atomic-waker",
- "bitflags 2.4.2",
- "bytemuck",
- "calloop 0.12.4",
- "cfg_aliases",
- "core-foundation 0.9.4",
- "core-graphics 0.23.1",
- "cursor-icon",
- "icrate",
- "js-sys",
- "libc",
- "log",
- "ndk 0.8.0",
- "ndk-sys 0.5.0+25.2.9519653",
- "objc2 0.4.1",
- "once_cell",
- "orbclient",
- "percent-encoding 2.3.1",
- "raw-window-handle",
- "redox_syscall 0.3.5",
- "rustix",
- "smol_str",
- "unicode-segmentation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "web-time",
- "windows-sys 0.48.0",
- "x11-dl",
- "x11rb",
- "xkbcommon-dl",
 ]
 
 [[package]]
@@ -8379,27 +7976,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "x11rb"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
-dependencies = [
- "as-raw-xcb-connection",
- "gethostname",
- "libc",
- "libloading 0.8.1",
- "once_cell",
- "rustix",
- "x11rb-protocol",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
-
-[[package]]
 name = "xcursor"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8410,25 +7986,6 @@ name = "xi-unicode"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
-
-[[package]]
-name = "xkbcommon-dl"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924668544c48c0133152e7eec86d644a056ca3d09275eb8d5cdb9855f9d8699"
-dependencies = [
- "bitflags 2.4.2",
- "dlib",
- "log",
- "once_cell",
- "xkeysym",
-]
-
-[[package]]
-name = "xkeysym"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 [[package]]
 name = "bevy"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_internal",
 ]
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "accesskit 0.12.2",
  "bevy_app",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2 1.0.76",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "bevy_audio"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "bevy_core"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -619,7 +619,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_macro_utils",
  "quote 1.0.35",
@@ -650,7 +650,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "async-channel",
  "bevy_ecs_macros",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2 1.0.76",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl 0.6.1",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -718,7 +718,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "base64 0.21.7",
  "bevy_animation",
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "bevy_hierarchy"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -780,7 +780,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -793,7 +793,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "glam 0.25.0",
  "serde",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "glam 0.25.0",
 ]
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -929,12 +929,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_math",
  "bevy_ptr",
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2 1.0.76",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1007,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2 1.0.76",
@@ -1018,7 +1018,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1062,7 +1062,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1075,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "ab_glyph",
  "bevy_app",
@@ -1096,7 +1096,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1109,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_a11y",
  "bevy_app",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils_proc_macros"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -1177,7 +1177,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "bevy_a11y",
  "bevy_app",
@@ -1193,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.12.0"
-source = "git+https://github.com/bevyengine/bevy?branch=main#9abf565138fc12d45c42b500f2c8fbbc1391599e"
+source = "git+https://github.com/bevyengine/bevy?branch=main#c9e1fcdb355b049fa3c3df8cb1cd1f4343f1b9d1"
 dependencies = [
  "accesskit_winit",
  "approx 0.5.1",
@@ -3376,7 +3376,8 @@ dependencies = [
 [[package]]
 name = "hotglsl"
 version = "0.2.0"
-source = "git+https://github.com/nannou-org/hotglsl?branch=master#534b2288809f4ada29089d27425a2064f8cacdcd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4255b32d5626f6c2f38801fb57b540edd95e8014ebb757b753bea7d946c031f7"
 dependencies = [
  "naga 0.14.2",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ members = [
     "scripts/set_version",
 ]
 
-[workspace.package]
-version = "0.19.0"
-
 # Required for wgpu v0.10 feature resolution.
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", features = ["default"] }
+bevy = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ members = [
     "scripts/set_version",
 ]
 
+[workspace.package]
+version = "0.19.0"
+
 # Required for wgpu v0.10 feature resolution.
 resolver = "2"
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,83 @@
+{ alsaLib
+, cmake
+, jq
+, lib
+, makeWrapper
+, pkg-config
+, rustPlatform
+, vulkan-loader
+, vulkan-validation-layers
+, xorg
+, openssl
+, XCURSOR_THEME ? "Adwaita"
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "nannou";
+  src = ./.;
+  version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+    outputHashes = {
+      "hotglsl-0.1.0" = "sha256-G88Sa/tgGppaxIIPXDqIazMWRBXpaSFb2mulNfCclm8=";
+      "isf-0.1.0" = "sha256-utexaXpZZgpRunVAQyD2JAwvabhZGzeorC4pRFIumAc=";
+      "skeptic-0.13.4" = "sha256-EZFtWIPfsfbpGBD8NwsVtMzRM10kVdg+djoV00dhT4Y=";
+    };
+  };
+
+  # Don't run tests every time, we'll do it in a separate CI pass.
+  doCheck = false;
+
+  nativeBuildInputs = [
+    # Required for `glsl-to-spirv` for `nannou_isf`. Should switch to `naga`.
+    cmake
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    # For filtering `cargo metadata` to get example names.
+    jq
+    # WGPU device availability.
+    vulkan-loader
+    vulkan-validation-layers
+    # Required for X11 backend on Linux.
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXrandr
+    # `nannou-new` needs this because of `cargo` dep. See #606.
+    openssl
+    # `nannou_audio`.
+    alsaLib
+  ];
+
+  env = {
+    inherit XCURSOR_THEME;
+    ALSA_LIB_DEV = "${alsaLib.dev}";
+    LD_LIBRARY_PATH = "${lib.makeLibraryPath buildInputs}";
+  };
+
+  # Build and include example binaries in `$out/bin/examples`
+  postBuild = ''
+    cargo build --locked --release --examples
+    mkdir -p $out/bin/examples
+    for example in $(cargo metadata --format-version=1 --no-deps | ${jq}/bin/jq -r '.packages[].targets[] | select(.kind[] | contains("example")) | .name'); do
+      if [ -f "target/release/examples/$example" ]; then
+        mv "target/release/examples/$example" $out/bin/examples/
+      fi
+    done
+  '';
+
+  # Wrap the binaries to ensure the runtime env vars are set.
+  postFixup = ''
+    for prog in $out/bin/* $out/bin/examples/*; do
+      if [ -f "$prog" -a -x "$prog" ]; then
+        wrapProgram "$prog" \
+          --set ALSA_LIB_DEV "${env.ALSA_LIB_DEV}" \
+          --set LD_LIBRARY_PATH "${env.LD_LIBRARY_PATH}" \
+          --set XCURSOR_THEME "${env.XCURSOR_THEME}"
+      fi
+    done
+  '';
+}

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@
 , xorg
 , openssl
 , stdenv
+, udev
 , XCURSOR_THEME ? "Adwaita"
 }:
 rustPlatform.buildRustPackage rec {
@@ -41,6 +42,7 @@ rustPlatform.buildRustPackage rec {
     openssl
   ] ++ lib.optionals stdenv.isLinux [
     alsaLib
+    udev
     vulkan-loader
     vulkan-validation-layers
     xorg.libX11

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@
 rustPlatform.buildRustPackage rec {
   pname = "nannou";
   src = ./.;
-  version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+  version = (builtins.fromTOML (builtins.readFile ./nannou/Cargo.toml)).package.version;
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dev-dependencies]
 audrey = "0.3"
-hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
+hotglsl = "0.2"
 hrtf = "0.2"
 nannou = { version ="0.19.0", path = "../nannou" }
 nannou_audio = { version ="0.19.0", path = "../nannou_audio" }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1705316053,
+        "narHash": "sha256-J2Ey5mPFT8gdfL2XC0JTZvKaBw/b2pnyudEXFvl+dQM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c3e128f3c0ecc1fb04aef9f72b3dcc2f6cecf370",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = ''
+    A Nix flake for nannou development.
+  '';
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = inputs:
+    let
+      systems = import inputs.systems;
+      lib = inputs.nixpkgs.lib;
+      perSystem = f: lib.genAttrs systems f;
+      systemPkgs = system: import inputs.nixpkgs { inherit system; };
+      perSystemPkgs = f: perSystem (system: f (systemPkgs system));
+    in
+    {
+      packages = perSystemPkgs (pkgs: {
+        nannou = pkgs.callPackage ./default.nix { };
+        default = inputs.self.packages.${pkgs.system}.nannou;
+      });
+
+      apps = perSystemPkgs (pkgs:
+        let
+          nannou = inputs.self.packages.${pkgs.system}.nannou;
+        in
+        {
+          draw = {
+            type = "app";
+            program = "${nannou}/bin/examples/draw";
+          };
+          draw_textured_mesh = {
+            type = "app";
+            program = "${nannou}/bin/examples/draw_textured_mesh";
+          };
+        });
+
+      devShells = perSystemPkgs (pkgs: {
+        nannou-dev = pkgs.callPackage ./shell.nix {
+          inherit (inputs.self.packages.${pkgs.system}) nannou;
+        };
+        default = inputs.self.packages.${pkgs.system}.nannou;
+      });
+
+      formatter = perSystemPkgs (pkgs: pkgs.nixpkgs-fmt);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
         nannou-dev = pkgs.callPackage ./shell.nix {
           inherit (inputs.self.packages.${pkgs.system}) nannou;
         };
-        default = inputs.self.packages.${pkgs.system}.nannou;
+        default = inputs.self.devShells.${pkgs.system}.nannou-dev;
       });
 
       formatter = perSystemPkgs (pkgs: pkgs.nixpkgs-fmt);

--- a/guide/src/contributing.md
+++ b/guide/src/contributing.md
@@ -7,6 +7,7 @@ you in the right direction.
 - [**PR Checklist**](./contributing/pr-checklist.md)
 - [**PR Reviews**](./contributing/pr-reviews.md)
 - [**Publishing New Versions**](./contributing/publishing-new-versions.md)
+- [**Nix Shell**](./contributing/nix-shell.md)
 
 ## Still have questions?
 

--- a/guide/src/contributing/nix-shell.md
+++ b/guide/src/contributing/nix-shell.md
@@ -1,0 +1,54 @@
+# Nix Shell
+
+The nannou repo offers a Nix shell as a way of providing a reproducible
+environment across both macOS and Linux. This simplifies the nannou repo CI a
+little while making it easier to experiment with nannou using a known working
+environment.
+
+### Installing Nix
+
+The [Determinate Systems installer](https://github.com/DeterminateSystems/nix-installer)
+is one of the easiest ways to get started with Nix.
+
+### Nannou's Nix Files
+
+- **default.nix** - A derivation that describes how to build the nannou Rust
+  package, including all of its examples and with all of the necessary environment
+  variables. This is what is built by default when running `nix build`. When
+- **shell.nix** - A derivation that describes a development shell providing all
+  of the necessary system dependencies and environment variables for working on
+  nannou and its examples.
+- **flake.nix** - A Nix manifest standard declaring the `nannou` package and
+  devShell.
+
+### Adding a `nannou` Dependency
+
+When adding a new package (e.g. system dependency):
+
+1. Find the package in nixpkgs (`nix search nixpkgs <name>` is handy)
+2. Add the package to the `default.nix` input attribute set.
+3. Add the package to `buildInputs` if its a runtime dependency, or
+   `nativeBuildInputs` if its a build-time dependency.
+
+### Adding a Development Shell Dependency
+
+To add handy development dependencies (e.g. rustfmt, rust-analyser), do the same
+but add them to `shell.nix` instead.
+
+### Adding Environment Variables
+
+Add these to the `env` attributes within either `default.nix` or `shell.nix`.
+
+### Build Everything
+
+Build all binaries, examples and dylibs within the `nannou` workspace with
+`nix build`. When finished, look in the `result` symlink directory to find all
+of the built binaries.
+
+### Enter a nannou `devShell`
+
+To enter a development shell with all of the tools and env vars necessary for
+nannou dev, use `nix develop`.
+
+To quickly enter a nannou dev shell to build a downstream nannou project, you
+can use: `nix develop github:nannou-org/nannou`.

--- a/nannou_isf/Cargo.toml
+++ b/nannou_isf/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
+hotglsl = "0.2"
 isf = { git = "https://github.com/nannou-org/isf", branch = "master" }
 nannou = { version ="0.19.0", path = "../nannou", features = ["spirv"] }
 thiserror = "1"

--- a/nannou_isf/tests/gen_glsl.rs
+++ b/nannou_isf/tests/gen_glsl.rs
@@ -134,6 +134,8 @@ const GLSL_450_INCOMPATIBLE: &[&str] = &[
     // Error: `function call, method, or subroutine call expected`
     "RGB Halftone-lookaround.fs",
     "CMYK Halftone-Lookaround.fs",
+    // Don't work after switching to `naga`
+    "Pixelize.fs",
 ];
 
 // Tests that are known to fail but there's no clear solution explained by the spec.

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ nannou
+, mkShell
+}:
+mkShell {
+  name = "nannou-dev";
+  inputsFrom = [ nannou ];
+  env = {
+    inherit (nannou) ALSA_LIB_DEV LD_LIBRARY_PATH XCURSOR_THEME;
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,15 @@
-{ nannou
+{ lib
+, nannou
 , mkShell
+, stdenv
 }:
 mkShell {
   name = "nannou-dev";
   inputsFrom = [ nannou ];
-  env = {
-    inherit (nannou) ALSA_LIB_DEV LD_LIBRARY_PATH XCURSOR_THEME;
-  };
+  env = (lib.optionalAttrs stdenv.isLinux
+    {
+      inherit (nannou) ALSA_LIB_DEV LD_LIBRARY_PATH XCURSOR_THEME;
+    } // lib.optionalAttrs stdenv.isDarwin {
+    inherit (nannou) COREAUDIO_SDK_PATH;
+  });
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,5 @@
 { lib
+, mdbook
 , nannou
 , mkShell
 , stdenv
@@ -6,6 +7,7 @@
 mkShell {
   name = "nannou-dev";
   inputsFrom = [ nannou ];
+  buildInputs = [ mdbook ];
   env = (lib.optionalAttrs stdenv.isLinux
     {
       inherit (nannou) ALSA_LIB_DEV LD_LIBRARY_PATH XCURSOR_THEME;

--- a/shell.nix
+++ b/shell.nix
@@ -2,12 +2,18 @@
 , mdbook
 , nannou
 , mkShell
+, rust-analyzer
+, rustfmt
 , stdenv
 }:
 mkShell {
   name = "nannou-dev";
   inputsFrom = [ nannou ];
-  buildInputs = [ mdbook ];
+  buildInputs = [
+    mdbook
+    rust-analyzer
+    rustfmt
+  ];
   env = (lib.optionalAttrs stdenv.isLinux
     {
       inherit (nannou) ALSA_LIB_DEV LD_LIBRARY_PATH XCURSOR_THEME;


### PR DESCRIPTION
These can be ignored by most users, but will be useful for Nix folks and may help to simplify our CI a little.

The default.nix can also be used as a CI-checked reference of what system dependencies and env vars are required on Linux and macOS.

Tested successfully on `x86_64-linux` and `aarch64-darwin`.

### TODO

- [x] Rebase onto `bevy-refactor` branch.
- [x] Simplify CI dependency installation with Nix.
- [x] Add section to `Contributing.md` about Nix.

---

The `hotglsl` crate was updated to 0.2 in order to switch from the `glsl-to-spirv` crate to the pure-Rust `naga` removing the need for some system deps like libclang.