### PR TITLE
Updates to allow easy usage of bevy_nannou with bevy.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,7 @@ name = "bevy_nannou"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bevy_nannou_derive",
  "bevy_nannou_draw",
  "bevy_nannou_isf",
  "bevy_nannou_video",
@@ -3061,6 +3062,8 @@ name = "examples"
 version = "0.1.0"
 dependencies = [
  "audrey",
+ "bevy",
+ "bevy_nannou",
  "bytemuck",
  "futures 0.3.31",
  "hound",
@@ -5171,7 +5174,6 @@ dependencies = [
  "bevy_common_assets",
  "bevy_egui",
  "bevy_nannou",
- "bevy_nannou_derive",
  "find_folder",
  "image 0.25.5",
  "lyon",

--- a/bevy_nannou/Cargo.toml
+++ b/bevy_nannou/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bevy = { workspace = true, features = ["jpeg"]}
+bevy_nannou_derive = { path = "../bevy_nannou_derive" }
 bevy_nannou_draw = { path = "../bevy_nannou_draw" }
 bevy_nannou_isf = { path = "../bevy_nannou_isf", optional = true }
 bevy_nannou_video = { path = "../bevy_nannou_video", optional = true }

--- a/bevy_nannou/src/lib.rs
+++ b/bevy_nannou/src/lib.rs
@@ -14,6 +14,7 @@ pub mod prelude {
     pub use bevy::render::render_asset::*;
     pub use bevy::render::render_resource::*;
     pub use bevy::winit::UpdateMode;
+    pub use bevy_nannou_derive::shader_model;
 
     pub use bevy_nannou_draw::color::*;
     pub use bevy_nannou_draw::draw::*;
@@ -32,7 +33,7 @@ pub struct NannouPlugin;
 
 impl Plugin for NannouPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((bevy_nannou_draw::NannouDrawPlugin,));
+        app.add_plugins(bevy_nannou_draw::NannouDrawPlugin);
         #[cfg(feature = "isf")]
         {
             app.add_plugins(bevy_nannou_isf::NannouIsfPlugin);

--- a/bevy_nannou_draw/src/draw/mod.rs
+++ b/bevy_nannou_draw/src/draw/mod.rs
@@ -48,7 +48,7 @@ pub mod theme;
 ///
 /// See the [draw](https://github.com/nannou-org/nannou/blob/master/examples) examples for a
 /// variety of demonstrations of how the [Draw] type can be used!
-#[derive(Clone)]
+#[derive(Component, Clone)]
 pub struct Draw<SM = DefaultNannouShaderModel>
 where
     SM: ShaderModel + Default,

--- a/bevy_nannou_draw/src/lib.rs
+++ b/bevy_nannou_draw/src/lib.rs
@@ -1,6 +1,6 @@
+use crate::render::{NannouRenderPlugin, NannouShaderModel};
 use bevy::prelude::*;
-
-use crate::render::NannouRenderPlugin;
+use draw::Draw;
 
 pub mod color;
 pub mod draw;
@@ -16,19 +16,16 @@ impl Plugin for NannouDrawPlugin {
     }
 }
 
-fn reset_draw(mut draw_q: Query<&mut DrawHolder>) {
+fn reset_draw(mut draw_q: Query<&mut Draw>) {
     for mut draw in draw_q.iter_mut() {
         draw.reset();
     }
 }
 
-fn spawn_draw(mut commands: Commands, query: Query<Entity, (Without<DrawHolder>, With<Window>)>) {
+fn spawn_draw(mut commands: Commands, query: Query<Entity, (Without<Draw>, With<Window>)>) {
     for entity in query.iter() {
         commands
             .entity(entity)
-            .insert(DrawHolder(draw::Draw::new(entity)));
+            .insert(Draw::<NannouShaderModel>::new(entity));
     }
 }
-
-#[derive(Component, Clone, Deref, DerefMut)]
-pub struct DrawHolder(pub draw::Draw);

--- a/bevy_nannou_draw/src/render.rs
+++ b/bevy_nannou_draw/src/render.rs
@@ -729,10 +729,10 @@ fn clear_previous_frame(
     meshes_q: Query<Entity, With<NannouTransient>>,
 ) {
     for entity in meshes_q.iter() {
-        commands.entity(entity).despawn_recursive();
+        commands.entity(entity).despawn();
     }
     for entity in bg_color_q.iter() {
-        commands.entity(entity).despawn_recursive();
+        commands.entity(entity).despawn();
     }
 }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,6 +15,8 @@ edition = "2018"
 
 [dev-dependencies]
 audrey = "0.3"
+bevy = { workspace = true }
+bevy_nannou = { path = "../bevy_nannou" }
 hrtf = "0.2"
 nannou = { version ="0.19.0", path = "../nannou" }
 nannou_audio = { version ="0.19.0", path = "../nannou_audio" }
@@ -48,6 +50,17 @@ path = "audio/record_wav.rs"
 [[example]]
 name = "feedback"
 path = "audio/feedback.rs"
+
+# Bevy
+[[example]]
+name = "simple"
+path = "bevy/simple.rs"
+[[example]]
+name = "simple_shader"
+path = "bevy/simple_shader.rs"
+[[example]]
+name = "windows"
+path = "bevy/windows.rs"
 
 # Communication
 [[example]]

--- a/examples/assets/shaders/simple_shader.wgsl
+++ b/examples/assets/shaders/simple_shader.wgsl
@@ -1,0 +1,6 @@
+@group(2) @binding(0) var<uniform> color: vec4<f32>;
+
+@fragment
+fn fragment() -> @location(0) vec4<f32> {
+    return color;
+}

--- a/examples/bevy/simple.rs
+++ b/examples/bevy/simple.rs
@@ -1,0 +1,24 @@
+use bevy::prelude::*;
+use bevy_nannou::prelude::*;
+use bevy_nannou::NannouPlugin;
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins((DefaultPlugins, NannouPlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, update)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    // We only have to spawn a camera to have access to `Draw`, which will be inserted
+    // automatically by `NannouPlugin` on the main window.
+    commands.spawn(render::NannouCamera);
+}
+
+// This is our update loop, which will be called every frame. We can access `Draw` here using
+// the `Single` query because we only have a single camera/window.
+fn update(draw: Single<&Draw>) {
+    draw.background().color(DIM_GRAY);
+    draw.ellipse().color(BLUE).w_h(100.0, 100.0);
+}

--- a/examples/bevy/simple_shader.rs
+++ b/examples/bevy/simple_shader.rs
@@ -1,0 +1,40 @@
+use bevy::prelude::*;
+use bevy_nannou::prelude::*;
+use bevy_nannou::NannouPlugin;
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins((
+        DefaultPlugins,
+        NannouPlugin,
+        NannouShaderModelPlugin::<ShaderModel>::default(),
+    ))
+    .add_systems(Startup, setup)
+    .add_systems(Update, update)
+    .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(render::NannouCamera);
+}
+
+fn update(draw: Single<&Draw>, time: Res<Time>) {
+    draw.background().color(DIM_GRAY);
+    // Animate color by time
+    let color = LinearRgba::new(
+        time.elapsed_secs().sin() * 0.5 + 0.5,
+        time.elapsed_secs().cos() * 0.5 + 0.5,
+        0.0,
+        1.0,
+    );
+    // This moves our draw instances to use our shader model for anything we draw
+    let draw = draw.shader_model(ShaderModel { color });
+    // This ellipse will use our shader
+    draw.ellipse().w_h(100.0, 100.0);
+}
+
+#[shader_model(fragment = "shaders/simple_shader.wgsl")]
+struct ShaderModel {
+    #[uniform(0)]
+    color: LinearRgba,
+}

--- a/examples/bevy/windows.rs
+++ b/examples/bevy/windows.rs
@@ -1,0 +1,64 @@
+use bevy::prelude::*;
+use bevy::render::view::RenderLayers;
+use bevy::window::WindowResolution;
+use bevy_nannou::prelude::*;
+use bevy_nannou::NannouPlugin;
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins((DefaultPlugins, NannouPlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, update)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    // Spawn a camera for our main window
+    commands.spawn(render::NannouCamera);
+}
+
+#[derive(Component)]
+pub struct WindowColor(Color);
+
+fn update(
+    mut commands: Commands,
+    keys: Res<ButtonInput<KeyCode>>,
+    draws: Query<(&Draw, Option<&WindowColor>)>,
+    mut count: Local<usize>,
+) {
+    if keys.just_pressed(KeyCode::Space) {
+        // Increment the count to track the number of windows
+        *count += 1;
+        // We need a render layer to make sure we only render the camera for this window
+        let layer = RenderLayers::layer(*count);
+        // Spawn a new window with a unique title, resolution, and background color
+        let entity = commands
+            .spawn((
+                Window {
+                    title: "Nannou".to_string(),
+                    resolution: WindowResolution::new(400.0, 400.0),
+                    ..Default::default()
+                },
+                layer.clone(),
+                WindowColor(match *count {
+                    1 => RED.into(),
+                    2 => GREEN.into(),
+                    3 => BLUE.into(),
+                    _ => PURPLE.into(),
+                }),
+            ))
+            .id();
+        // Spawn a camera for our new window with the matching render layer
+        commands.spawn((render::NannouCamera::for_window(entity), layer.clone()));
+    }
+
+    for (draw, window_color) in draws.iter() {
+        if let Some(window_color) = window_color {
+            draw.background().color(window_color.0);
+        } else {
+            draw.background().color(DIM_GRAY);
+        }
+
+        draw.ellipse().color(LIGHT_GRAY).w_h(100.0, 100.0);
+    }
+}

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -16,7 +16,6 @@ bevy-inspector-egui = { workspace = true, optional = true }
 bevy_egui = { workspace = true, optional = true }
 bevy_common_assets = { workspace = true, optional = true }
 bevy_nannou = { version = "0.1.0", path = "../bevy_nannou" }
-bevy_nannou_derive = { version = "0.1.0", path = "../bevy_nannou_derive" }
 find_folder = "0.3"
 lyon = "1.0"
 nannou_core = { version ="0.19.0", path = "../nannou_core", features = ["std"] }

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -949,20 +949,20 @@ impl<'w> App<'w> {
         config.fullscreen_on_shortcut = b;
     }
 
-    /// Produce the [App]'s [DrawHolder] API for drawing geometry and text with colors and textures.
+    /// Produce the [App]'s [draw::Draw] API for drawing geometry and text with colors and textures.
     pub fn draw(&self) -> draw::Draw {
         let window_id = match self.current_view {
             Some(window_id) => window_id,
             None => self.window_id(),
         };
         let world = self.component_world();
-        let draw = world.entity(window_id).get::<DrawHolder>();
+        let draw = world.entity(window_id).get::<draw::Draw>();
         draw.unwrap().0.clone()
     }
 
     pub fn draw_for_window(&self, window: Entity) -> draw::Draw {
         let world = self.component_world();
-        let draw = world.entity(window).get::<DrawHolder>();
+        let draw = world.entity(window).get::<draw::Draw>();
         draw.unwrap().0.clone()
     }
 

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -48,7 +48,7 @@ use crate::render::{
 use crate::window::WindowUserFunctions;
 use crate::{camera, geom, light, window};
 use bevy_nannou::prelude::render::NannouCamera;
-use bevy_nannou::prelude::{draw, DrawHolder};
+use bevy_nannou::prelude::draw;
 use bevy_nannou::NannouPlugin;
 use find_folder;
 use std::any::Any;

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -47,8 +47,8 @@ use crate::render::{
 };
 use crate::window::WindowUserFunctions;
 use crate::{camera, geom, light, window};
-use bevy_nannou::prelude::render::NannouCamera;
 use bevy_nannou::prelude::draw;
+use bevy_nannou::prelude::render::NannouCamera;
 use bevy_nannou::NannouPlugin;
 use find_folder;
 use std::any::Any;

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -446,7 +446,6 @@ where
             .insert_resource(ViewFnRes(self.default_view))
             .insert_resource(ExitFnRes(self.exit))
             .add_systems(Startup, startup::<M>)
-            .add_systems(First, first::<M>)
             .add_systems(
                 Update,
                 (
@@ -1077,21 +1076,6 @@ where
     // Initialise the model.
     let model = model_fn(&mut app);
     world.insert_resource(ModelHolder(model));
-}
-
-fn first<M>(
-    mut commands: Commands,
-    bg_color_q: Query<Entity, With<BackgroundColor>>,
-    meshes_q: Query<Entity, With<NannouTransient>>,
-) where
-    M: 'static + Send + Sync,
-{
-    for entity in meshes_q.iter() {
-        commands.entity(entity).despawn_recursive();
-    }
-    for entity in bg_color_q.iter() {
-        commands.entity(entity).despawn_recursive();
-    }
 }
 
 #[allow(clippy::type_complexity)]

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -957,13 +957,13 @@ impl<'w> App<'w> {
         };
         let world = self.component_world();
         let draw = world.entity(window_id).get::<draw::Draw>();
-        draw.unwrap().0.clone()
+        draw.unwrap().clone()
     }
 
     pub fn draw_for_window(&self, window: Entity) -> draw::Draw {
         let world = self.component_world();
         let draw = world.entity(window).get::<draw::Draw>();
-        draw.unwrap().0.clone()
+        draw.unwrap().clone()
     }
 
     /// The number of times the focused window's **view** function has been called since the start

--- a/nannou/src/prelude.rs
+++ b/nannou/src/prelude.rs
@@ -17,7 +17,6 @@ pub use crate::render::*;
 pub use crate::wgpu;
 pub use crate::wgpu::util::{BufferInitDescriptor, DeviceExt};
 pub use bevy_nannou::prelude::*;
-pub use bevy_nannou_derive::shader_model;
 pub use nannou_core::prelude::*;
 
 pub use crate::app::{self, App, RunMode, UpdateModeExt};


### PR DESCRIPTION
A few small changes to make it more ergonomic to use `BevyNannouPlugin` with a plain bevy app:
1. Remove `DrawHolder`. This was probably just an attempt to avoid adding the `Component` trait to `Draw` itself, but isn't necessary.
2. Make `Draw` work with the `PrimaryWindow` that bevy spawns by default.
3. Move clearing `NannouTransient` out of `App` and into `NannouRenderPlugin`. This ensures we despawn any meshes or other transient entities we spawned last frame.
4. Use bevy `0.15` "required components" feature to spawn required camera components when `NannouCamera` is spawned.
5. Misc. cleanup of unused `NannouTexture` code.

See the examples for a few simple uses!