### PR TITLE
fix(compute): keep dispatched entry point and bind group in sync

### DIFF
--- a/examples/compute/game_of_life.rs
+++ b/examples/compute/game_of_life.rs
@@ -89,7 +89,7 @@ fn update(_app: &App, model: &mut Model) {
     if model.display == model.texture_a {
         model.display = model.texture_b.clone();
     } else {
-        model.display = model.texture_b.clone();
+        model.display = model.texture_a.clone();
     }
 }
 

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -401,6 +401,7 @@ where
                         commands.entity(view).insert(ComputeState {
                             current: CM::State::default(),
                             next: None,
+                            next_ready: false,
                         });
                     }
                 },
@@ -1217,19 +1218,24 @@ fn compute<M, CM>(
     let (app, (model, compute, mut views_q)) = get_app_and_state(world, state);
     let compute = compute.0;
     for (view, state) in views_q.iter_mut() {
-        let (new_state, compute_model) = compute(&app, &model, state.current.clone(), view);
+        // Advance to the state queued last frame once the render world has signalled that its
+        // pipeline is ready. Doing this here (rather than in the render world) keeps `current`
+        // and the `ComputeModel` bind group built below in sync for the same state.
+        let current = match (state.next_ready, &state.next) {
+            (true, Some(next)) => next.clone(),
+            _ => state.current.clone(),
+        };
+        let (new_state, compute_model) = compute(&app, &model, current.clone(), view);
+        let next = (new_state != current).then_some(new_state);
         unsafe {
             app.component_world
                 .borrow_mut()
                 .world_mut()
                 .entity_mut(view)
                 .insert(ComputeState {
-                    current: state.current.clone(),
-                    next: if new_state != state.current {
-                        Some(new_state)
-                    } else {
-                        None
-                    },
+                    current,
+                    next,
+                    next_ready: false,
                 })
                 .insert(ComputeModel(compute_model));
         }

--- a/nannou/src/render/compute.rs
+++ b/nannou/src/render/compute.rs
@@ -82,9 +82,15 @@ fn sync_pipeline_cache<CM>(
                 match pipelines.get_compute_pipeline_state(*id) {
                     CachedPipelineState::Queued => {}
                     CachedPipelineState::Creating(_) => {}
+                    // Only signal that `next` is ready - the main world performs the actual
+                    // advancement so that `current` and the `ComputeModel` bind group are
+                    // updated together. Advancing `current` here would race with component
+                    // extraction and leave the dispatched entry point bound to the previous
+                    // state's bind group.
                     CachedPipelineState::Ok(_) => {
-                        state.current = next_state.clone();
-                        state.next = None;
+                        if !state.next_ready {
+                            state.next_ready = true;
+                        }
                     }
                     CachedPipelineState::Err(e) => {
                         error!("Failed to create pipeline {:?}", e);
@@ -161,6 +167,11 @@ fn prepare_bind_group<CM>(
 pub(crate) struct ComputeState<S: Default + Clone + Send + Sync + 'static> {
     pub current: S,
     pub next: Option<S>,
+    /// Set by `sync_pipeline_cache` in the render world once the pipeline for `next` has
+    /// compiled. The main-world compute system reads this to advance `current` to `next`
+    /// while it rebuilds the matching bind group, keeping the dispatched entry point and
+    /// bind group in sync.
+    pub next_ready: bool,
 }
 
 #[derive(Resource, Deref, DerefMut)]


### PR DESCRIPTION
Part of https://github.com/nannou-org/nannou/issues/1008

This aims to fix a couple of the compute shader examples! `particle_sdf` is still not working, but I think something else is going on there.

## Problem

The compute state machine advanced `current` to `next` from the render world (in `sync_pipeline_cache`) once the next pipeline had compiled. That advancement raced with component extraction: on the transition frame the render world dispatched the new state's entry point while still bound to the previous state's `ComputeModel` bind group, since the bind group is rebuilt from the main-world `compute` callback that ran before the advancement.

For a compute shader whose bind group is the same in every state (e.g. `particle_mouse`) this was harmless, but `game_of_life` ping-pongs two storage textures per state, so the `update` entry ran against the `init` bind group - reading the empty texture and clearing the displayed one to black.

## Solution

Make the main world the sole owner of state advancement: the render world only signals readiness via `ComputeState::next_ready`, and the main-world `compute` system advances `current` while it rebuilds the matching bind group, so the dispatched entry point and bind group always correspond to the same state.

Also fix `game_of_life`'s `update` to alternate the displayed texture between the two ping-pong buffers instead of always selecting one.