### PR TITLE
fix: Add required libxkbcommon input for nannou nix pkg

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,7 @@
 , ffmpeg
 , jq
 , lib
+, libxkbcommon
 , llvmPackages
 , makeWrapper
 , pkg-config
@@ -49,6 +50,7 @@ rustPlatform.buildRustPackage rec {
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib
     udev
+    libxkbcommon
     llvmPackages.bintools
     llvmPackages.libclang
     vulkan-loader


### PR DESCRIPTION
I *think* this is required for copy-paste behaviour in egui, though I don't quite remember.