### PR TITLE
Align nannou_core::math::fmod with C++ behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,6 +1581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float_eq"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
+
+[[package]]
 name = "float_next_after"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3021,7 @@ dependencies = [
 name = "nannou_core"
 version = "0.19.0"
 dependencies = [
+ "float_eq",
  "glam",
  "num-traits",
  "palette",

--- a/nannou_core/Cargo.toml
+++ b/nannou_core/Cargo.toml
@@ -21,6 +21,9 @@ rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 # TODO: Needs no-std support before we can add text logic to this core.
 # rusttype = "0.8"
 
+[dev-dependencies]
+float_eq = "1.0.1"
+
 [features]
 default = ["std"]
 libm = ["glam/libm", "num-traits/libm", "palette/libm" ]

--- a/nannou_core/src/math.rs
+++ b/nannou_core/src/math.rs
@@ -243,3 +243,27 @@ where
 {
     s.rad_to_turns()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use float_eq::assert_float_eq;
+
+    #[test]
+    fn test_fmod() {
+        /*
+            Test values sourced from:
+            https://en.cppreference.com/w/c/numeric/math/fmod
+        */
+        assert_float_eq!(fmod(5.1, 3.0), 2.1, r2nd <= Float::epsilon());
+        assert_float_eq!(fmod(-5.1, 3.0), -2.1, r2nd <= Float::epsilon());
+        assert_float_eq!(fmod(5.1, -3.0), 2.1, r2nd <= Float::epsilon());
+        assert_float_eq!(fmod(-5.1, -3.0), -2.1, r2nd <= Float::epsilon());
+
+        assert_float_eq!(fmod(0.0, 1.0), 0.0, r2nd <= Float::epsilon());
+        assert_float_eq!(fmod(-0.0, 1.0), -0.0, r2nd <= Float::epsilon());
+
+        assert!(fmod(5.1, Float::infinity()).is_sign_negative());
+        assert!(fmod(5.1, Float::infinity()).is_nan());
+    }
+}

--- a/nannou_core/src/math.rs
+++ b/nannou_core/src/math.rs
@@ -208,7 +208,7 @@ pub fn fmod<F>(numer: F, denom: F) -> F
 where
     F: Float,
 {
-    let rquot: F = (numer / denom).floor();
+    let rquot: F = (numer / denom).trunc();
     numer - rquot * denom
 }
 


### PR DESCRIPTION
Hi all,

This PR addresses the minor inconsistency that I brought up in issue #983 (see for more context). In short, during the fmod calculation, truncating (moving towards 0) is more accurate to the original `fmod` function from C.

I do have a few small notes/questions:
1. I brought in the `float_eq` crate as a dev dependency in order to assert against the float values. Is that okay or would you prefer a test assertion that doesn't pull in a dependency? I can hand roll a delta check (or similar) if we would prefer that.
2. I included the unit test with the `math.rs` file. I didn't see a strong standard elsewhere in the project. Is this okay or would a doctest or a package-level test (`nannou_core/tests/*` maybe) be preferable?

Thanks for the opportunity to contribute the the project. Please let me know if there's anything I can update for you, I'm happy to do so.