### PR TITLE
feat: (WIP) Add support to nannou_laser for lasercube devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,6 +3754,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lasercube"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "lasercube-core",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "lasercube-core"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.9.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "lasy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4206,6 +4226,7 @@ version = "0.19.0"
 dependencies = [
  "ether-dream",
  "ilda-idtf",
+ "lasercube",
  "lasy",
  "thiserror 2.0.12",
 ]
@@ -6691,6 +6712,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ hrtf = "0.8"
 ilda-idtf = "0.1"
 image = { version = "0.25", default-features = false }
 isf = "0.1.0"
+lasercube = { path = "../lasercube/crates/lasercube" }
 lasy = "0.4"
 lyon = "1.0"
 noise = "0.7"

--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 [dependencies]
 ether-dream.workspace = true
 ilda-idtf = { workspace = true, optional = true }
+lasercube.workspace = true
 lasy.workspace = true
 thiserror.workspace = true
 

--- a/nannou_laser/src/lib.rs
+++ b/nannou_laser/src/lib.rs
@@ -19,6 +19,7 @@ pub mod ffi;
 #[cfg(feature = "ilda-idtf")]
 pub mod ilda_idtf;
 pub mod point;
+pub mod protocol;
 pub mod stream;
 pub mod util;
 

--- a/nannou_laser/src/protocol.rs
+++ b/nannou_laser/src/protocol.rs
@@ -1,0 +1,4 @@
+//! Implementations for each supported protocol (etherdream, lasercube).
+
+pub mod etherdream;
+pub mod lasercube;

--- a/nannou_laser/src/protocol/etherdream.rs
+++ b/nannou_laser/src/protocol/etherdream.rs
@@ -1,0 +1,29 @@
+// Represent etherdream device IDs by their MAC address.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Id {
+    pub mac_address: [u8; 6],
+}
+
+/// An ether dream laser DAC discovered via the ether dream protocol broadcast
+/// message.
+#[derive(Clone, Debug)]
+pub struct DetectedDac {
+    pub broadcast: ether_dream::protocol::DacBroadcast,
+    pub source_addr: std::net::SocketAddr,
+}
+
+impl DetectedDac {
+    pub fn max_point_hz(&self) -> u32 {
+        self.broadcast.max_point_rate as u32
+    }
+
+    pub fn buffer_capacity(&self) -> u32 {
+        self.broadcast.buffer_capacity as u32
+    }
+
+    pub fn id(&self) -> Id {
+        Id {
+            mac_address: self.broadcast.mac_address,
+        }
+    }
+}

--- a/nannou_laser/src/protocol/lasercube.rs
+++ b/nannou_laser/src/protocol/lasercube.rs
@@ -1,0 +1,28 @@
+// Represent lasercube device IDs by their serial number.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Id {
+    pub serial_number: [u8; 6],
+}
+
+/// A lasercube discovered via a `GET_FULL_INFO` response.
+#[derive(Clone, Debug)]
+pub struct DetectedDac {
+    info: lasercube::core::LaserInfo,
+    source_addr: std::net::SocketAddr,
+}
+
+impl DetectedDac {
+    pub fn max_point_hz(&self) -> u32 {
+        self.info.header.max_dac_rate
+    }
+
+    pub fn buffer_capacity(&self) -> u32 {
+        self.info.header.rx_buffer_size as u32
+    }
+
+    pub fn id(&self) -> Id {
+        Id {
+            serial_number: self.info.header.serial_number,
+        }
+    }
+}

--- a/nannou_laser/src/stream/raw.rs
+++ b/nannou_laser/src/stream/raw.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use thiserror::Error;
 
 use crate::util::{clamp, map_range};
-use crate::Inner as ApiInner;
+use crate::{protocol, Inner as ApiInner};
 use crate::{DetectedDac, RawPoint};
 
 /// The function that will be called when a `Buffer` of points is requested.
@@ -649,11 +649,14 @@ where
     F: RenderFn<M>,
 {
     // Currently only ether dream is supported, so retrieve the broadcast and addr.
+    // TODO: Refactor this into the protocol/etherdream.rs submodule, add
+    // similar implementation for `lasercube` inspired by `circle.rs` example.
     let (broadcast, src_addr) = match dac {
-        DetectedDac::EtherDream {
+        DetectedDac::EtherDream(protocol::etherdream::DetectedDac {
             broadcast,
             source_addr,
-        } => (broadcast, source_addr),
+        }) => (broadcast, source_addr),
+        _ => todo!("Implement lasercube handling"),
     };
 
     // A buffer for collecting model updates.


### PR DESCRIPTION
Adds `lasercube` support via the new crate: https://github.com/nannou-org/lasercube.

## To-Do

- [x] Add LaserCube dependencies to `nannou_laser/Cargo.toml`
- [x] Update `DetectedDac` enum to add a `LaserCube` variant
- [x] Update `Id` enum to add a `LaserCube` variant 
- [x] Create `src/protocol/lasercube.rs` module
- [x] Update `max_point_hz()`, `buffer_capacity()`, and `id()` methods on `DetectedDac`
- [ ] Update `StreamError` enum to handle LaserCube errors
- [ ] Create point conversion functions (LaserCube ↔ nannou_laser)
- [ ] Implement device detection for LaserCube DACs (using `lasercube::discover`).
- [ ] Move ether-dream specific stream logic (e.g. `run_laser_stream_tcp_loop`) into `protocol/etherdream.rs`.
- [ ] Add raw stream implementation for lasercube (inspired by circle.rs example).
- [ ] Update stream building logic to handle LaserCube DACs
- [ ] Update `ffi` module.
- [ ] Test both etherdream and lasercube implementations.