### PR TITLE
docs: update guide, READMEs, manifests & module docs for the bevy refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ The project was started out of a desire for a creative coding framework inspired
 by Processing, OpenFrameworks and Cinder, but for Rust. <sup>Named after
 [this](https://www.youtube.com/watch?v=A-Pkx37kYf4).</sup>
 
+nannou is built on the [**Bevy**](https://bevyengine.org) game engine. Its
+crates are exposed as a set of Bevy plugins, so nannou's familiar sketch/app
+API and `Draw` interface can be used on their own or dropped into any Bevy
+application.
+
 |     |     |     |
 | --- |:---:| ---:|
 | [![1](https://i.imgur.com/kPn91tW.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_polygon.rs) | [![2](https://i.imgur.com/gaiWHZX.gif)](https://github.com/nannou-org/nannou/blob/master/examples/ui/egui/simple_ui.rs) | [![3](https://i.imgur.com/lm4RI4N.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_polyline.rs) |
@@ -34,7 +39,7 @@ It is still early days and there is a lot of work to be done. Feel free to help 
   - [**Editor Setup**](https://www.guide.nannou.cc/getting_started/editor_setup.html)
   - [**Running Examples**](https://www.guide.nannou.cc/getting_started/running_examples.html)
   - [**Create A Project**](https://www.guide.nannou.cc/getting_started/create_a_project.html)
-  - [**Upgrading to a New Release**](https://guide.nannou.cc/getting_started/upgrading.html)
+  - [**Updating Nannou and Rust**](https://guide.nannou.cc/getting_started/updating.html)
 - [**Tutorials**](https://www.guide.nannou.cc/tutorials.html)
 - [**Community Tutorials**](https://www.guide.nannou.cc/community_tutorials.html)
 - [**Developer Reference**](https://www.guide.nannou.cc/developer_reference.html)
@@ -73,11 +78,13 @@ The following nannou **libraries** are included within this repository.
 | [**`nannou`**](./nannou) | [![Crates.io](https://img.shields.io/crates/v/nannou.svg)](https://crates.io/crates/nannou) [![docs.rs](https://docs.rs/nannou/badge.svg)](https://docs.rs/nannou/) | App, sketching, graphics, windowing and UI. |
 | [**`nannou_audio`**](./nannou_audio) | [![Crates.io](https://img.shields.io/crates/v/nannou_audio.svg)](https://crates.io/crates/nannou_audio) [![docs.rs](https://docs.rs/nannou_audio/badge.svg)](https://docs.rs/nannou_audio/) | Audio hosts, devices and streams. |
 | [**`nannou_core`**](./nannou_core) | [![Crates.io](https://img.shields.io/crates/v/nannou_core.svg)](https://crates.io/crates/nannou_core) [![docs.rs](https://docs.rs/nannou_core/badge.svg)](https://docs.rs/nannou_core/) | Just-the-core for headless, embedded and libraries. |
-| [**`nannou_egui`**](./nannou_egui) | [![Crates.io](https://img.shields.io/crates/v/nannou_egui.svg)](https://crates.io/crates/nannou_egui) [![docs.rs](https://docs.rs/nannou_egui/badge.svg)](https://docs.rs/nannou_egui/) | For creating egui UIs in nannou apps. |
+| [**`nannou_draw`**](./nannou_draw) | [![Crates.io](https://img.shields.io/crates/v/nannou_draw.svg)](https://crates.io/crates/nannou_draw) [![docs.rs](https://docs.rs/nannou_draw/badge.svg)](https://docs.rs/nannou_draw/) | The `Draw` API for 2D and 3D graphics. |
 | [**`nannou_isf`**](./nannou_isf) | [![Crates.io](https://img.shields.io/crates/v/nannou_isf.svg)](https://crates.io/crates/nannou_isf) [![docs.rs](https://docs.rs/nannou_isf/badge.svg)](https://docs.rs/nannou_isf/) | An Interactive Shader Format pipeline. |
 | [**`nannou_laser`**](./nannou_laser) | [![Crates.io](https://img.shields.io/crates/v/nannou_laser.svg)](https://crates.io/crates/nannou_laser) [![docs.rs](https://docs.rs/nannou_laser/badge.svg)](https://docs.rs/nannou_laser/) | LASER devices, streams and path optimisation. |
-| [**`nannou_mesh`**](./nannou_mesh) | [![Crates.io](https://img.shields.io/crates/v/nannou_mesh.svg)](https://crates.io/crates/nannou_mesh) [![docs.rs](https://docs.rs/nannou_mesh/badge.svg)](https://docs.rs/nannou_mesh/) | API for composing meshes from channels. |
+| [**`nannou_midi`**](./nannou_midi) | [![Crates.io](https://img.shields.io/crates/v/nannou_midi.svg)](https://crates.io/crates/nannou_midi) [![docs.rs](https://docs.rs/nannou_midi/badge.svg)](https://docs.rs/nannou_midi/) | Simple MIDI input and output. |
 | [**`nannou_osc`**](./nannou_osc) | [![Crates.io](https://img.shields.io/crates/v/nannou_osc.svg)](https://crates.io/crates/nannou_osc) [![docs.rs](https://docs.rs/nannou_osc/badge.svg)](https://docs.rs/nannou_osc/) | Simple OSC sender and receiver. |
+| [**`nannou_video`**](./nannou_video) | [![Crates.io](https://img.shields.io/crates/v/nannou_video.svg)](https://crates.io/crates/nannou_video) [![docs.rs](https://docs.rs/nannou_video/badge.svg)](https://docs.rs/nannou_video/) | Video decoding and playback. |
+| [**`nannou_webcam`**](./nannou_webcam) | [![Crates.io](https://img.shields.io/crates/v/nannou_webcam.svg)](https://crates.io/crates/nannou_webcam) [![docs.rs](https://docs.rs/nannou_webcam/badge.svg)](https://docs.rs/nannou_webcam/) | Cross-platform webcam capture. |
 | [**`nannou_wgpu`**](./nannou_wgpu) | [![Crates.io](https://img.shields.io/crates/v/nannou_wgpu.svg)](https://crates.io/crates/nannou_wgpu) [![docs.rs](https://docs.rs/nannou_wgpu/badge.svg)](https://docs.rs/nannou_wgpu/) | WGPU helpers and extensions. |
 
 ## Links

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
     "JoshuaBatty <joshpbatty@gmail.com>",
 ]
-description = "A suite examples for nannou, the creative coding framework."
+description = "A suite of examples for nannou, the creative coding framework."
 readme = "README.md"
 keywords = ["creative", "sketch", "graphics", "audio", "example"]
 repository.workspace = true

--- a/generative_design/Cargo.toml
+++ b/generative_design/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
 ]
 description = "An implementation of the Generative Gestaltung examples."
-readme = "README.md"
+readme = "../README.md"
 keywords = ["creative", "sketch", "generative", "design", "gestaltung"]
 repository.workspace = true
 homepage.workspace = true

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -20,6 +20,7 @@
     - [Draw - Drawing Images](./tutorials/draw/drawing-images.md)
     - [OSC - Introduction](./tutorials/osc/osc-introduction.md)
     - [OSC - Sending OSC](./tutorials/osc/osc-sender.md)
+    - [OSC - Receiving OSC](./tutorials/osc/osc-receiver.md)
 - [Community Tutorials](./community_tutorials.md)
 - [Contributing](./contributing.md)
     - [About the Codebase](./contributing/about-the-codebase.md)

--- a/guide/src/getting_started/create_a_project.md
+++ b/guide/src/getting_started/create_a_project.md
@@ -28,10 +28,10 @@ create a new project with just a few small steps:
    name = "my_project"
    version = "0.1.0"
    authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
-   edition = "2021"
+   edition = "2024"
 
    [dependencies]
-   nannou = "0.17"
+   nannou = "0.19"
    ```
 
    Note that there is a chance the nannou version above might be out of date.

--- a/guide/src/getting_started/platform-specific_setup.md
+++ b/guide/src/getting_started/platform-specific_setup.md
@@ -74,13 +74,6 @@ Ensure you have the following system packages installed:
   sudo pacman -S alsa-lib
   ```
 
-- **curl lib dev package**
-
-  Nannou depends on the `curl-sys` crate. Some Linux distributions use
-  LibreSSL instead of OpenSSL (such as AlpineLinux, Voidlinux, possibly
-  [others](https://en.wikipedia.org/wiki/LibreSSL#Adoption) if manually
-  installed).
-
 - **xcb**
 
   The XCB library provides inter-operability with Xlib.

--- a/guide/src/getting_started/updating.md
+++ b/guide/src/getting_started/updating.md
@@ -1,10 +1,10 @@
 # Updating nannou
 
 You can update to a new version of nannou by editing your `Cargo.toml` file to
-use the new crate. For version 0.12 add the line
+use the new crate. For version 0.19 add the line
 
 ```toml
-nannou = "0.12"
+nannou = "0.19"
 ```
 
 Then within the nannou directory run the following to update all dependencies:
@@ -16,9 +16,9 @@ cargo update
 ## Updating Rust.
 
 From time to time, a nannou update might require features from a newer version
-of rustc. For example, nannou 0.12 is known to require at least rustc 1.35.0. In
-these cases, you can update your rust toolchain to the latest version by running
-the following:
+of rustc. For example, nannou 0.19 uses the Rust 2024 edition and requires a
+recent stable toolchain. In these cases, you can update your rust toolchain to
+the latest version by running the following:
 
 ```bash
 rustup update

--- a/guide/src/tutorials/basics/anatomy-of-a-nannou-app.md
+++ b/guide/src/tutorials/basics/anatomy-of-a-nannou-app.md
@@ -258,11 +258,11 @@ fn view(_app: &App, _model: &Model, _window: Entity) {
 # fn main() {}
 ```
 
-Finally, the **view** allows us to present the state of the model to a window by
-drawing to its **Frame** and returning the frame at the end. Here we can change
-the background colour, use the **Draw** API to draw a scene, draw a GUI to the
-window or even use the wgpu API to draw to the frame using our own textures and
-render passes. All of this will be covered by future tutorials.
+Finally, the **view** allows us to present the state of the model to a window. It
+is called each time the window needs to be redrawn. Here we can change the
+background colour, use the **Draw** API to draw a scene, draw a GUI to the window
+or even use the wgpu API to draw using our own textures and render passes. All of
+this will be covered by future tutorials.
 
 ## Concluding Remarks
 

--- a/guide/src/tutorials/basics/draw-a-sketch.md
+++ b/guide/src/tutorials/basics/draw-a-sketch.md
@@ -59,11 +59,11 @@ After this import the actual sketching code starts. The `main()` functions is wh
 ```
 
 calls a function to draw on the single window (`view()` in this case). This
-function has the signature `fn(_: &App, _: Frame);`. Don't worry if you
+function has the signature `fn(_: &App);`. Don't worry if you
 don't know what a function signature is. Just copy the `main()` function
 and you will be fine.
 
-Within the view() function, what we draw to the Frame will be presented in our window.
+Within the view() function, whatever we draw will be presented in our window.
 
 ```rust,no_run
 # #![allow(unused_imports)]
@@ -94,7 +94,7 @@ let draw = app.draw();
 ```
 
 lets us assign a canvas-like datatype to the variable `draw`.
-We can now paint on the this canvas by setting the background to blue.
+We can now paint on this canvas by setting the background to blue.
 
 ```rust,no_run
 # #![allow(unused_imports)]
@@ -108,8 +108,8 @@ draw.background().color(BLUE);
 # }
 ```
 
-Now we have a canvas with only a blue background. We take this canvas and
-create a computer graphics frame from it to display in the main window.
+Now we have a canvas with only a blue background, which nannou presents in the
+main window for us.
 
 ```rust,no_run
 # #![allow(unused_imports)]

--- a/guide/src/tutorials/basics/sketch-vs-app.md
+++ b/guide/src/tutorials/basics/sketch-vs-app.md
@@ -145,7 +145,7 @@ flexibility, you can turn it into an app by following these steps:
 
 3. Add a `model` function for creating the `Model`:
 
-   ```rust,no_Run
+   ```rust,no_run
    # #![allow(dead_code)]
    # use nannou::prelude::*;
    # fn main() {}

--- a/guide/src/tutorials/draw/drawing-images.md
+++ b/guide/src/tutorials/draw/drawing-images.md
@@ -60,7 +60,7 @@ If you `cargo run` your app, you'll see an empty window.
 
 ## Setting up a Texture
 
-Now, at the top of your `main.rs` file, add a [WGPU Texture](https://docs.rs/nannou/latest/nannou/wgpu/struct.Texture.html) type field named `texture` to the `Model` struct.
+Now, at the top of your `main.rs` file, add an image [`Handle<Image>`](https://docs.rs/bevy/latest/bevy/asset/struct.Handle.html) field named `texture` to the `Model` struct. A `Handle` is a lightweight reference to an asset (in this case an image/texture) managed by Bevy's asset system.
 
 ```rust,no_run
 # #![allow(unreachable_code, unused_variables, dead_code)]
@@ -81,7 +81,7 @@ struct Model {
 # }
 ```
 
-Next, we'll need to create a GPU texture to initialize the struct with. We can accomplish this by loading a texture from an image file after we create the window in our `model` function. We will let nannou find the assets directory for us using the app's [`assets_path()`](https://docs.rs/nannou/0.14.1/nannou/app/struct.App.html#method.assets_path) method, so we only need to spell out the image path from the root of that directory.
+Next, we'll need to load an image to initialize the struct with. We can accomplish this by asking Bevy's asset server to load an image file after we create the window in our `model` function, via the app's [`asset_server()`](https://docs.rs/nannou/latest/nannou/app/struct.App.html#method.asset_server) method. The asset server looks for files within the project's `assets` directory, so we only need to spell out the image path from the root of that directory. Loading happens in the background, and the returned `Handle` can be drawn as soon as the asset is ready.
 
 ```rust,no_run
 # #![allow(unreachable_code, unused_variables, dead_code)]
@@ -129,7 +129,6 @@ fn view(app: &App, model: &Model) {
   let draw = app.draw();
   draw.background().color(BLACK);
 
-  let draw = app.draw();
   draw
     .rect()
     .texture(&model.texture);
@@ -165,7 +164,6 @@ fn view(app: &App, model: &Model) {
   let win = app.window_rect();
   let r = geom::Rect::from_w_h(100.0, 100.0).top_left_of(win);
 
-  let draw = app.draw();
   draw
     .rect()
     .texture(&model.texture)

--- a/guide/src/tutorials/osc/osc-introduction.md
+++ b/guide/src/tutorials/osc/osc-introduction.md
@@ -21,10 +21,10 @@ To use OSC in nannou, it is necessary to add the `nannou_osc` crate as a depende
 Open up your `Cargo.toml` file at the root of your nannou project and add the following line under the `[dependencies]` tag:
 
 ```toml
-nannou_osc = "0.15.0"
+nannou_osc = "0.19.0"
 ```
 
-The value in the quotes is the version of the OSC package. At the time of writing this, `"0.15.0"` is the latest version.
+The value in the quotes is the version of the OSC package. At the time of writing this, `"0.19.0"` is the latest version.
 
 To get the latest version of the osc library, execute `cargo search nannou_osc` on the command line and read the resulting version from there.
 

--- a/guide/src/tutorials/osc/osc-receiver.md
+++ b/guide/src/tutorials/osc/osc-receiver.md
@@ -1,1 +1,187 @@
 # Receiving OSC
+
+**Tutorial Info**
+
+- Author: mitchmindtree
+- Required Knowledge:
+    - [Anatomy of a nannou App](/tutorials/basics/anatomy-of-a-nannou-app.md)
+    - [OSC introduction](/tutorials/osc/osc-introduction.md)
+    - [Sending OSC](/tutorials/osc/osc-sender.md)
+- Reading Time: 15 minutes
+
+---
+
+In the [previous tutorial](/tutorials/osc/osc-sender.md) we sent the position of
+a circle out over OSC. In this tutorial we will do the opposite: we will *receive*
+OSC packets from another application and display them in a window.
+
+We will again use the `nannou_osc` crate. If you have not already added it to your
+project, see the [OSC introduction](/tutorials/osc/osc-introduction.md).
+
+```rust,no_run
+# #![allow(unused_imports)]
+use nannou_osc as osc;
+# fn main() {}
+```
+
+## Setting up an OSC receiver
+
+Where the sender stored an `osc::Sender` in its `Model`, the receiver stores an
+[`osc::Receiver`](https://docs.rs/nannou_osc/latest/nannou_osc/recv/struct.Receiver.html).
+We will also keep a list of the packets we have received so that we can draw them.
+Each received packet comes paired with the network address it was sent from, so we
+store both.
+
+```rust,no_run
+# #![allow(dead_code, unused_imports)]
+# use nannou_osc as osc;
+struct Model {
+    receiver: osc::Receiver,
+    received_packets: Vec<(std::net::SocketAddr, osc::Packet)>,
+}
+# fn main() {}
+```
+
+Next, we set up our `Model` in the `model` function. An `osc::Receiver` is bound
+to a network *port* - the same port that the sending application is targeting.
+Make sure this matches the port used by your sender (in the
+[sending tutorial](/tutorials/osc/osc-sender.md) we used `1234`, here we use
+`34254` to match nannou's `osc_sender.rs` example - pick whichever you like, as
+long as the sender and receiver agree).
+
+```rust,no_run
+# #![allow(dead_code, unused_imports)]
+# use nannou_osc as osc;
+# use nannou::prelude::*;
+# struct Model {
+#     receiver: osc::Receiver,
+#     received_packets: Vec<(std::net::SocketAddr, osc::Packet)>,
+# }
+// The port on which we will listen for OSC packets.
+const PORT: u16 = 34254;
+
+fn model(_app: &App) -> Model {
+    // Bind an `osc::Receiver` to the port.
+    let receiver = osc::receiver(PORT).unwrap();
+
+    // A vec for collecting packets and their source address.
+    let received_packets = vec![];
+
+    Model {
+        receiver,
+        received_packets,
+    }
+}
+# fn main() {}
+```
+
+Binding can fail (for example if another program is already using the port), so
+`osc::receiver` returns a `Result`. Here we simply `unwrap()` it, which will exit
+the program with an error message if binding was unsuccessful.
+
+## Receiving OSC messages
+
+The receiver collects incoming packets in the background. To retrieve them, we
+poll the receiver each frame from an `update` function. The
+[`try_iter`](https://docs.rs/nannou_osc/latest/nannou_osc/recv/struct.Receiver.html#method.try_iter)
+method returns an iterator over all packets that have arrived since we last
+checked, *without* blocking if there are none. Each item is a tuple of the
+`osc::Packet` and the `SocketAddr` it came from.
+
+```rust,no_run
+# #![allow(dead_code, unused_imports)]
+# use nannou_osc as osc;
+# use nannou::prelude::*;
+# struct Model {
+#     receiver: osc::Receiver,
+#     received_packets: Vec<(std::net::SocketAddr, osc::Packet)>,
+# }
+fn update(_app: &App, model: &mut Model) {
+    // Receive any pending OSC packets.
+    for (packet, addr) in model.receiver.try_iter() {
+        model.received_packets.push((addr, packet));
+    }
+
+    // We'll display 10 packets at a time, so remove any excess.
+    while model.received_packets.len() > 10 {
+        model.received_packets.remove(0);
+    }
+}
+# fn main() {}
+```
+
+> **Note:** If you would rather *wait* for a packet to arrive than continue
+> without one, you can use the blocking
+> [`recv`](https://docs.rs/nannou_osc/latest/nannou_osc/recv/struct.Receiver.html#method.recv)
+> method instead. In a nannou app we usually prefer the non-blocking `try_iter`
+> so that drawing and other events are not held up.
+
+## The finished app
+
+Finally, we draw the packets we have received as text in the window. Putting it
+all together:
+
+```rust,no_run
+use nannou::prelude::*;
+use nannou_osc as osc;
+
+// Match this to the port used by the sender.
+const PORT: u16 = 34254;
+
+fn main() {
+    nannou::app(model).update(update).simple_window(view).run();
+}
+
+struct Model {
+    receiver: osc::Receiver,
+    received_packets: Vec<(std::net::SocketAddr, osc::Packet)>,
+}
+
+fn model(_app: &App) -> Model {
+    let receiver = osc::receiver(PORT).unwrap();
+    let received_packets = vec![];
+    Model {
+        receiver,
+        received_packets,
+    }
+}
+
+fn update(_app: &App, model: &mut Model) {
+    // Receive any pending OSC packets.
+    for (packet, addr) in model.receiver.try_iter() {
+        model.received_packets.push((addr, packet));
+    }
+
+    // We'll display 10 packets at a time, so remove any excess.
+    while model.received_packets.len() > 10 {
+        model.received_packets.remove(0);
+    }
+}
+
+fn view(app: &App, model: &Model, _window: Entity) {
+    let draw = app.draw();
+    draw.background().color(DARK_BLUE);
+
+    // Create a string showing all the packets received so far.
+    let mut packets_text = format!("Listening on port {}\nReceived packets:\n", PORT);
+    for &(addr, ref packet) in model.received_packets.iter().rev() {
+        packets_text.push_str(&format!("{}: {:?}\n", addr, packet));
+    }
+
+    let rect = app.window_rect().pad(10.0);
+
+    draw.text(&packets_text)
+        .font_size(16)
+        .align_text_top()
+        .left_justify()
+        .wh(rect.wh());
+}
+```
+
+Run this app alongside the sender from the previous tutorial (or nannou's
+`osc_sender.rs` example) and you should see the OSC messages appear in the window
+as they arrive.
+
+You can find a complete, runnable version of this example as
+[`osc_receiver.rs`](https://github.com/nannou-org/nannou/blob/master/examples/communication/osc_receiver.rs)
+in the nannou repository.

--- a/guide/src/tutorials/osc/osc-sender.md
+++ b/guide/src/tutorials/osc/osc-sender.md
@@ -6,7 +6,7 @@
 - Required Knowledge:
     - [Anatomy of a nannou App](/tutorials/basics/anatomy-of-a-nannou-app.md)
     - [Drawing 2D Shapes](/tutorials/basics/drawing-2d-shapes.md)
-    - [Moving a circle about on the screen](/tutorials/tutorial/moving-a-circle-about.md)
+    - [Animating a Circle](/tutorials/draw/animating-a-circle.md)
     - [OSC introduction](/tutorials/osc/osc-introduction.md)
 - Reading Time: 20 minutes
 
@@ -14,13 +14,13 @@
 
 In this tutorial we will cover how to send OSC data from a nannou app to another application using the `nannou_osc` crate.
 
-We are going to write a simple program which has a circle moving about on the screen while the circle's position is sent via OSC to another application. We will continue working on the app from [Moving a circle about on the screen](/tutorials/basics/moving-a-circle-about.md).
+We are going to write a simple program which has a circle moving about on the screen while the circle's position is sent via OSC to another application. We will continue working on the app from [Animating a Circle](/tutorials/draw/animating-a-circle.md).
 
 ## Setting up an OSC sender
 
 At the top of your `main.rs`-file, import the `nannou_osc` crate and make it available in your program via the shorthand `osc`.
 
-```rust, norun
+```rust,no_run
 # #![allow(unused_imports)]
 use nannou_osc as osc;
 # fn main(){}

--- a/guide/src/why_nannou.md
+++ b/guide/src/why_nannou.md
@@ -9,16 +9,25 @@ The project was started out of a desire for a creative coding framework inspired
 by Processing, OpenFrameworks and Cinder, but for Rust. <sup>Named after
 [this](https://www.youtube.com/watch?v=A-Pkx37kYf4).</sup>
 
+Today, nannou is built on top of the [Bevy](https://bevyengine.org) game engine.
+nannou's crates are exposed as a set of Bevy plugins, which means you get
+nannou's friendly sketch/app API and `Draw` interface while also being able to
+reach for the wider Bevy ecosystem (its ECS, renderer, asset system and plugins)
+whenever you need it.
+
 ## Goals
 
 Nannou aims to provide easy, cross-platform access to the things that artists
 need:
 
-- [x] **Windowing & Events** via [winit](https://crates.io/crates/winit).
+- [x] **Windowing & Events** via [Bevy](https://bevyengine.org) (which uses
+  [winit](https://crates.io/crates/winit) under the hood).
 - [x] **Audio** via [CPAL](https://crates.io/crates/cpal). *Input and
   output streams. Duplex are not yet supported.*
-- [ ] **Video** input, playback and processing (*would love suggestions and
-  ideas*).
+- [x] **Video** playback via the
+  [`nannou_video`](https://github.com/nannou-org/nannou/tree/master/nannou_video)
+  crate and webcam input via
+  [`nannou_webcam`](https://github.com/nannou-org/nannou/tree/master/nannou_webcam).
 - [x] **GUI** via [egui](https://crates.io/crates/egui). *May switch to a custom
   nannou solution [in the
   future](https://github.com/nannou-org/nannou/issues/383)*.
@@ -31,7 +40,8 @@ need:
   - [x] Vertex & index iterators.
   - [x] [Graph](https://docs.rs/nannou/latest/nannou/geom/graph/index.html) for
     composing geometry.
-- **Graphics** via WGPU (via [wgpu-rs](https://github.com/gfx-rs/wgpu-rs)):
+- **Graphics** via [Bevy](https://bevyengine.org)'s renderer (built on
+  [wgpu](https://github.com/gfx-rs/wgpu)):
   - [x] [Draw](https://docs.rs/nannou/latest/nannou/draw/index.html) API. E.g.
     `draw.ellipse().w_h(20.0, 20.0).color(RED)`.
   - [x] [Mesh](https://docs.rs/nannou/latest/nannou/mesh/index.html) API.
@@ -54,7 +64,9 @@ need:
     lighting and effects.
   - [x] [Serial](https://crates.io/crates/serial) - commonly used for
     interfacing with LEDs and other hardware.
-  - [ ] MIDI - No friendly nannou API is provided yet, but cross-platform MIDI I/O is possible via [midir](https://crates.io/crates/midir).
+  - [x] [MIDI](https://github.com/nannou-org/nannou/tree/master/nannou_midi) -
+    cross-platform MIDI I/O via the `nannou_midi` crate (built on
+    [midir](https://crates.io/crates/midir)).
   - [x] [UDP](https://doc.rust-lang.org/std/net/struct.UdpSocket.html) via
     std.
   - [x] TCP
@@ -65,7 +77,8 @@ need:
   - [x] Windowing.
   - [x] Application events.
   - [x] [Audio](https://docs.rs/nannou/latest/nannou/app/struct.Audio.html).
-  - [ ] Video.
+  - [x] [Video](https://github.com/nannou-org/nannou/tree/master/nannou_video)
+    and [Webcam](https://github.com/nannou-org/nannou/tree/master/nannou_webcam).
   - [x] [Lasers](https://github.com/nannou-org/nannou/tree/master/nannou_laser).
   - [ ] Lights. *For now, we recommend DMX via the [sacn crate](https://docs.rs/sacn/0.4.4/sacn/).*
   - [ ] LEDs. *For now, we recommend DMX via the [sacn crate](https://docs.rs/sacn/0.4.4/sacn/).*

--- a/nannou/README.md
+++ b/nannou/README.md
@@ -8,10 +8,14 @@ The `nannou` library allows you to create windows, draw to them, and interact
 via events such as mouse movement or keyboard presses. Here you can find
 tools for creating graphics, user interfaces and low-level access to the GPU.
 
+nannou is built on the [**Bevy**](https://bevyengine.org) game engine and is
+exposed as a Bevy plugin, so its sketch/app API can be used standalone or
+alongside the rest of the Bevy ecosystem.
+
 |     |     |     |
 | --- |:---:| ---:|
-| [![1](https://i.imgur.com/4TtL8kP.gif)](https://github.com/nannou-org/nannou/blob/master/examples/generative_design/color/p_1_0_01.rs) | [![2](https://i.imgur.com/ly3Uk3g.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_mesh.rs) | [![3](https://i.imgur.com/GP6zlSR.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw.rs) |
-| [![4](https://i.imgur.com/kPn91tW.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_polygon.rs) | [![5](https://i.imgur.com/gaiWHZX.gif)](https://github.com/nannou-org/nannou/blob/master/examples/simple_ui.rs) | [![6](https://i.imgur.com/lm4RI4N.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_polyline.rs) |
+| [![1](https://i.imgur.com/4TtL8kP.gif)](https://github.com/nannou-org/nannou/blob/master/generative_design/color/p_1_0_01.rs) | [![2](https://i.imgur.com/ly3Uk3g.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_mesh.rs) | [![3](https://i.imgur.com/GP6zlSR.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw.rs) |
+| [![4](https://i.imgur.com/kPn91tW.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_polygon.rs) | [![5](https://i.imgur.com/gaiWHZX.gif)](https://github.com/nannou-org/nannou/blob/master/examples/ui/egui/simple_ui.rs) | [![6](https://i.imgur.com/lm4RI4N.gif)](https://github.com/nannou-org/nannou/blob/master/examples/draw/draw_polyline.rs) |
 
 ## License
 

--- a/nannou/src/camera.rs
+++ b/nannou/src/camera.rs
@@ -13,11 +13,19 @@ use bevy::{
     window::WindowRef,
 };
 
+/// A handle to an existing camera [`Entity`], used to update its configuration.
+///
+/// Construct one via [`Camera::new`] (or `app.camera(entity)`) and use the [`SetCamera`] methods
+/// to mutate the camera's transform, projection and rendering options in place.
 pub struct Camera<'a, 'w> {
     entity: Entity,
     app: &'a App<'w>,
 }
 
+/// The set of components that make up a nannou camera.
+///
+/// Used by the camera [`Builder`] to accumulate configuration before spawning, and by [`Camera`]
+/// when reading back and updating an existing camera entity.
 #[derive(Default)]
 pub struct CameraComponents {
     pub transform: Transform,
@@ -30,11 +38,20 @@ pub struct CameraComponents {
     pub render_target: Option<RenderTarget>,
 }
 
+/// A context for building and spawning a new camera.
+///
+/// Created via `app.new_camera()`. Configure it with the [`SetCamera`] methods, then call
+/// [`Builder::build`] to spawn the camera and obtain its [`Entity`].
 pub struct Builder<'a, 'w> {
     app: &'a App<'w>,
     camera: CameraComponents,
 }
 
+/// Shared camera configuration methods, implemented by both the camera `Builder` and `Camera`.
+///
+/// Implementors only need to provide [`map_camera`](SetCamera::map_camera); all other methods are
+/// expressed in terms of it. This allows the same fluent API to be used whether configuring a new
+/// camera before it is spawned or updating an existing one.
 pub trait SetCamera: Sized {
     fn layer(self, layer: RenderLayers) -> Self {
         self.map_camera(|mut camera| {

--- a/nannou/src/frame.rs
+++ b/nannou/src/frame.rs
@@ -1,3 +1,9 @@
+//! Items related to the **Frame** - a window's render target for a single update.
+//!
+//! A [`Frame`] wraps Bevy's [`ViewTarget`] for a particular window, giving access to the
+//! intermediary texture that nannou draws into and the window's final surface texture, along with
+//! the GPU device and render context used to encode draw commands.
+
 use bevy::ecs::entity::EntityHashMap;
 use bevy::prelude::*;
 use bevy::render::render_resource::Extent3d;
@@ -64,13 +70,13 @@ impl<'a, 'r, 'w, 's> Frame<'a, 'r, 'w, 's> {
         }
     }
 
-    /// Access the command encoder in order to encode commands that will be submitted to the swap
-    /// chain queue at the end of the call to **view**.
+    /// Access the command encoder in order to encode commands that will be submitted to the GPU
+    /// queue at the end of the call to **view**.
     pub fn command_encoder(&self) -> std::cell::RefMut<'_, wgpu::CommandEncoder> {
         std::cell::RefMut::map(self.render_context.borrow_mut(), |x| x.command_encoder())
     }
 
-    /// The `Id` of the window whose wgpu surface is associated with this frame.
+    /// The [`Entity`] of the window whose surface is associated with this frame.
     pub fn window_id(&self) -> Entity {
         self.window_id
     }
@@ -99,7 +105,7 @@ impl<'a, 'r, 'w, 's> Frame<'a, 'r, 'w, 's> {
         todo!()
     }
 
-    /// The swap chain texture that will be the target for drawing this frame.
+    /// The window's surface texture that will be the target for presenting this frame.
     pub fn swap_chain_texture(&self) -> &wgpu::TextureView {
         // Bevy 0.19's `ViewTarget` exposes the output texture as an `Option`.
         self.view_target
@@ -107,25 +113,21 @@ impl<'a, 'r, 'w, 's> Frame<'a, 'r, 'w, 's> {
             .expect("frame has no output texture")
     }
 
-    /// The texture format of the frame's swap chain texture.
+    /// The texture format of the window's surface texture.
     pub fn swap_chain_texture_format(&self) -> wgpu::TextureFormat {
         self.view_target
             .out_texture_view_format()
             .expect("frame has no output texture")
     }
 
-    /// The device and queue on which the swap chain was created and which will be used to submit
-    /// the **RawFrame**'s encoded commands.
-    ///
-    /// This refers to the same **DeviceQueuePair** as held by the window associated with this
-    /// frame.
+    /// The GPU device used to submit this frame's encoded commands.
     pub fn device(&self) -> &wgpu::Device {
         self.render_device.wgpu_device()
     }
 
     /// The texture to which all graphics should be drawn this frame.
     ///
-    /// This is **not** the swapchain texture, but rather an intermediary linear sRGBA image. This
+    /// This is **not** the window's surface texture, but rather an intermediary linear sRGBA image. This
     /// intermediary image is used in order to:
     ///
     /// - Ensure consistent MSAA resolve behaviour across platforms.
@@ -139,7 +141,7 @@ impl<'a, 'r, 'w, 's> Frame<'a, 'r, 'w, 's> {
     /// supported by the platform), this will be a multisampled texture. After the **view**
     /// function returns, this texture will be resolved to a non-multisampled linear sRGBA texture.
     /// After the texture has been resolved if necessary, it will then be used as a shader input
-    /// within a graphics pipeline used to draw the swapchain texture.
+    /// within a graphics pipeline used to draw to the window's surface texture.
     pub fn texture(&self) -> &wgpu::Texture {
         self.view_target.main_texture()
     }
@@ -193,7 +195,7 @@ impl<'a, 'r, 'w, 's> Frame<'a, 'r, 'w, 's> {
     ///
     /// Note that this method will not perform any resolving. In the case that `msaa_samples` is
     /// greater than `1`, a render pass will be automatically added after the `view` completes and
-    /// before the texture is drawn to the swapchain.
+    /// before the texture is drawn to the window's surface.
     pub fn color_attachment_descriptor(&self) -> wgpu::RenderPassColorAttachment<'_> {
         self.view_target.get_color_attachment()
     }

--- a/nannou/src/lib.rs
+++ b/nannou/src/lib.rs
@@ -12,6 +12,11 @@
 //! If you're new to nannou, we recommend checking out [the
 //! examples](https://github.com/nannou-org/nannou/tree/master/examples) to get an idea of how
 //! nannou applications are structured and how the API works.
+//!
+//! Nannou is built on the [Bevy](https://bevyengine.org) game engine. The [`nannou::app`](app())
+//! and [`nannou::sketch`](sketch()) builders provide the familiar nannou entry points, while
+//! [`NannouPlugin`] bundles nannou's functionality as a Bevy [`Plugin`] so it can also be added to
+//! an existing Bevy `App`.
 use bevy::prelude::{App as BevyApp, Plugin};
 
 pub use find_folder;

--- a/nannou/src/light.rs
+++ b/nannou/src/light.rs
@@ -11,11 +11,19 @@ use crate::prelude::{Entity, Vec3, default};
 
 use crate::App;
 
+/// A handle to an existing directional light [`Entity`], used to update its configuration.
+///
+/// Construct one via [`Light::new`] (or `app.light(entity)`) and use the [`SetLight`] methods to
+/// mutate the light's transform and properties in place.
 pub struct Light<'a, 'w> {
     entity: Entity,
     app: &'a App<'w>,
 }
 
+/// The set of components that make up a nannou directional light.
+///
+/// Used by the light [`Builder`] to accumulate configuration before spawning, and by [`Light`]
+/// when reading back and updating an existing light entity.
 #[derive(Default)]
 pub struct LightComponents {
     pub transform: Transform,
@@ -23,11 +31,20 @@ pub struct LightComponents {
     pub render_layers: RenderLayers,
 }
 
+/// A context for building and spawning a new directional light.
+///
+/// Created via `app.new_light()`. Configure it with the [`SetLight`] methods, then call
+/// [`Builder::build`] to spawn the light and obtain its [`Entity`].
 pub struct Builder<'a, 'w> {
     app: &'a App<'w>,
     light: LightComponents,
 }
 
+/// Shared light configuration methods, implemented by both the light `Builder` and `Light`.
+///
+/// Implementors only need to provide [`map_light`](SetLight::map_light); all other methods are
+/// expressed in terms of it, so the same fluent API configures a new light before it is spawned
+/// or updates an existing one.
 pub trait SetLight: Sized {
     fn x_y(self, x: f32, y: f32) -> Self {
         self.map_light(|mut light| {

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -29,8 +29,9 @@ use nannou_core::geom;
 
 /// A nannou window.
 ///
-/// The **Window** acts as a wrapper around the `winit::window::Window` and the `wgpu::Surface`
-/// types.
+/// The **Window** is a lightweight handle to a Bevy window [`Entity`], providing convenient
+/// access to the underlying [`bevy::window::Window`] component and related window state through
+/// the [`App`]'s ECS world.
 pub struct Window<'a, 'w> {
     entity: Entity,
     app: &'a App<'w>,

--- a/nannou_derive/Cargo.toml
+++ b/nannou_derive/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "nannou_derive"
 version.workspace = true
+description = "Procedural macros for nannou - the creative-coding framework."
+readme = "README.md"
 edition.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/nannou_derive/README.md
+++ b/nannou_derive/README.md
@@ -1,0 +1,19 @@
+# nannou_derive
+
+**Procedural macros for** [**nannou**](https://nannou.cc)**, the creative coding
+framework.**
+
+**nannou_derive** provides nannou's procedural macros, such as the
+`#[shader_model]` attribute used to define custom shader models for the `Draw`
+API. Its macros are re-exported via the main
+[**nannou**](https://crates.io/crates/nannou) crate's prelude, so it is not
+usually depended upon directly.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/nannou_draw/Cargo.toml
+++ b/nannou_draw/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "nannou_draw"
 version.workspace = true
+description = "A simple and expressive API for drawing 2D and 3D graphics, built on Bevy for nannou - the creative-coding framework."
+readme = "README.md"
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 bevy = { workspace = true, default-features = false, features = [

--- a/nannou_draw/README.md
+++ b/nannou_draw/README.md
@@ -1,0 +1,20 @@
+# nannou_draw
+
+**The drawing API for** [**nannou**](https://nannou.cc)**, the creative coding
+framework.**
+
+**nannou_draw** provides `Draw` - a simple, expressive API for drawing 2D and 3D
+graphics. It is built on the [**Bevy**](https://bevyengine.org) game engine: the
+`NannouDrawPlugin` renders the meshes, text, textures and shaders produced by the
+`Draw` API through Bevy's renderer. While it is re-exported by the main
+[**nannou**](https://crates.io/crates/nannou) crate, it may also be used directly
+as a Bevy plugin.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/nannou_draw/src/lib.rs
+++ b/nannou_draw/src/lib.rs
@@ -1,3 +1,17 @@
+//! A simple and expressive API for drawing 2D and 3D graphics, built on [Bevy].
+//!
+//! The heart of this crate is [`Draw`] - a state machine that records drawing
+//! commands (shapes, paths, meshes, text and textures) and converts them into meshes for
+//! rendering. Construct one via `Draw::new`, chain calls like `draw.ellipse()` or
+//! `draw.background()` to describe a scene, and let the renderer turn it into Bevy meshes.
+//!
+//! Add the [`NannouDrawPlugin`] to a Bevy `App` to enable the `Draw` API: it attaches a [`Draw`]
+//! component to each window and renders the recorded commands each frame via the
+//! [`render`] module. The [**nannou**](https://docs.rs/nannou) crate re-exports this API and adds
+//! this plugin for you, so most users will not need to depend on `nannou_draw` directly.
+//!
+//! [Bevy]: https://bevyengine.org
+
 use crate::render::{NannouRenderPlugin, NannouShaderModel};
 use bevy::prelude::*;
 use draw::Draw;

--- a/nannou_isf/Cargo.toml
+++ b/nannou_isf/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "nannou_isf"
 version.workspace = true
+description = "Interactive Shader Format (ISF) support, built on Bevy for nannou - the creative-coding framework."
+readme = "README.md"
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 bevy = { workspace = true, features = ["shader_format_glsl"] }

--- a/nannou_isf/README.md
+++ b/nannou_isf/README.md
@@ -1,0 +1,18 @@
+# nannou_isf
+
+**Interactive Shader Format (ISF) support for**
+[**nannou**](https://nannou.cc)**, the creative coding framework.**
+
+**nannou_isf** provides a [**Bevy**](https://bevyengine.org) plugin
+(`NannouIsfPlugin`) for loading and rendering
+[**ISF**](https://isf.video) shaders, allowing the large existing library of ISF
+shaders to be used within nannou and Bevy applications.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/nannou_laser/Cargo.toml
+++ b/nannou_laser/Cargo.toml
@@ -4,6 +4,7 @@ version ="0.19.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 keywords = ["laser", "dac", "stream", "frame", "ether-dream"]
+readme = "README.md"
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true

--- a/nannou_midi/Cargo.toml
+++ b/nannou_midi/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "nannou_midi"
 version.workspace = true
+description = "The MIDI API for nannou - the creative-coding framework."
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 

--- a/nannou_video/Cargo.toml
+++ b/nannou_video/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "nannou_video"
 version.workspace = true
+description = "Video decoding and playback, built on Bevy for nannou - the creative-coding framework."
+readme = "README.md"
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 bevy = { workspace = true, default-features = false, features = [

--- a/nannou_video/README.md
+++ b/nannou_video/README.md
@@ -1,0 +1,18 @@
+# nannou_video
+
+**The video API for** [**nannou**](https://nannou.cc)**, the creative coding
+framework.**
+
+**nannou_video** provides a [**Bevy**](https://bevyengine.org) plugin
+(`NannouVideoPlugin`) for decoding and playing back video. It uses
+[**video-rs**](https://crates.io/crates/video-rs) on native platforms and the web
+media APIs on wasm, streaming decoded frames as Bevy `Image` assets.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/nannou_webcam/Cargo.toml
+++ b/nannou_webcam/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "nannou_webcam"
-description = "webcam plugin for nannou/bevy"
+description = "The webcam API for nannou - the creative-coding framework."
+readme = "README.md"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/nature_of_code/Cargo.toml
+++ b/nature_of_code/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
 ]
 description = "An implementation of Dan Shiffman's The Nature of Code."
-readme = "README.md"
+readme = "../README.md"
 keywords = ["creative", "sketch", "nature", "code", "processing"]
 repository.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Closes #1004.

A documentation pass to get nannou's prose/reference docs accurate ahead of landing the bevy refactor.

- **READMEs & manifests** - add `description` (+ `license`/`readme`) for the crates that were missing them (`nannou_draw`, `nannou_isf`, `nannou_video`, `nannou_midi`, `nannou_derive`); add stub READMEs for the new crates; rework the root README library table (drop the removed `nannou_egui`/`nannou_mesh`, add `nannou_draw`/`nannou_midi`/`nannou_video`/`nannou_webcam`, note that nannou is now built on Bevy); fix stale example paths, a dead guide link, and two phantom `readme =` declarations.
- **Module/item rustdoc** - reword the `Window` doc (Bevy window entity rather than a winit/wgpu surface wrapper) and the `Frame` docs (drop legacy "swap chain" wgpu terminology); add a crate-level doc to `nannou_draw`; document the previously-bare `Camera`/`Light` types and the `SetCamera`/`SetLight` traits; note the `NannouPlugin` / Bevy plugin model in the `nannou` crate doc.
- **Guide** - a correctness pass over the prose to match the bevy API (the code snippets were already migrated and pass `book_tests`): fix wording that still described the old `Frame`-passing view and the winit/wgpu-centric architecture; reframe `why_nannou` around Bevy and mark MIDI/video/webcam as available; bump referenced versions (nannou `0.17`->`0.19`, nannou_osc `0.15`->`0.19`, edition 2024); drop the stale `curl-sys` Linux setup step; fix malformed code fences and broken intra-guide links; and write the previously-empty **Receiving OSC** tutorial (added to `SUMMARY.md`).
