### PR TITLE
Fix wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.8.3",
+ "miniz_oxide 0.8.4",
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
@@ -1135,7 +1135,7 @@ dependencies = [
  "proc-macro2 1.0.93",
  "quote 1.0.38",
  "syn 2.0.98",
- "toml_edit 0.22.23",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -1202,7 +1202,6 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_nannou_draw",
- "proc-macro2 1.0.93",
  "quote 1.0.38",
  "syn 1.0.109",
 ]
@@ -1213,10 +1212,8 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bitflags 2.8.0",
- "bytemuck",
  "lyon",
  "nannou_core",
- "num-traits",
  "rayon",
  "rusttype",
  "uuid 1.12.1",
@@ -1228,7 +1225,6 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",
- "bevy_egui",
  "bytemuck",
  "isf",
  "meval",
@@ -1375,7 +1371,7 @@ dependencies = [
  "image 0.25.5",
  "js-sys",
  "ktx2",
- "naga 23.1.0",
+ "naga",
  "naga_oil",
  "nonmax",
  "offset-allocator",
@@ -1835,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+checksum = "73848a43c5d63a1251d17adf6c2bf78aa94830e60a335a95eeea45d6ba9e1e4d"
 
 [[package]]
 name = "bumpalo"
@@ -1902,9 +1898,9 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bytesize"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
 
 [[package]]
 name = "bzip2"
@@ -1918,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.12+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
 dependencies = [
  "cc",
  "libc",
@@ -2063,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.12"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "jobserver",
  "libc",
@@ -2671,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.78+curl-8.11.0"
+version = "0.4.79+curl-8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eec768341c5c7789611ae51cf6c459099f22e64a5d5d0ce4892434e33821eaf"
+checksum = "18a9bbeeb3996717ef1248018db20d1b0b5ba7165bff60e3b5135b4f4c2b37a5"
 dependencies = [
  "cc",
  "libc",
@@ -2743,9 +2739,9 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "deflate"
@@ -3067,16 +3063,13 @@ dependencies = [
  "audrey",
  "bytemuck",
  "futures 0.3.31",
- "hotglsl",
  "hound",
  "hrtf",
  "nannou",
  "nannou_audio",
  "nannou_laser",
  "nannou_osc",
- "pitch_calc",
  "ringbuf",
- "time_calc",
  "tokio 1.43.0",
  "walkdir",
 ]
@@ -3090,7 +3083,7 @@ dependencies = [
  "bit_field",
  "half",
  "lebe",
- "miniz_oxide 0.8.3",
+ "miniz_oxide 0.8.4",
  "rayon-core",
  "smallvec 1.13.2",
  "zune-inflate",
@@ -3211,7 +3204,7 @@ checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide 0.8.3",
+ "miniz_oxide 0.8.4",
 ]
 
 [[package]]
@@ -3592,9 +3585,9 @@ dependencies = [
 
 [[package]]
 name = "gilrs-core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed2326d21aa97752d41b2c195aee1d99cd84456ff4d5a7f5e6e1cdbd3dcb0b8"
+checksum = "b4ed3920aa2e2a5b02fb67182e269b7c988ffbba86e1278bb9f9bbe1815e3ae1"
 dependencies = [
  "core-foundation 0.10.0",
  "inotify 0.11.0",
@@ -3927,17 +3920,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "hotglsl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4255b32d5626f6c2f38801fb57b540edd95e8014ebb757b753bea7d946c031f7"
-dependencies = [
- "naga 0.14.2",
- "notify 6.1.1",
- "thiserror",
 ]
 
 [[package]]
@@ -4363,17 +4345,6 @@ name = "inflections"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
-
-[[package]]
-name = "inotify"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
 
 [[package]]
 name = "inotify"
@@ -5056,9 +5027,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -5081,18 +5052,6 @@ dependencies = [
  "net2",
  "slab",
  "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5152,23 +5111,6 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae585df4b6514cf8842ac0f1ab4992edc975892704835b549cf818dc0191249e"
-dependencies = [
- "bit-set 0.5.3",
- "bitflags 2.8.0",
- "indexmap 2.7.1",
- "log",
- "num-traits",
- "pp-rs",
- "rustc-hash",
- "spirv 0.2.0+1.5.4",
- "thiserror",
-]
-
-[[package]]
-name = "naga"
 version = "23.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "364f94bc34f61332abebe8cad6f6cd82a5b65cff22c828d05d0968911462ca4f"
@@ -5185,7 +5127,7 @@ dependencies = [
  "pp-rs",
  "rustc-hash",
  "serde",
- "spirv 0.3.0+sdk-1.3.268.0",
+ "spirv",
  "termcolor",
  "thiserror",
  "unicode-xid 0.2.6",
@@ -5201,7 +5143,7 @@ dependencies = [
  "codespan-reporting",
  "data-encoding",
  "indexmap 2.7.1",
- "naga 23.1.0",
+ "naga",
  "once_cell",
  "regex",
  "regex-syntax 0.8.5",
@@ -5231,24 +5173,17 @@ dependencies = [
  "bevy_nannou",
  "bevy_nannou_derive",
  "find_folder",
- "futures 0.3.31",
- "getrandom 0.2.15",
  "image 0.25.5",
- "instant",
  "lyon",
  "nannou_core",
  "nannou_wgpu",
  "noise",
- "notosans",
- "num_cpus",
  "pennereq",
- "rusttype",
  "serde",
  "serde_json",
  "tokio 1.43.0",
  "toml 0.8.20",
  "walkdir",
- "web-sys",
  "wgpu",
 ]
 
@@ -5312,8 +5247,6 @@ version = "0.19.0"
 dependencies = [
  "futures 0.3.31",
  "image 0.25.5",
- "instant",
- "num_cpus",
  "tokio 1.43.0",
  "wgpu",
 ]
@@ -5540,25 +5473,6 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
-dependencies = [
- "bitflags 2.8.0",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
- "inotify 0.9.6",
- "kqueue",
- "libc",
- "log",
- "mio 0.8.11",
- "walkdir",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "notify"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
@@ -5584,7 +5498,7 @@ checksum = "9dcf855483228259b2353f89e99df35fc639b2b2510d1166e4858e3f67ec1afb"
 dependencies = [
  "file-id",
  "log",
- "notify 7.0.0",
+ "notify",
  "notify-types",
  "walkdir",
 ]
@@ -5597,12 +5511,6 @@ checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
 dependencies = [
  "instant",
 ]
-
-[[package]]
-name = "notosans"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004d578bbfc8a6bdd4690576a8381af234ef051dd4cc358604e1784821e8205c"
 
 [[package]]
 name = "ntapi"
@@ -5624,33 +5532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bdb1fb680e609c2e0930c1866cafdd0be7e7c7a1ecf92aec71ed8d99d3e133"
-dependencies = [
- "num-bigint 0.1.45",
- "num-complex 0.1.44",
- "num-integer",
- "num-iter",
- "num-rational 0.1.43",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1357c02fa1d647dd0769ef5bc2bf86281f064231c09c192a46c71246e3ec9258"
-dependencies = [
- "autocfg 1.4.0",
- "num-integer",
- "num-traits",
- "rand 0.4.6",
- "rustc-serialize",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5658,17 +5539,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cf384bef067563c44d41028840dbecc7f06f2aa5d7881a81dfb0fc7c72f202"
-dependencies = [
- "autocfg 1.4.0",
- "num-traits",
- "rustc-serialize",
 ]
 
 [[package]]
@@ -5724,19 +5594,6 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfff0773e8a07fb033d726b9ff1327466709820788e5298afce4d752965ff1e"
-dependencies = [
- "autocfg 1.4.0",
- "num-bigint 0.1.45",
- "num-integer",
- "num-traits",
- "rustc-serialize",
-]
-
-[[package]]
-name = "num-rational"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
@@ -5752,7 +5609,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -6406,17 +6263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pitch_calc"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387005d7ff9e9970f954ffd33e258f9b755d5f27f11a4b57df3e5c6eab5a46f8"
-dependencies = [
- "num",
- "rand 0.3.23",
- "serde",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6444,7 +6290,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.3",
+ "miniz_oxide 0.8.4",
 ]
 
 [[package]]
@@ -6518,7 +6364,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.23",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -7204,7 +7050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd573ac64f04bec39254cdebd0b2cc637076eff9e97ec66aeab38403cd746531"
 dependencies = [
  "log",
- "num-complex 0.3.1",
+ "num-complex",
  "num-integer",
  "num-traits",
  "realfft",
@@ -7230,12 +7076,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
-
-[[package]]
 name = "rustc-workspace-hack"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7256,7 +7096,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f107ffb2ec15915d932b7b1537fe4d6efb36955ee2b06f8f759c80a0725f80b1"
 dependencies = [
- "num-complex 0.3.1",
+ "num-complex",
  "num-integer",
  "num-traits",
  "strength_reduce",
@@ -7698,16 +7538,6 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.2.0+1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
-dependencies = [
- "bitflags 1.3.2",
- "num-traits",
-]
-
-[[package]]
-name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
@@ -8052,17 +7882,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time_calc"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87eac2313f2e8e6ac326f44b662cd4491c6f1c6b590668abcdd48be1cc439e83"
-dependencies = [
- "num",
- "rand 0.3.23",
- "serde",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8301,7 +8120,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.23",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -8337,15 +8156,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.23"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.1",
+ "winnow 0.7.2",
 ]
 
 [[package]]
@@ -9026,7 +8845,7 @@ dependencies = [
  "document-features",
  "js-sys",
  "log",
- "naga 23.1.0",
+ "naga",
  "parking_lot 0.12.3",
  "profiling",
  "raw-window-handle",
@@ -9055,7 +8874,7 @@ dependencies = [
  "document-features",
  "indexmap 2.7.1",
  "log",
- "naga 23.1.0",
+ "naga",
  "once_cell",
  "parking_lot 0.12.3",
  "profiling",
@@ -9094,7 +8913,7 @@ dependencies = [
  "libloading",
  "log",
  "metal",
- "naga 23.1.0",
+ "naga",
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
@@ -9742,9 +9561,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
 ]

--- a/bevy_nannou_derive/Cargo.toml
+++ b/bevy_nannou_derive/Cargo.toml
@@ -9,7 +9,6 @@ proc-macro = true
 [dependencies]
 syn = {  version = "1", features = ["full"] }
 quote = "1.0"
-proc-macro2 = "1.0"
 
 [dev-dependencies]
 bevy = { workspace = true }

--- a/bevy_nannou_draw/Cargo.toml
+++ b/bevy_nannou_draw/Cargo.toml
@@ -8,8 +8,6 @@ bevy = { workspace = true }
 lyon = "1.0"
 nannou_core = { path = "../nannou_core" }
 rusttype = { version = "0.8", features = ["gpu_cache"] }
-num-traits = "0.2"
-bytemuck = "1.15.0"
 rayon = { workspace = true }
 uuid = "1.8"
 bitflags = "2.6.0"

--- a/bevy_nannou_draw/src/lib.rs
+++ b/bevy_nannou_draw/src/lib.rs
@@ -22,7 +22,7 @@ fn reset_draw(mut draw_q: Query<&mut DrawHolder>) {
     }
 }
 
-fn spawn_draw(mut commands: Commands, query: Query<Entity, Added<Window>>) {
+fn spawn_draw(mut commands: Commands, query: Query<Entity, (Without<DrawHolder>, With<Window>)>) {
     for entity in query.iter() {
         commands
             .entity(entity)

--- a/bevy_nannou_isf/Cargo.toml
+++ b/bevy_nannou_isf/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 bevy = { workspace = true, features = ["shader_format_glsl"] }
-bevy_egui = { workspace = true }
 bevy-inspector-egui = { workspace = true }
 isf = "0.1.0"
 thiserror = "1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,14 +15,11 @@ edition = "2018"
 
 [dev-dependencies]
 audrey = "0.3"
-hotglsl = "0.2"
 hrtf = "0.2"
 nannou = { version ="0.19.0", path = "../nannou" }
 nannou_audio = { version ="0.19.0", path = "../nannou_audio" }
 nannou_laser = { version ="0.19.0", features = ["ffi", "ilda-idtf"], path = "../nannou_laser" }
 nannou_osc = { version ="0.19.0", path = "../nannou_osc" }
-pitch_calc = { version = "0.12", features = ["serde"] }
-time_calc = { version= "0.13", features = ["serde"] }
 walkdir = "2"
 hound = "3.4.0"
 ringbuf = "0.2.2"

--- a/examples/draw/draw.rs
+++ b/examples/draw/draw.rs
@@ -8,7 +8,6 @@ fn view(app: &App) {
     // Begin drawing
     let draw = app.draw();
 
-    info!("draw");
     // Clear the background to blue.
     draw.background().color(CORNFLOWER_BLUE);
 

--- a/examples/draw/draw.rs
+++ b/examples/draw/draw.rs
@@ -8,6 +8,7 @@ fn view(app: &App) {
     // Begin drawing
     let draw = app.draw();
 
+    info!("draw");
     // Clear the background to blue.
     draw.background().color(CORNFLOWER_BLUE);
 

--- a/examples/wasm/index.html
+++ b/examples/wasm/index.html
@@ -1,0 +1,27 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        background: linear-gradient(
+          135deg,
+          white 0%,
+          white 49%,
+          black 49%,
+          black 51%,
+          white 51%,
+          white 100%
+        ) repeat;
+        background-size: 20px 20px;
+      }
+      canvas {
+        background-color: white;
+      }
+    </style>
+    <title>Wasm Example</title>
+  </head>
+  <script type="module">
+    import init from './target/draw.js'
+    init()
+  </script>
+</html>

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -17,34 +17,28 @@ bevy_egui = { workspace = true, optional = true }
 bevy_common_assets = { workspace = true, optional = true }
 bevy_nannou = { version = "0.1.0", path = "../bevy_nannou" }
 bevy_nannou_derive = { version = "0.1.0", path = "../bevy_nannou_derive" }
-futures = "0.3"
 find_folder = "0.3"
-getrandom = "0.2.3"
-instant = "0.1.9"
 lyon = "1.0"
 nannou_core = { version ="0.19.0", path = "../nannou_core", features = ["std"] }
 nannou_wgpu = { version = "0.19.0", path = "../nannou_wgpu", features = ["capturer"]}
 noise = "0.7"
-notosans = { version = "0.1", optional = true }
-num_cpus = "1"
 pennereq = "0.3"
-rusttype = { version = "0.8", features = ["gpu_cache"] }
 serde = { workspace = true, features = ["derive"], optional = true}
 serde_json = { workspace = true, optional = true }
 toml = { workspace = true, optional = true }
 walkdir = "2"
-web-sys = { version = "0.3.64", optional = true }
 wgpu = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"]}
 image = { workspace = true, features = ["default"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+bevy = { workspace = true, features = ["webgpu"] }
 tokio = { version = "1", features = ["rt"]}
 image = { workspace = true, features = [], default-features = false }
 
 [features]
-default = ["notosans"]
+default = []
 egui = ["bevy_egui", "bevy-inspector-egui"]
 hot_reload = ["bevy/file_watcher"]
 isf = ["bevy_nannou/isf"]

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -252,8 +252,17 @@ where
         let mut app = bevy::app::App::new();
         app.add_plugins((
             DefaultPlugins.set(WindowPlugin {
+                #[cfg(not(target_arch = "wasm32"))]
                 // Don't spawn a  window by default, we'll handle this ourselves
                 primary_window: None,
+                #[cfg(target_arch = "wasm32")]
+                // We create a default window on wasm to make sure that the render initialization
+                // has a canvas to attach to when configuring the surface.
+                primary_window: Some(Window {
+                    title: "Nannou".to_string(),
+                    resolution: (1024.0, 768.0).into(),
+                    ..default()
+                }),
                 exit_condition: ExitCondition::OnAllClosed,
                 ..default()
             }),
@@ -1061,10 +1070,8 @@ where
                 };
             }
         };
-        #[cfg(not(target_os = "unknown"))]
-        {
-            let _ = window.primary().build();
-        }
+
+        let _ = window.primary().build();
     }
 
     // Initialise the model.

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -410,26 +410,52 @@ where
         self
     }
 
-    #[cfg(not(target_os = "unknown"))]
     /// Builds the window, inserts it into the `App`'s display map and returns the unique ID.
     pub fn build(self) -> Entity {
-        let entity = self
-            .app
-            .component_world_mut()
-            .spawn((self.window, WindowUserFunctions(self.user_functions)))
-            .id();
+        if cfg!(target_arch = "wasm32") && !self.primary {
+            // TODO: figure out a way to dynamically attach to a canvas with new windows
+            panic!("Non-primary windows are not supported on wasm");
+        }
 
-        if self.primary {
-            let mut q = self.app.component_world_mut().query::<&PrimaryWindow>();
-            if q.get_single(&mut self.app.component_world_mut()).is_ok() {
-                panic!("Only one primary window can be created");
+        let entity = if !cfg!(target_arch = "wasm32") {
+            let entity = self
+                .app
+                .component_world_mut()
+                .spawn((self.window, WindowUserFunctions(self.user_functions)))
+                .id();
+
+            if self.primary {
+                let mut q = self.app.component_world_mut().query::<&PrimaryWindow>();
+                if q.get_single(&mut self.app.component_world_mut()).is_ok() {
+                    panic!("Only one primary window can be created");
+                }
+
+                self.app
+                    .component_world_mut()
+                    .entity_mut(entity)
+                    .insert(PrimaryWindow);
             }
+
+            entity
+        } else {
+            let mut q = self
+                .app
+                .component_world_mut()
+                .query_filtered::<(Entity, &mut bevy::window::Window), With<PrimaryWindow>>();
+            let entity = if let Ok((entity, mut window)) = q.get_single_mut(&mut self.app.component_world_mut()) {
+                *window = self.window;
+                entity
+            } else {
+                panic!("No primary window found");
+            };
 
             self.app
                 .component_world_mut()
                 .entity_mut(entity)
-                .insert(PrimaryWindow);
-        }
+                .insert(WindowUserFunctions(self.user_functions));
+
+            entity
+        };
 
         let layer = RenderLayers::layer(self.app.window_count());
 

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -442,7 +442,9 @@ where
                 .app
                 .component_world_mut()
                 .query_filtered::<(Entity, &mut bevy::window::Window), With<PrimaryWindow>>();
-            let entity = if let Ok((entity, mut window)) = q.get_single_mut(&mut self.app.component_world_mut()) {
+            let entity = if let Ok((entity, mut window)) =
+                q.get_single_mut(&mut self.app.component_world_mut())
+            {
                 *window = self.window;
                 entity
             } else {

--- a/nannou_wgpu/Cargo.toml
+++ b/nannou_wgpu/Cargo.toml
@@ -12,8 +12,6 @@ edition = "2018"
 [dependencies]
 futures = "0.3"
 image = { workspace = true, optional = true }
-instant = { version = "0.1.9", optional = true }
-num_cpus = { version = "1", optional = true }
 wgpu = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -22,7 +20,7 @@ tokio = { version = "1", features = ["full"]}
 tokio = { version = "1", features = ["rt"]}
 
 [features]
-capturer = ["image", "instant", "num_cpus"]
+capturer = ["image"]
 replay = ["wgpu/replay"]
 serde = ["wgpu/serde"]
 spirv = ["wgpu/spirv"]


### PR DESCRIPTION
Because we weren't creating a default window in `WindowPlugin`, the renderer wasn't able to initialize with the correct surface to attach to the canvas. This PR fixes this by doing some hacks when compiling under `wasm32` to create the default window and then update it to whatever the user provides in their `WindowBuilder`. This only supports a single primary window on web.

Ideally, long term, we'd figure out a better pattern for spawning a new canvas element when the window is created dynamically, rather than relying on Bevy's window initialization logic in the renderer. I'm sure this is possible, just need some more consultation with some other Bevy folks to figure out how to do it.

Test with:
```sh
cargo build --release --example draw --target wasm32-unknown-unknown
wasm-bindgen --out-name draw \ 
    --out-dir examples/wasm/target \
    --target web target/wasm32-unknown-unknown/release/examples/draw.wasm
basic-http-server examples/wasm
```

![image](https://github.com/user-attachments/assets/9da6b7b9-30fc-4df9-a463-80d4904b04b8)
