### PR TITLE
Use non-none format for webcam format request.

### DIFF
--- a/nannou_webcam/src/native.rs
+++ b/nannou_webcam/src/native.rs
@@ -84,7 +84,8 @@ fn nokhwa_initialize_blocking() {
 }
 
 fn query_device_formats(index: &CameraIndex) -> Vec<WebcamSupportedFormat> {
-    let requested = RequestedFormat::new::<RgbFormat>(RequestedFormatType::None);
+    let requested =
+        RequestedFormat::new::<RgbFormat>(RequestedFormatType::AbsoluteHighestFrameRate);
     let mut camera = match Camera::new(index.clone(), requested) {
         Ok(c) => c,
         Err(err) => {


### PR DESCRIPTION
On Wayland, we get `Could not get device property CameraFormat: Failed to Fufill` when using format `None`. 