### PR TITLE
chore(run_all_examples): forward output and cap build jobs at -j 8

### DIFF
--- a/scripts/run_all_examples/main.rs
+++ b/scripts/run_all_examples/main.rs
@@ -12,87 +12,98 @@
 //! cargo run -p run_all_examples
 //! ```
 //!
-//! TODO: Collect a map of failed examples so that they can be concisely reported at the end.
+//! All build and example output is forwarded to the terminal so that progress can be observed.
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+/// Cap the number of parallel build jobs - nannou builds are currently quite RAM intensive.
+const JOBS: &str = "8";
+
+/// The packages whose examples are run when none are specified on the command line.
+const ALL_PACKAGES: &[&str] = &["examples", "generative_design", "nature_of_code"];
+
+/// How long each example is allowed to run before it is stopped.
+const RUN_DURATION: Duration = Duration::from_secs(3);
 
 fn main() {
-    const ALL_PACKAGES: &[&str] = &["examples", "generative_design", "nature_of_code"];
-
-    // Retrieve the specified packages if any, otherwise default to ALL_PACKAGES.
-    let mut args = std::env::args();
-    args.next().unwrap();
-    let specified_packages: Vec<String> = args.collect();
+    // Retrieve the specified packages if any, otherwise default to `ALL_PACKAGES`.
+    let specified_packages: Vec<String> = std::env::args().skip(1).collect();
     let packages: Vec<String> = if specified_packages.is_empty() {
-        ALL_PACKAGES.iter().cloned().map(Into::into).collect()
+        ALL_PACKAGES.iter().map(|s| s.to_string()).collect()
     } else {
         specified_packages
     };
 
-    // Read the nannou cargo manifest to a `toml::Value`.
+    // Resolve the workspace directory relative to this script's manifest (nannou/scripts/..).
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let workspace_manifest_dir = std::path::Path::new(manifest_dir)
+    let workspace_dir = Path::new(manifest_dir)
         .parent()
         .unwrap() // nannou/scripts
         .parent()
         .unwrap(); // nannou
 
-    for package in packages {
-        let examples_dir = workspace_manifest_dir.join(&package);
-        let manifest_path = examples_dir.join("Cargo").with_extension("toml");
+    // Examples that exited with a failure before they could be stopped, as "<package>/<example>".
+    let mut failed: Vec<String> = vec![];
+
+    for package in &packages {
+        let manifest_path = workspace_dir.join(package).join("Cargo.toml");
         let bytes = std::fs::read(&manifest_path).unwrap();
         let toml: toml::Value = toml::from_str(std::str::from_utf8(&bytes).unwrap()).unwrap();
 
-        // Frist, build all examples in the package.
-        println!("Building all examples within /nannou/{}...", package);
-        let output = std::process::Command::new("cargo")
-            .arg("build")
-            .arg("-p")
-            .arg(&package)
-            .arg("--examples")
-            .output()
+        // First, build all examples in the package, forwarding output to the terminal.
+        println!("Building all examples within /nannou/{package}...");
+        let status = Command::new("cargo")
+            .args(["build", "-j", JOBS, "-p", package, "--examples"])
+            .status()
             .expect("failed to run `cargo build -p package --examples`");
-        if !output.stderr.is_empty() {
-            let stderr = String::from_utf8(output.stderr).unwrap();
-            if stderr.contains("error[E") {
-                panic!(
-                    "failed to build examples for package \"{}\":\n{}",
-                    package, stderr
-                );
-            }
+        if !status.success() {
+            panic!("failed to build examples for package \"{package}\"");
         }
 
-        // Find the `examples` table within the `toml::Value` to find all example names.
+        // Find the `example` array within the manifest to retrieve all example names.
         let examples = toml["example"]
             .as_array()
             .expect("failed to retrieve example array");
-        println!("Running all examples within /nannou/{}...", package);
+        println!("Running all examples within /nannou/{package}...");
         for example in examples {
             let name = example["name"]
                 .as_str()
                 .expect("failed to retrieve example name");
 
-            // For each example, invoke a cargo sub-process to run the example.
-            let mut child = std::process::Command::new("cargo")
-                .arg("run")
-                .arg("-p")
-                .arg(&package)
-                .arg("--example")
-                .arg(name)
+            // Run the example, forwarding its output to the terminal.
+            println!("Running example \"{name}\"...");
+            let mut child = Command::new("cargo")
+                .args(["run", "-j", JOBS, "-p", package, "--example", name])
                 .spawn()
                 .expect("failed to spawn `cargo run --example` process");
 
-            // Allow each example to run for 3 secs each.
-            std::thread::sleep(std::time::Duration::from_secs(3));
+            // Allow the example to run for a moment.
+            std::thread::sleep(RUN_DURATION);
 
-            // Kill the example and retrieve any output.
-            child.kill().ok();
-            let output = child
-                .wait_with_output()
-                .expect("failed to wait for child process");
-
-            // If the example wrote to `stderr` it must have failed.
-            if !output.stderr.is_empty() {
-                panic!("example {} wrote to stderr: {:?}", name, output);
+            // If the example exited on its own with a failure before we stopped it, it must
+            // have failed.
+            if let Ok(Some(exit)) = child.try_wait() {
+                if !exit.success() {
+                    eprintln!("example \"{name}\" exited with {exit}");
+                    failed.push(format!("{package}/{name}"));
+                }
             }
+
+            // Stop the example and wait for it to exit.
+            child.kill().ok();
+            child.wait().ok();
         }
+    }
+
+    if failed.is_empty() {
+        println!("All examples ran successfully.");
+    } else {
+        eprintln!("{} example(s) failed:", failed.len());
+        for entry in &failed {
+            eprintln!("  - {entry}");
+        }
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
Forward all cargo build and example output to the terminal so progress is visible: the build phase now uses `status()` rather than capturing output, and failure is detected via the exit status. Cap parallel build jobs at `-j 8` on both the build and run invocations, as nannou builds are currently RAM intensive.

Replace the dead "wrote to stderr" check (output is inherited, so it never fired) with a `try_wait()` that detects an example exiting with a failure before it is stopped, collecting failures and reporting them at the end with a non-zero exit. Implements the existing TODO. Also hoist consts to module level and fix a stale manifest-path dance and typos.