### PR TITLE
962 use mid level render apis for render

### DIFF
--- a/bevy_nannou/src/main.rs
+++ b/bevy_nannou/src/main.rs
@@ -78,7 +78,7 @@ fn update_draw(
     };
 
     // TODO: why is the texture rotated?
-    draw.texture(texture_handle.clone(), texture.clone());
+    // draw.texture(texture_handle.clone(), texture.clone());
     draw.ellipse().w_h(100.0, 100.0).color(SALMON);
     draw.ellipse()
         .x(100.0 + time.elapsed().as_millis() as f32 / 100.0)

--- a/bevy_nannou/src/main.rs
+++ b/bevy_nannou/src/main.rs
@@ -65,7 +65,7 @@ fn update_mesh(mut handles: Query<(&Handle<Mesh>, &mut Transform)>) {
 }
 
 fn update_draw(
-    draw: Query<(&mut bevy_nannou_draw::Draw)>,
+    draw: Query<&mut bevy_nannou_draw::Draw>,
     texture_handle: Res<MyTexture>,
     images: Res<Assets<Image>>,
     time: Res<Time>,
@@ -78,7 +78,7 @@ fn update_draw(
     };
 
     // TODO: why is the texture rotated?
-    // draw.texture(texture_handle.clone(), texture.clone());
+    draw.texture(texture_handle.clone(), texture.clone());
     draw.ellipse().w_h(100.0, 100.0).color(SALMON);
     draw.ellipse()
         .x(100.0 + time.elapsed().as_millis() as f32 / 100.0)

--- a/bevy_nannou_draw/src/lib.rs
+++ b/bevy_nannou_draw/src/lib.rs
@@ -14,8 +14,8 @@ impl Plugin for NannouDrawPlugin {
     }
 }
 
-fn spawn_draw(mut commands: Commands, query: Query<(Entity, &Camera), Added<Camera>>) {
-    for (entity, _camera) in query.iter() {
+fn spawn_draw(mut commands: Commands, query: Query<Entity, Added<Camera>>) {
+    for entity in query.iter() {
         commands.entity(entity).insert(Draw(draw::Draw::new()));
     }
 }

--- a/bevy_nannou_render/src/draw_function.rs
+++ b/bevy_nannou_render/src/draw_function.rs
@@ -1,0 +1,147 @@
+use bevy::ecs::query::ROQueryItem;
+use bevy::ecs::system::lifetimeless::{Read, SRes};
+use bevy::ecs::system::SystemParamItem;
+use bevy::pbr::SetMeshViewBindGroup;
+use bevy::render::extract_component::DynamicUniformIndex;
+use bevy::render::render_asset::RenderAssets;
+use bevy::render::render_phase::{
+    PhaseItem, RenderCommand, RenderCommandResult, SetItemPipeline, TrackedRenderPass,
+};
+use bevy::render::render_resource as wgpu;
+
+use crate::pipeline::NannouPipeline;
+use crate::{
+    DefaultTextureHandle, DrawMesh, DrawMeshHandle, DrawMeshItem, DrawMeshUniform,
+    DrawMeshUniformBindGroup, TextureBindGroupCache,
+};
+
+pub type DrawDrawMeshItem3d = (
+    SetItemPipeline,
+    SetMeshViewBindGroup<0>,
+    SetDrawMeshUniformBindGroup<1>,
+    SetDrawMeshTextBindGroup<2>,
+    SetDrawMeshTextureBindGroup<3>,
+    SetDrawMeshScissor,
+    DrawDrawMeshItem,
+);
+
+pub struct SetDrawMeshUniformBindGroup<const I: usize>;
+impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetDrawMeshUniformBindGroup<I> {
+    type Param = SRes<DrawMeshUniformBindGroup>;
+    type ViewWorldQuery = ();
+    type ItemWorldQuery = Read<DynamicUniformIndex<DrawMeshUniform>>;
+
+    #[inline]
+    fn render<'w>(
+        _item: &P,
+        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
+        uniform_index: ROQueryItem<'w, Self::ItemWorldQuery>,
+        bind_group: SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        pass.set_bind_group(
+            I,
+            &bind_group.into_inner().bind_group,
+            &[uniform_index.index()],
+        );
+        RenderCommandResult::Success
+    }
+}
+
+pub struct SetDrawMeshTextureBindGroup<const I: usize>;
+impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetDrawMeshTextureBindGroup<I> {
+    type Param = (SRes<DefaultTextureHandle>, SRes<TextureBindGroupCache>);
+    type ViewWorldQuery = ();
+    type ItemWorldQuery = Read<DrawMeshItem>;
+
+    #[inline]
+    fn render<'w>(
+        _item: &P,
+        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
+        draw_mesh_item: ROQueryItem<'w, Self::ItemWorldQuery>,
+        (default_texture, bind_groups): SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let texture = match &draw_mesh_item.texture {
+            None => &default_texture.0,
+            Some(texture) => texture,
+        };
+
+        let Some(bind_group) = bind_groups.into_inner().get(texture) else {
+            return RenderCommandResult::Failure;
+        };
+
+        pass.set_bind_group(I, &bind_group, &[]);
+        RenderCommandResult::Success
+    }
+}
+
+pub struct SetDrawMeshTextBindGroup<const I: usize>;
+impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetDrawMeshTextBindGroup<I> {
+    type Param = SRes<NannouPipeline>;
+    type ViewWorldQuery = ();
+    type ItemWorldQuery = ();
+
+    #[inline]
+    fn render<'w>(
+        _item: &P,
+        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
+        _entity: ROQueryItem<'w, Self::ItemWorldQuery>,
+        pipeline: SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        pass.set_bind_group(I, &pipeline.into_inner().text_bind_group, &[]);
+        RenderCommandResult::Success
+    }
+}
+
+pub struct SetDrawMeshScissor;
+impl<P: PhaseItem> RenderCommand<P> for SetDrawMeshScissor {
+    type Param = ();
+    type ViewWorldQuery = ();
+    type ItemWorldQuery = Read<DrawMeshItem>;
+
+    fn render<'w>(
+        _item: &P,
+        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
+        entity: ROQueryItem<'w, Self::ItemWorldQuery>,
+        _param: SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        if let Some(scissor) = entity.scissor {
+            pass.set_scissor_rect(scissor.left, scissor.bottom, scissor.width, scissor.height);
+        }
+
+        RenderCommandResult::Success
+    }
+}
+
+pub struct DrawDrawMeshItem;
+impl<P: PhaseItem> RenderCommand<P> for DrawDrawMeshItem {
+    type Param = SRes<RenderAssets<DrawMesh>>;
+    type ViewWorldQuery = Read<DrawMeshHandle>;
+    type ItemWorldQuery = Read<DrawMeshItem>;
+
+    #[inline]
+    fn render<'w>(
+        _item: &P,
+        handle: ROQueryItem<'w, Self::ViewWorldQuery>,
+        draw_mesh_item: ROQueryItem<'w, Self::ItemWorldQuery>,
+        draw_meshes: SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let Some(mesh) = draw_meshes.into_inner().get(&handle.0) else {
+            return RenderCommandResult::Failure;
+        };
+
+        // Set the buffers.
+        // Note: this is a no-op if the buffers have already been set on this pass
+        pass.set_index_buffer(mesh.index_buffer.slice(..), 0, wgpu::IndexFormat::Uint32);
+        pass.set_vertex_buffer(0, mesh.point_buffer.slice(..));
+        pass.set_vertex_buffer(1, mesh.color_buffer.slice(..));
+        pass.set_vertex_buffer(2, mesh.tex_coords_buffer.slice(..));
+
+        pass.draw_indexed(draw_mesh_item.index_range.clone(), 0, 0..1);
+        RenderCommandResult::Success
+    }
+}

--- a/bevy_nannou_render/src/lib.rs
+++ b/bevy_nannou_render/src/lib.rs
@@ -1,34 +1,46 @@
 use std::collections::HashMap;
-use std::ops::Deref;
+use std::ops::{Deref, Range};
 
 use bevy::asset::load_internal_asset;
+use bevy::core::cast_slice;
 use bevy::core_pipeline::core_3d;
-use bevy::core_pipeline::core_3d::CORE_3D;
+use bevy::core_pipeline::core_3d::{Transparent3d, CORE_3D};
+use bevy::ecs::system::lifetimeless::SRes;
+use bevy::ecs::system::SystemParamItem;
 use bevy::prelude::*;
-use bevy::render::camera::{ExtractedCamera, NormalizedRenderTarget};
-use bevy::render::extract_component::{ExtractComponent, ExtractComponentPlugin};
+use bevy::render::camera::{ExtractedCamera, NormalizedRenderTarget, RenderTarget};
+use bevy::render::extract_component::{
+    ComponentUniforms, ExtractComponent, ExtractComponentPlugin, UniformComponentPlugin,
+};
 use bevy::render::extract_resource::{ExtractResource, ExtractResourcePlugin};
-use bevy::render::render_asset::{RenderAsset, RenderAssets};
+use bevy::render::render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssets};
 use bevy::render::render_graph::{RenderGraphApp, ViewNode, ViewNodeRunner};
+use bevy::render::render_phase::{AddRenderCommand, RenderPhase};
 use bevy::render::render_resource::{
-    CachedRenderPipelineId, PipelineCache, ShaderType, SpecializedRenderPipeline,
-    SpecializedRenderPipelines,
+    BindGroupLayout, BufferInitDescriptor, CachedRenderPipelineId, PipelineCache, ShaderType,
+    SpecializedRenderPipeline, SpecializedRenderPipelines,
 };
 use bevy::render::renderer::RenderDevice;
 use bevy::render::texture::BevyDefault;
 use bevy::render::view::{
     ExtractedView, ExtractedWindow, ExtractedWindows, ViewDepthTexture, ViewTarget, ViewUniforms,
 };
-use bevy::render::{render_resource as wgpu, RenderSet};
+use bevy::render::{render_resource as wgpu, Extract, RenderSet};
 use bevy::render::{Render, RenderApp};
+use bevy::window::{PrimaryWindow, WindowRef};
 use lyon::lyon_tessellation::{FillTessellator, StrokeTessellator};
 
-use bevy_nannou_draw::draw::render::{GlyphCache, RenderContext, RenderPrimitive, Scissor};
+use bevy_nannou_draw::draw::mesh::vertex;
+use bevy_nannou_draw::draw::render::{
+    GlyphCache, RenderContext, RenderPrimitive, Scissor, VertexMode,
+};
 use bevy_nannou_draw::{draw, Draw};
 use nannou_core::geom;
 use nannou_core::math::map_range;
 
-use crate::pipeline::{NannouPipeline, NannouPipelineKey, NannouViewNode, TextureBindGroupCache};
+use crate::pipeline::{
+    queue_draw_mesh_items, DrawDrawMeshItem3d, NannouPipeline, NannouPipelineKey,
+};
 
 mod pipeline;
 
@@ -46,44 +58,19 @@ impl Plugin for NannouRenderPlugin {
         );
 
         app.add_systems(Startup, setup_default_texture)
-            .add_systems(Update, texture_event_handler)
+            .add_plugins(UniformComponentPlugin::<DrawMeshUniform>::default())
+            .add_plugins(RenderAssetPlugin::<DrawMesh>::default())
             .add_plugins((
                 ExtractComponentPlugin::<Draw>::default(),
+                ExtractComponentPlugin::<DrawMeshHandle>::default(),
                 ExtractComponentPlugin::<NannouTextureHandle>::default(),
             ))
-            .add_plugins(ExtractResourcePlugin::<DefaultTextureHandle>::default());
-
-        app.get_sub_app_mut(RenderApp)
-            .unwrap()
-            // TODO: how are these parameters defined? should they be configurable?
+            .add_plugins(ExtractResourcePlugin::<DefaultTextureHandle>::default())
             .insert_resource(GlyphCache::new([1024; 2], 0.1, 0.1))
-            .init_resource::<SpecializedRenderPipelines<NannouPipeline>>()
-            .init_resource::<TextureBindGroupCache>()
-            .add_systems(
-                Render,
-                (
-                    prepare_default_texture_bind_group.in_set(RenderSet::PrepareBindGroups),
-                    prepare_texture_bind_groups.in_set(RenderSet::PrepareBindGroups),
-                    prepare_view_mesh
-                        .after(prepare_default_texture_bind_group)
-                        .in_set(RenderSet::Prepare),
-                    prepare_view_uniform.in_set(RenderSet::PrepareBindGroups),
-                ),
-            )
-            // Register the NannouViewNode with the render graph
-            // The node runs at the last stage of the main 3d pass
-            .add_render_graph_node::<ViewNodeRunner<NannouViewNode>>(
-                core_3d::graph::NAME,
-                NannouViewNode::NAME,
-            )
-            .add_render_graph_edges(
-                CORE_3D,
-                &[
-                    core_3d::graph::node::MAIN_TRANSPARENT_PASS,
-                    NannouViewNode::NAME,
-                    core_3d::graph::node::END_MAIN_PASS,
-                ],
-            );
+            .init_asset::<DrawMesh>()
+            .add_systems(PreUpdate, clear_draw_items)
+            .add_systems(Update, texture_event_handler)
+            .add_systems(Last, (add_meshes, update_draw_mesh).chain());
     }
 
     fn finish(&self, app: &mut App) {
@@ -91,7 +78,22 @@ impl Plugin for NannouRenderPlugin {
             return;
         };
 
-        render_app.init_resource::<NannouPipeline>();
+        render_app
+            .init_resource::<SpecializedRenderPipelines<NannouPipeline>>()
+            .init_resource::<TextureBindGroupCache>()
+            .add_render_command::<Transparent3d, DrawDrawMeshItem3d>()
+            .add_systems(ExtractSchedule, extract_draw_items)
+            .add_systems(
+                Render,
+                (
+                    prepare_default_texture_bind_group,
+                    prepare_texture_bind_groups,
+                    prepare_draw_mesh_uniform_bind_group,
+                )
+                    .in_set(RenderSet::PrepareBindGroups),
+            )
+            .add_systems(Render, queue_draw_mesh_items.in_set(RenderSet::Queue))
+            .init_resource::<NannouPipeline>();
     }
 }
 
@@ -100,6 +102,34 @@ struct DefaultTextureHandle(Handle<Image>);
 
 #[derive(Component, Deref, DerefMut, ExtractComponent, Clone)]
 struct NannouTextureHandle(Handle<Image>);
+
+#[derive(Component, ExtractComponent, Clone)]
+pub struct DrawMeshItem {
+    scissor: Option<Scissor>,
+    texture: Handle<Image>,
+    vertex_mode: VertexMode,
+    blend: wgpu::BlendState,
+    topology: wgpu::PrimitiveTopology,
+    index_range: Range<u32>,
+}
+
+#[derive(Component, ExtractComponent, Clone)]
+pub struct DrawMeshHandle(Handle<DrawMesh>);
+
+/// Create a mesh asset for every draw instance
+fn add_meshes(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<DrawMesh>>,
+    draw: Query<(Entity, Option<&DrawMeshHandle>), With<Draw>>,
+) {
+    for (entity, handle) in draw.iter() {
+        if let None = handle {
+            let mesh = DrawMesh::default();
+            let mesh = meshes.add(mesh);
+            commands.entity(entity).insert(DrawMeshHandle(mesh));
+        }
+    }
+}
 
 fn texture_event_handler(
     mut commands: Commands,
@@ -175,69 +205,64 @@ fn prepare_texture_bind_groups(
     }
 }
 
+fn extract_draw_items(mut commands: Commands, items: Extract<Query<(Entity, &DrawMeshItem)>>) {
+    for (entity, item) in items.iter() {
+        commands.get_or_spawn(entity).insert((
+            item.clone(),
+            DrawMeshUniform {
+                vertex_mode: item.vertex_mode as u32,
+            },
+        ));
+    }
+}
+
+fn clear_draw_items(mut commands: Commands, items: Query<Entity, With<DrawMeshItem>>) {
+    for entity in items.iter() {
+        commands.entity(entity).despawn();
+    }
+}
+
 // Prepare our mesh for rendering
-fn prepare_view_mesh(
+fn update_draw_mesh(
     mut commands: Commands,
-    mut pipeline: ResMut<NannouPipeline>,
     mut glyph_cache: ResMut<GlyphCache>,
-    mut texture_bind_group_cache: ResMut<TextureBindGroupCache>,
-    mut pipelines: ResMut<SpecializedRenderPipelines<NannouPipeline>>,
-    windows: Res<ExtractedWindows>,
+    windows: Query<(&Window, Has<PrimaryWindow>)>,
     msaa: Res<Msaa>,
-    pipeline_cache: Res<PipelineCache>,
     default_texture_handle: Res<DefaultTextureHandle>,
-    draw: Query<(
-        Entity,
-        &Draw,
-        &ExtractedView,
-        &ExtractedCamera,
-        &ViewDepthTexture,
-    )>,
+    mut meshes: ResMut<Assets<DrawMesh>>,
+    draw: Query<(&Draw, &DrawMeshHandle, &Camera)>,
 ) {
-    for (entity, draw, view, camera, depth) in &draw {
-        let mut render_commands = ViewRenderCommands::default();
-        let mut mesh = ViewMesh::default();
+    for (draw, handle, camera) in &draw {
+        let Some(mut mesh) = meshes.get_mut(&handle.0) else {
+            continue;
+        };
+        mesh.clear();
+        let mut items: Vec<DrawMeshItem> = Vec::new();
 
-        // Pushes a draw command and updates the `curr_start_index`.
-        //
-        // Returns `true` if the command was added, `false` if there was nothing to
-        // draw.
-        fn push_draw_cmd(
-            curr_start_index: &mut u32,
-            end_index: u32,
-            render_commands: &mut Vec<RenderCommand>,
-        ) -> bool {
-            let index_range = *curr_start_index..end_index;
-            if index_range.len() != 0 {
-                let start_vertex = 0;
-                *curr_start_index = index_range.end;
-                let cmd = RenderCommand::DrawIndexed {
-                    start_vertex,
-                    index_range,
-                };
-                render_commands.push(cmd);
-                true
-            } else {
-                false
-            }
-        }
-
-        let window = if let Some(NormalizedRenderTarget::Window(window_ref)) = camera.target {
-            let window_entity = window_ref.entity();
-            if let Some(window) = windows.windows.get(&window_entity) {
-                window
-            } else {
-                continue;
+        let window = if let RenderTarget::Window(window_ref) = camera.target {
+            match window_ref {
+                WindowRef::Primary => {
+                    let mut primary_window = None;
+                    for (window, is_primary) in windows.iter() {
+                        if is_primary {
+                            primary_window = Some(window);
+                            break;
+                        }
+                    }
+                    primary_window.unwrap()
+                }
+                WindowRef::Entity(entity) => windows.get(entity).unwrap().0,
             }
         } else {
             // TODO: handle other render targets
             // For now, we only support rendering to a window
+            warn!("Unsupported render target");
             continue;
         };
 
         // TODO: Unclear if we need to track this, or if the physical size is enough.
         let scale_factor = 1.0;
-        let [w_px, h_px] = [window.physical_width, window.physical_height];
+        let [w_px, h_px] = [window.physical_width(), window.physical_height()];
 
         // Converting between pixels and points.
         let px_to_pt = |s: u32| s as f32 / scale_factor;
@@ -258,9 +283,9 @@ fn prepare_view_mesh(
         let mut curr_ctxt = draw::Context::default();
         let mut curr_start_index = 0;
         // Track whether new commands are required.
-        let mut curr_pipeline_id = None;
         let mut curr_scissor = None;
-        let mut curr_texture_handle: Option<Handle<Image>> = None;
+        let mut curr_texture_handle: Handle<Image> = (**default_texture_handle).clone();
+        let mut curr_mode = VertexMode::Color;
 
         // Collect all draw commands to avoid borrow errors.
         let draw_cmds: Vec<_> = draw.drain_commands().collect();
@@ -307,7 +332,7 @@ fn prepare_view_mesh(
                         continue;
                     }
 
-                    let new_texture_handle = match render.texture_handle {
+                    curr_texture_handle = match render.texture_handle {
                         Some(handle) => handle,
                         None => {
                             // If there is no texture, use the default texture.
@@ -318,64 +343,22 @@ fn prepare_view_mesh(
                     let new_pipeline_key = {
                         let topology = curr_ctxt.topology;
                         NannouPipelineKey {
-                            output_color_format: if view.hdr {
+                            output_color_format: if camera.hdr {
                                 ViewTarget::TEXTURE_FORMAT_HDR
                             } else {
                                 wgpu::TextureFormat::bevy_default()
                             },
                             sample_count: msaa.samples(),
-                            depth_format: depth.texture.format(),
                             topology,
                             blend_state: curr_ctxt.blend,
                         }
                     };
 
-                    let new_pipeline_id =
-                        pipelines.specialize(&pipeline_cache, &pipeline, new_pipeline_key);
                     let new_scissor = curr_ctxt.scissor;
-
-                    // Determine which have changed and in turn which require submitting new
-                    // commands.
-                    let pipeline_changed = Some(new_pipeline_id) != curr_pipeline_id;
-                    let texture_changed = Some(new_texture_handle.clone()) != curr_texture_handle;
                     let scissor_changed = Some(new_scissor) != curr_scissor;
 
-                    // If we require submitting a scissor, pipeline or bind group command, first
-                    // draw whatever pending vertices we have collected so far. If there have been
-                    // no graphics yet, this will do nothing.
-                    if scissor_changed || pipeline_changed || texture_changed {
-                        push_draw_cmd(
-                            &mut curr_start_index,
-                            prev_index_count,
-                            &mut render_commands,
-                        );
-                    }
-
-                    // If necessary, push a new pipeline command.
-                    if pipeline_changed {
-                        curr_pipeline_id = Some(new_pipeline_id);
-                        let cmd = RenderCommand::SetPipeline(new_pipeline_id);
-                        render_commands.push(cmd);
-                    }
-
-                    // If necessary, push a new bind group command.
-                    // Because the texture is loaded asynchronously, we need to check if the
-                    // bind group is already in the cache.
-                    if texture_changed && texture_bind_group_cache.contains_key(&new_texture_handle)
-                    {
-                        let cmd = RenderCommand::SetBindGroup(new_texture_handle.clone());
-                        render_commands.push(cmd);
-                    // If the texture is not in the cache and we haven't set a bind group yet,
-                    // we need to use the default texture. This happens when a user texture
-                    // is the first draw command.
-                    } else if curr_texture_handle.is_none() {
-                        curr_texture_handle = Some(new_texture_handle.clone());
-                        let cmd = RenderCommand::SetBindGroup((**default_texture_handle).clone());
-                        render_commands.push(cmd);
-                    }
-
                     // If necessary, push a new scissor command.
-                    if scissor_changed {
+                    let scissor = if scissor_changed {
                         curr_scissor = Some(new_scissor);
                         let rect = match curr_ctxt.scissor {
                             draw::Scissor::Full => full_rect,
@@ -393,87 +376,142 @@ fn prepare_view_mesh(
                             width,
                             height,
                         };
-                        let cmd = RenderCommand::SetScissor(scissor);
-                        render_commands.push(cmd);
-                    }
+                        Some(scissor)
+                    } else {
+                        None
+                    };
 
                     // Extend the vertex mode channel.
-                    let mode = render.vertex_mode;
-                    let new_vs = mesh
-                        .points()
-                        .len()
-                        .saturating_sub(pipeline.vertex_mode_buffer.len());
-                    pipeline
-                        .vertex_mode_buffer
-                        .extend((0..new_vs).map(|_| mode));
+                    curr_mode = render.vertex_mode;
+                    items.push(DrawMeshItem {
+                        scissor,
+                        texture: curr_texture_handle.clone(),
+                        vertex_mode: curr_mode,
+                        blend: curr_ctxt.blend,
+                        topology: curr_ctxt.topology,
+                        index_range: curr_start_index..mesh.indices().len() as u32,
+                    });
+                    curr_start_index = mesh.indices().len() as u32;
                 }
             }
         }
 
-        // Insert the final draw command if there is still some drawing to be done.
-        push_draw_cmd(
-            &mut curr_start_index,
-            mesh.indices().len() as u32,
-            &mut render_commands,
-        );
-        commands.entity(entity).insert((mesh, render_commands));
+        // Insert a final item if there is still draw data.
+        items.push(DrawMeshItem {
+            scissor: None,
+            texture: curr_texture_handle.clone(),
+            vertex_mode: curr_mode,
+            blend: curr_ctxt.blend,
+            topology: curr_ctxt.topology,
+            index_range: curr_start_index..mesh.indices().len() as u32,
+        });
+        commands.spawn_batch(items);
     }
 }
 
-// Prepare our uniform bind group from Bevy's view uniforms
-fn prepare_view_uniform(
+#[derive(Component, ShaderType, Clone, Copy)]
+pub struct DrawMeshUniform {
+    vertex_mode: u32,
+}
+
+// Resource wrapper for our view uniform bind group
+#[derive(Resource)]
+pub struct DrawMeshUniformBindGroup {
+    bind_group: wgpu::BindGroup,
+}
+
+impl DrawMeshUniformBindGroup {
+    fn new(
+        device: &RenderDevice,
+        layout: &wgpu::BindGroupLayout,
+        binding: wgpu::BindingResource,
+    ) -> DrawMeshUniformBindGroup {
+        let bind_group = bevy_nannou_wgpu::BindGroupBuilder::new()
+            .binding(binding)
+            .build(device, layout);
+
+        DrawMeshUniformBindGroup { bind_group }
+    }
+}
+
+fn prepare_draw_mesh_uniform_bind_group(
     mut commands: Commands,
+    pipeline: Res<NannouPipeline>,
     render_device: Res<RenderDevice>,
-    pipline: Res<NannouPipeline>,
-    view_uniforms: Res<ViewUniforms>,
+    uniforms: Res<ComponentUniforms<DrawMeshUniform>>,
 ) {
-    if let Some(binding) = view_uniforms.uniforms.binding() {
-        commands.insert_resource(ViewUniformBindGroup::new(
+    if let Some(binding) = uniforms.uniforms().binding() {
+        commands.insert_resource(DrawMeshUniformBindGroup::new(
             &render_device,
-            &pipline.view_bind_group_layout,
+            &pipeline.mesh_bind_group_layout,
             binding,
         ));
     }
 }
 
-// Resource wrapper for our view uniform bind group
-#[derive(Resource)]
-struct ViewUniformBindGroup {
-    bind_group: wgpu::BindGroup,
+#[derive(Asset, Deref, DerefMut, TypePath, Clone, Default, Debug)]
+pub struct DrawMesh(draw::Mesh);
+
+#[derive(Debug, Clone)]
+pub struct GpuDrawMesh {
+    index_buffer: wgpu::Buffer,
+    point_buffer: wgpu::Buffer,
+    color_buffer: wgpu::Buffer,
+    tex_coords_buffer: wgpu::Buffer,
 }
 
-impl ViewUniformBindGroup {
-    fn new(
-        device: &RenderDevice,
-        layout: &wgpu::BindGroupLayout,
-        binding: wgpu::BindingResource,
-    ) -> ViewUniformBindGroup {
-        let bind_group = bevy_nannou_wgpu::BindGroupBuilder::new()
-            .binding(binding)
-            .build(device, layout);
+impl RenderAsset for DrawMesh {
+    type ExtractedAsset = DrawMesh;
+    type PreparedAsset = GpuDrawMesh;
+    type Param = SRes<RenderDevice>;
 
-        ViewUniformBindGroup { bind_group }
+    fn extract_asset(&self) -> Self::ExtractedAsset {
+        self.clone()
+    }
+
+    fn prepare_asset(
+        mesh: Self::ExtractedAsset,
+        render_device: &mut SystemParamItem<Self::Param>,
+    ) -> Result<Self::PreparedAsset, PrepareAssetError<Self::ExtractedAsset>> {
+        let colors = mesh
+            .colors()
+            .iter()
+            .map(|c| Vec4::new(c.red, c.green, c.blue, c.alpha))
+            .collect::<Vec<Vec4>>();
+        let vertex_usage = wgpu::BufferUsages::VERTEX;
+        let points_bytes = cast_slice(&mesh.points()[..]);
+        let colors_bytes = cast_slice(&colors);
+        let tex_coords_bytes = cast_slice(&mesh.tex_coords());
+        let indices_bytes = cast_slice(&mesh.indices());
+        let point_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+            label: Some("nannou Renderer point_buffer"),
+            contents: points_bytes,
+            usage: vertex_usage,
+        });
+        let color_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+            label: Some("nannou Renderer color_buffer"),
+            contents: colors_bytes,
+            usage: vertex_usage,
+        });
+        let tex_coords_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+            label: Some("nannou Renderer tex_coords_buffer"),
+            contents: tex_coords_bytes,
+            usage: vertex_usage,
+        });
+        let index_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+            label: Some("nannou Renderer index_buffer"),
+            contents: indices_bytes,
+            usage: wgpu::BufferUsages::INDEX,
+        });
+
+        Ok(GpuDrawMesh {
+            index_buffer,
+            point_buffer,
+            color_buffer,
+            tex_coords_buffer,
+        })
     }
 }
 
-#[derive(Component, Deref, DerefMut, Default, Debug)]
-pub struct ViewMesh(draw::Mesh);
-
-/// Commands that map to wgpu encodable commands.
-#[derive(Debug, Clone)]
-pub enum RenderCommand {
-    /// Change pipeline for the new blend mode and topology.
-    SetPipeline(CachedRenderPipelineId),
-    /// Change bind group for a new image.
-    SetBindGroup(Handle<Image>),
-    /// Set the rectangular scissor.
-    SetScissor(Scissor),
-    /// Draw the given vertex range.
-    DrawIndexed {
-        start_vertex: i32,
-        index_range: std::ops::Range<u32>,
-    },
-}
-
-#[derive(Component, Deref, DerefMut, Default)]
-pub struct ViewRenderCommands(Vec<RenderCommand>);
+#[derive(Resource, Deref, DerefMut, Default)]
+pub struct TextureBindGroupCache(HashMap<Handle<Image>, wgpu::BindGroup>);

--- a/bevy_nannou_render/src/lib.rs
+++ b/bevy_nannou_render/src/lib.rs
@@ -227,8 +227,6 @@ fn update_draw_mesh(
     mut commands: Commands,
     mut glyph_cache: ResMut<GlyphCache>,
     windows: Query<(&Window, Has<PrimaryWindow>)>,
-    msaa: Res<Msaa>,
-    default_texture_handle: Res<DefaultTextureHandle>,
     mut meshes: ResMut<Assets<DrawMesh>>,
     draw: Query<(&Draw, &DrawMeshHandle, &Camera)>,
 ) {

--- a/bevy_nannou_render/src/pipeline.rs
+++ b/bevy_nannou_render/src/pipeline.rs
@@ -1,42 +1,28 @@
 use std::hash::Hash;
 
-use bevy::core_pipeline::core_3d::{Transparent3d, CORE_3D_DEPTH_FORMAT};
-use bevy::ecs::query::ROQueryItem;
-use bevy::ecs::system::lifetimeless::{Read, SRes};
-use bevy::ecs::system::SystemParamItem;
-use bevy::pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup};
+use bevy::core_pipeline::core_3d::CORE_3D_DEPTH_FORMAT;
+use bevy::pbr::{MeshPipeline, MeshPipelineKey};
 use bevy::prelude::*;
-use bevy::render::extract_component::DynamicUniformIndex;
-use bevy::render::render_asset::RenderAssets;
-use bevy::render::render_phase::{
-    DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult, RenderPhase, SetItemPipeline,
-    TrackedRenderPass,
-};
+use bevy::render::render_phase::RenderCommand;
 use bevy::render::render_resource as wgpu;
-use bevy::render::render_resource::{
-    PipelineCache, RenderPipelineDescriptor, SpecializedRenderPipeline, SpecializedRenderPipelines,
-};
+use bevy::render::render_resource::{RenderPipelineDescriptor, SpecializedRenderPipeline};
 use bevy::render::renderer::RenderDevice;
-use bevy::render::texture::BevyDefault;
-use bevy::render::view::{ExtractedView, ViewTarget};
+use bevy::render::view::ViewTarget;
 
 use bevy_nannou_draw::draw::mesh;
 use bevy_nannou_draw::draw::mesh::vertex::Point;
 
-use crate::{
-    DefaultTextureHandle, DrawMesh, DrawMeshHandle, DrawMeshItem, DrawMeshUniform,
-    DrawMeshUniformBindGroup, TextureBindGroupCache, NANNOU_SHADER_HANDLE,
-};
+use crate::{DrawMeshUniform, NANNOU_SHADER_HANDLE};
 
 #[derive(Resource)]
 pub struct NannouPipeline {
-    mesh_pipeline: MeshPipeline,
-    glyph_cache_texture: wgpu::Texture,
-    text_bind_group_layout: wgpu::BindGroupLayout,
-    text_bind_group: wgpu::BindGroup,
-    pub(crate) texture_bind_group_layout: wgpu::BindGroupLayout,
-    texture_bind_group: wgpu::BindGroup,
-    pub(crate) mesh_bind_group_layout: wgpu::BindGroupLayout,
+    pub mesh_pipeline: MeshPipeline,
+    pub glyph_cache_texture: wgpu::Texture,
+    pub text_bind_group_layout: wgpu::BindGroupLayout,
+    pub text_bind_group: wgpu::BindGroup,
+    pub texture_bind_group_layout: wgpu::BindGroupLayout,
+    pub texture_bind_group: wgpu::BindGroup,
+    pub mesh_bind_group_layout: wgpu::BindGroupLayout,
 }
 
 // This key is computed and used to cache the pipeline.
@@ -247,183 +233,13 @@ impl FromWorld for NannouPipeline {
         let mesh_pipeline = render_world.resource::<MeshPipeline>().clone();
 
         NannouPipeline {
+            mesh_pipeline,
+            mesh_bind_group_layout,
             glyph_cache_texture,
             text_bind_group_layout,
             text_bind_group,
             texture_bind_group_layout,
             texture_bind_group,
-            mesh_bind_group_layout,
-            mesh_pipeline,
         }
-    }
-}
-
-pub fn queue_draw_mesh_items(
-    draw_functions: Res<DrawFunctions<Transparent3d>>,
-    pipeline: Res<NannouPipeline>,
-    mut pipelines: ResMut<SpecializedRenderPipelines<NannouPipeline>>,
-    pipeline_cache: Res<PipelineCache>,
-    msaa: Res<Msaa>,
-    items: Query<(Entity, &DrawMeshItem)>,
-    mut views: Query<(&ExtractedView, &mut RenderPhase<Transparent3d>)>,
-) {
-    let draw_function = draw_functions
-        .read()
-        .get_id::<DrawDrawMeshItem3d>()
-        .unwrap();
-    for (view, mut transparent_phase) in &mut views {
-        for (entity, item) in items.iter() {
-            let key = NannouPipelineKey {
-                output_color_format: if view.hdr {
-                    ViewTarget::TEXTURE_FORMAT_HDR
-                } else {
-                    wgpu::TextureFormat::bevy_default()
-                },
-                sample_count: msaa.samples(),
-                topology: item.topology,
-                blend_state: item.blend,
-            };
-
-            let pipeline = pipelines.specialize(&pipeline_cache, &pipeline, key);
-
-            transparent_phase.add(Transparent3d {
-                entity,
-                draw_function,
-                pipeline,
-                distance: 0.,
-                batch_range: 0..1,
-                dynamic_offset: None,
-            });
-        }
-    }
-}
-
-pub type DrawDrawMeshItem3d = (
-    SetItemPipeline,
-    SetMeshViewBindGroup<0>,
-    SetDrawMeshUniformBindGroup<1>,
-    SetDrawMeshTextBindGroup<2>,
-    SetDrawMeshTextureBindGroup<3>,
-    SetDrawMeshScissor,
-    DrawDrawMeshItem,
-);
-
-pub struct SetDrawMeshUniformBindGroup<const I: usize>;
-impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetDrawMeshUniformBindGroup<I> {
-    type Param = SRes<DrawMeshUniformBindGroup>;
-    type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<DynamicUniformIndex<DrawMeshUniform>>;
-
-    #[inline]
-    fn render<'w>(
-        _item: &P,
-        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
-        uniform_index: ROQueryItem<'w, Self::ItemWorldQuery>,
-        bind_group: SystemParamItem<'w, '_, Self::Param>,
-        pass: &mut TrackedRenderPass<'w>,
-    ) -> RenderCommandResult {
-        pass.set_bind_group(
-            I,
-            &bind_group.into_inner().bind_group,
-            &[uniform_index.index()],
-        );
-        RenderCommandResult::Success
-    }
-}
-
-pub struct SetDrawMeshTextureBindGroup<const I: usize>;
-impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetDrawMeshTextureBindGroup<I> {
-    type Param = (SRes<DefaultTextureHandle>, SRes<TextureBindGroupCache>);
-    type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<DrawMeshItem>;
-
-    #[inline]
-    fn render<'w>(
-        _item: &P,
-        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
-        draw_mesh_item: ROQueryItem<'w, Self::ItemWorldQuery>,
-        (default_texture, bind_groups): SystemParamItem<'w, '_, Self::Param>,
-        pass: &mut TrackedRenderPass<'w>,
-    ) -> RenderCommandResult {
-        let texture = match &draw_mesh_item.texture {
-            None => &default_texture.0,
-            Some(texture) => texture,
-        };
-
-        let Some(bind_group) = bind_groups.into_inner().get(texture) else {
-            return RenderCommandResult::Failure;
-        };
-
-        pass.set_bind_group(I, &bind_group, &[]);
-        RenderCommandResult::Success
-    }
-}
-
-pub struct SetDrawMeshTextBindGroup<const I: usize>;
-impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetDrawMeshTextBindGroup<I> {
-    type Param = SRes<NannouPipeline>;
-    type ViewWorldQuery = ();
-    type ItemWorldQuery = ();
-
-    #[inline]
-    fn render<'w>(
-        _item: &P,
-        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
-        _entity: ROQueryItem<'w, Self::ItemWorldQuery>,
-        pipeline: SystemParamItem<'w, '_, Self::Param>,
-        pass: &mut TrackedRenderPass<'w>,
-    ) -> RenderCommandResult {
-        pass.set_bind_group(I, &pipeline.into_inner().text_bind_group, &[]);
-        RenderCommandResult::Success
-    }
-}
-
-pub struct SetDrawMeshScissor;
-impl<P: PhaseItem> RenderCommand<P> for SetDrawMeshScissor {
-    type Param = ();
-    type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<DrawMeshItem>;
-
-    fn render<'w>(
-        _item: &P,
-        _view: ROQueryItem<'w, Self::ViewWorldQuery>,
-        entity: ROQueryItem<'w, Self::ItemWorldQuery>,
-        _param: SystemParamItem<'w, '_, Self::Param>,
-        pass: &mut TrackedRenderPass<'w>,
-    ) -> RenderCommandResult {
-        if let Some(scissor) = entity.scissor {
-            pass.set_scissor_rect(scissor.left, scissor.bottom, scissor.width, scissor.height);
-        }
-
-        RenderCommandResult::Success
-    }
-}
-
-pub struct DrawDrawMeshItem;
-impl<P: PhaseItem> RenderCommand<P> for DrawDrawMeshItem {
-    type Param = SRes<RenderAssets<DrawMesh>>;
-    type ViewWorldQuery = Read<DrawMeshHandle>;
-    type ItemWorldQuery = Read<DrawMeshItem>;
-
-    #[inline]
-    fn render<'w>(
-        _item: &P,
-        handle: ROQueryItem<'w, Self::ViewWorldQuery>,
-        draw_mesh_item: ROQueryItem<'w, Self::ItemWorldQuery>,
-        draw_meshes: SystemParamItem<'w, '_, Self::Param>,
-        pass: &mut TrackedRenderPass<'w>,
-    ) -> RenderCommandResult {
-        let Some(mesh) = draw_meshes.into_inner().get(&handle.0) else {
-            return RenderCommandResult::Failure;
-        };
-
-        // Set the buffers.
-        pass.set_index_buffer(mesh.index_buffer.slice(..), 0, wgpu::IndexFormat::Uint32);
-        pass.set_vertex_buffer(0, mesh.point_buffer.slice(..));
-        pass.set_vertex_buffer(1, mesh.color_buffer.slice(..));
-        pass.set_vertex_buffer(2, mesh.tex_coords_buffer.slice(..));
-
-        pass.draw_indexed(draw_mesh_item.index_range.clone(), 0, 0..1);
-        RenderCommandResult::Success
     }
 }

--- a/bevy_nannou_render/src/pipeline.rs
+++ b/bevy_nannou_render/src/pipeline.rs
@@ -1,5 +1,4 @@
 use std::hash::Hash;
-use std::ops::Range;
 
 use bevy::core_pipeline::core_3d::{Transparent3d, CORE_3D_DEPTH_FORMAT};
 use bevy::ecs::query::ROQueryItem;
@@ -19,12 +18,15 @@ use bevy::render::render_resource::{
 };
 use bevy::render::renderer::RenderDevice;
 use bevy::render::texture::BevyDefault;
-use bevy::render::view::{ExtractedView, ViewDepthTexture, ViewTarget, ViewUniform};
+use bevy::render::view::{ExtractedView, ViewTarget};
+
 use bevy_nannou_draw::draw::mesh;
 use bevy_nannou_draw::draw::mesh::vertex::Point;
-use bevy_nannou_draw::draw::render::VertexMode;
 
-use crate::{DrawMesh, DrawMeshHandle, DrawMeshItem, DrawMeshUniform, DrawMeshUniformBindGroup, Scissor, TextureBindGroupCache, NANNOU_SHADER_HANDLE, DefaultTextureHandle};
+use crate::{
+    DefaultTextureHandle, DrawMesh, DrawMeshHandle, DrawMeshItem, DrawMeshUniform,
+    DrawMeshUniformBindGroup, TextureBindGroupCache, NANNOU_SHADER_HANDLE,
+};
 
 #[derive(Resource)]
 pub struct NannouPipeline {
@@ -331,10 +333,7 @@ impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetDrawMeshUniformBindGr
 
 pub struct SetDrawMeshTextureBindGroup<const I: usize>;
 impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetDrawMeshTextureBindGroup<I> {
-    type Param = (
-        SRes<DefaultTextureHandle>,
-        SRes<TextureBindGroupCache>
-    );
+    type Param = (SRes<DefaultTextureHandle>, SRes<TextureBindGroupCache>);
     type ViewWorldQuery = ();
     type ItemWorldQuery = Read<DrawMeshItem>;
 
@@ -399,7 +398,6 @@ impl<P: PhaseItem> RenderCommand<P> for SetDrawMeshScissor {
         RenderCommandResult::Success
     }
 }
-
 
 pub struct DrawDrawMeshItem;
 impl<P: PhaseItem> RenderCommand<P> for DrawDrawMeshItem {

--- a/bevy_nannou_render/src/shaders/nannou.wgsl
+++ b/bevy_nannou_render/src/shaders/nannou.wgsl
@@ -2,13 +2,17 @@
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ VERTEX ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
 
+struct DrawMeshUniform {
+    mode: u32,
+};
+
 @group(0) @binding(0) var<uniform> view: View;
+@group(1) @binding(0) var<uniform> mesh: DrawMeshUniform;
 
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) color: vec4<f32>,
     @location(2) tex_coords: vec2<f32>,
-    @location(3) mode: u32,
 };
 
 struct VertexOutput {
@@ -23,7 +27,7 @@ fn vertex(
     input: VertexInput,
 ) -> VertexOutput {
     let out_pos: vec4<f32> = view.view_proj * vec4<f32>(input.position, 1.0);
-    return VertexOutput(input.color, input.tex_coords, input.mode, out_pos);
+    return VertexOutput(input.color, input.tex_coords, mesh.mode, out_pos);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FRAGMENT ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
@@ -38,16 +42,16 @@ struct FragmentOutput {
     @location(0) color: vec4<f32>,
 };
 
-@group(1) @binding(0) var text_sampler: sampler;
-@group(1) @binding(1) var text: texture_2d<f32>;
-@group(2) @binding(0) var tex_sampler: sampler;
-@group(2) @binding(1) var tex: texture_2d<f32>;
+@group(2) @binding(0) var text_sampler: sampler;
+@group(2) @binding(1) var text: texture_2d<f32>;
+@group(3) @binding(0) var texture_sampler: sampler;
+@group(3) @binding(1) var texture: texture_2d<f32>;
 
 @fragment
 fn fragment(
     input: FragmentInput,
 ) -> FragmentOutput {
-    let tex_color: vec4<f32> = textureSample(tex, tex_sampler, input.tex_coords);
+    let tex_color: vec4<f32> = textureSample(texture, texture_sampler, input.tex_coords);
     let text_color: vec4<f32> = textureSample(text, text_sampler, input.tex_coords);
     let text_alpha: f32 = text_color.x;
     var out_color: vec4<f32>;

--- a/bevy_nannou_render/src/shaders/nannou.wgsl
+++ b/bevy_nannou_render/src/shaders/nannou.wgsl
@@ -51,7 +51,7 @@ struct FragmentOutput {
 fn fragment(
     input: FragmentInput,
 ) -> FragmentOutput {
-    let tex_color: vec4<f32> = textureSample(texture, texture_sampler, input.tex_coords);
+    let texture_color: vec4<f32> = textureSample(texture, texture_sampler, input.tex_coords);
     let text_color: vec4<f32> = textureSample(text, text_sampler, input.tex_coords);
     let text_alpha: f32 = text_color.x;
     var out_color: vec4<f32>;
@@ -59,7 +59,7 @@ fn fragment(
         out_color = input.color;
     } else {
         if (input.mode == u32(1)) {
-            out_color = tex_color;
+            out_color = texture_color;
         } else {
             if (input.mode == u32(2)) {
                 out_color = vec4<f32>(input.color.xyz, input.color.w * text_alpha);

--- a/bevy_nannou_wgpu/src/bind_group_builder.rs
+++ b/bevy_nannou_wgpu/src/bind_group_builder.rs
@@ -33,7 +33,11 @@ impl BindGroupLayoutBuilder {
     }
 
     /// Add a uniform buffer binding to the layout.
-    pub fn uniform_buffer<T: ShaderType>(self, visibility: wgpu::ShaderStages, has_dynamic_offset: bool) -> Self {
+    pub fn uniform_buffer<T: ShaderType>(
+        self,
+        visibility: wgpu::ShaderStages,
+        has_dynamic_offset: bool,
+    ) -> Self {
         let ty = wgpu::BindingType::Buffer {
             ty: wgpu::BufferBindingType::Uniform,
             has_dynamic_offset,

--- a/bevy_nannou_wgpu/src/bind_group_builder.rs
+++ b/bevy_nannou_wgpu/src/bind_group_builder.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy::render::render_resource as wgpu;
+use bevy::render::render_resource::ShaderType;
 use bevy::render::renderer::RenderDevice;
 
 /// A type aimed at simplifying the creation of a bind group layout.
@@ -32,12 +33,11 @@ impl BindGroupLayoutBuilder {
     }
 
     /// Add a uniform buffer binding to the layout.
-    pub fn uniform_buffer(self, visibility: wgpu::ShaderStages, has_dynamic_offset: bool) -> Self {
+    pub fn uniform_buffer<T: ShaderType>(self, visibility: wgpu::ShaderStages, has_dynamic_offset: bool) -> Self {
         let ty = wgpu::BindingType::Buffer {
             ty: wgpu::BufferBindingType::Uniform,
             has_dynamic_offset,
-            // wgpu 0.5-0.6 TODO: potential perf hit, investigate this field
-            min_binding_size: None,
+            min_binding_size: Some(T::min_size()),
         };
         self.binding(visibility, ty)
     }

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/l6qwc0cii9g6hzrqcb79wr61jg32nhx6-nannou-0.19.0


### PR DESCRIPTION
# Mid-level Render APIs

This pull request moves us from using a roughly 1:1 conversion of the rendering technique on `master`, which uses a custom `ViewNode` that runs on Bevy's 3d render graph, to using a variety of "mid-level" render APIs that bring us closer in line with Bevy's idioms for render code.

## High level overview

Rather than executing a series of render commands, we queue a number of render items into the `Transparent3d` phase of Bevy's existing render graph. These items are then executed with a "draw function", which specifies a series of render operations to perform on each item, setting the pipeline, bind groups, and finally issuing a draw call.

This initially poses a problem, because our existing rendering code executes a variety of draw calls against a single mesh, and so isn't easily broken into "items." Unlike other rendering code Bevy handles, we don't have the benefit of assuming that logical rendering entities exist for multiple frames. In the worst case scenario, each frame is maximally different in every dimension from the one that came before it. This makes patterns in Bevy designed around rendering stable assets a bit more difficult to fit into.

The solution in this PR is the following:
- Keep our existing mesh, which has been renamed from `ViewMesh` to `DrawMesh` and converted to a Bevy asset. We still associate draw instances with a view, but instead let Bevy manage the lifetime of the asset, and interact with a handle to the mesh. This better identifies our mesh as having a relationship to certain GPU resources, which are created in the mesh lifecycle, rather than explicitly in the render code.
- When the mesh is filled, spawn a number of `DrawMeshItem`s that contain metadata that are used to drive our new draw function, like what texture should be used for rendering this portion of the mesh, etc. These are created on every frame and extracted into the render world where they are added to the render phase.
- Moved vertex mode information into another uniform, which was necessary to help decouple the new asset pattern from our previous imperative rendering logic.

## Learning examples in Bevy

These patterns are used all over the renderer, but it's worth calling out a few examples:

- [Gizmos](https://github.com/bevyengine/bevy/blob/main/crates/bevy_gizmos/src/pipeline_3d.rs), which are an immediate style drawing API somewhat similar conceptually to Nannou.
- [The instancing example](https://github.com/bevyengine/bevy/blob/main/examples/shader/shader_instancing.rs), which is pretty verbose right now but potentially relevant to our users.
- [The manual 2d mesh example](https://github.com/bevyengine/bevy/blob/main/examples/2d/mesh2d_manual.rs), which is probably the most straightforward example for understanding some of these patterns.

## How to review

Unfortunately, the diff here got pretty messy, I hope it's still somewhat comprehensible, but I can move things around into new files or otherwise if it would make it clearer or easier to review.

- Please bikeshed names. In particular, things like `DrawDrawMesh` are too overloaded. I was considering keeping `Draw` in terms of our high level API, but calling things `Drawing` in the render code to distinguish it from Bevy's draw/mesh abstractions.
- In `bevy_nannou_render/src/lib.rs`, notice how much code was able to be removed from `update_draw_mesh` (previously `prepare_view_mesh`. Also the `RenderAsset` mechanism for `DrawMesh`/`GpuDrawMesh`.
- `bevy_nannou_render/src/pipeline.rs` should be more straightforward.

## Conclusion and next steps

Some of these patterns are more verbose and a bit abstract, but I think are worthwhile in bringing us closer to Bevy. There's also definitely room for improvement here, including just more general cleanup and tidiness. In particular, it's still worth investigating whether we can make more use of Bevy's mesh infrastructure, rather than re-inventing the wheel here. This might not be possible due to our immediate mode needs, but is worth ruling out.