### PR TITLE
small fix: empty range error in circle_packing

### DIFF
--- a/examples/ui/egui/circle_packing.rs
+++ b/examples/ui/egui/circle_packing.rs
@@ -66,7 +66,7 @@ fn update(_app: &App, model: &mut Model, update: Update) {
             .add(egui::Slider::new(&mut settings.min_radius, 0.0..=20.0).text("min radius"))
             .changed();
         changed |= ui
-            .add(egui::Slider::new(&mut settings.max_radius, 0.0..=200.0).text("max radius"))
+            .add(egui::Slider::new(&mut settings.max_radius, 0.1..=200.0).text("max radius"))
             .changed();
         changed |= ui
             .add(egui::Slider::new(&mut settings.circle_count, 0..=2000).text("circle count"))


### PR DESCRIPTION
## Motivation for changes
* I was playing with the `circle_packing` example to better understand the egui library
* On setting both `min radius` and `max radius` to 0, the program panics and exits with `cannot sample empty range`
* I really value Nannou as a library, so wanted to give back a little by including a fix for this

## Summary of changes
* Set minimum value of `max radius` to 0.1 to avoid empty range errors

## PR checklist
As per the docs I have:
- [ ]  run `cargo fmt --all`
- [ ] Errors, none shown
- [ ] Warnings, no new added
- [ ] Check Examples, have run all examples with `cargo run --bin run_all_examples`
