### PR TITLE
fix: resolve MSAA in the raw wgpu Frame render path

### DIFF
--- a/examples/wgpu/wgpu_image/wgpu_image.rs
+++ b/examples/wgpu/wgpu_image/wgpu_image.rs
@@ -98,7 +98,9 @@ fn model(app: &App) -> Model {
 fn render(_app: &RenderApp, model: &Model, frame: Frame) {
     let mut encoder = frame.command_encoder();
     let mut render_pass = wgpu::RenderPassBuilder::new()
-        .color_attachment(frame.resolve_target_view().unwrap(), |color| color)
+        .color_attachment_descriptor(
+            frame.color_attachment(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+        )
         .begin(&mut encoder);
     render_pass.set_bind_group(0, &*model.bind_group, &[]);
     render_pass.set_pipeline(&model.render_pipeline);

--- a/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
+++ b/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
@@ -166,7 +166,9 @@ fn update(app: &App, model: &mut Model) {
 fn render(_app: &RenderApp, model: &Model, frame: Frame) {
     let mut encoder = frame.command_encoder();
     let mut render_pass = wgpu::RenderPassBuilder::new()
-        .color_attachment(frame.resolve_target_view().unwrap(), |color| color)
+        .color_attachment_descriptor(
+            frame.color_attachment(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+        )
         .begin(&mut encoder);
     render_pass.set_bind_group(0, &*model.bind_group, &[]);
     render_pass.set_pipeline(&model.render_pipeline);

--- a/examples/wgpu/wgpu_instancing/wgpu_instancing.rs
+++ b/examples/wgpu/wgpu_instancing/wgpu_instancing.rs
@@ -344,7 +344,9 @@ fn render(app: &RenderApp, model: &Model, frame: Frame) {
     let mut encoder = frame.command_encoder();
     encoder.copy_buffer_to_buffer(&new_uniform_buffer, 0, &g.uniform_buffer, 0, uniforms_size);
     let mut render_pass = wgpu::RenderPassBuilder::new()
-        .color_attachment(frame.resolve_target_view().unwrap(), |color| color)
+        .color_attachment_descriptor(
+            frame.color_attachment(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+        )
         // We'll use a depth texture to assist with the order of rendering fragments based on depth.
         .depth_stencil_attachment(&g.depth_texture_view, |depth| depth)
         .begin(&mut encoder);

--- a/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
+++ b/examples/wgpu/wgpu_teapot/wgpu_teapot.rs
@@ -155,7 +155,9 @@ fn render(app: &RenderApp, model: &Model, frame: Frame) {
     let mut encoder = frame.command_encoder();
     encoder.copy_buffer_to_buffer(&new_uniform_buffer, 0, &g.uniform_buffer, 0, uniforms_size);
     let mut render_pass = wgpu::RenderPassBuilder::new()
-        .color_attachment(frame.resolve_target_view().unwrap(), |color| color)
+        .color_attachment_descriptor(
+            frame.color_attachment(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+        )
         // We'll use a depth texture to assist with the order of rendering fragments based on depth.
         .depth_stencil_attachment(&g.depth_texture_view, |depth| depth)
         .begin(&mut encoder);

--- a/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
+++ b/examples/wgpu/wgpu_triangle/wgpu_triangle.rs
@@ -91,7 +91,9 @@ fn render(_app: &RenderApp, model: &Model, frame: Frame) {
     // begin a render pass that outputs to the frame's texture. Then we add sub-commands for
     // setting the bind group, render pipeline, vertex buffers and then finally drawing.
     let mut render_pass = wgpu::RenderPassBuilder::new()
-        .color_attachment(frame.resolve_target_view().unwrap(), |color| color)
+        .color_attachment_descriptor(
+            frame.color_attachment(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+        )
         .begin(&mut encoder);
     render_pass.set_bind_group(0, &*model.bind_group, &[]);
     render_pass.set_pipeline(&model.render_pipeline);

--- a/nannou/src/frame.rs
+++ b/nannou/src/frame.rs
@@ -146,19 +146,31 @@ impl<'a, 'r, 'w, 's> Frame<'a, 'r, 'w, 's> {
         self.view_target.main_texture()
     }
 
-    /// A full view into the frame's texture.
+    /// A full view into the frame's single-sample texture.
+    ///
+    /// This is the texture that is presented to the window's surface (after tonemapping).
+    /// When MSAA is enabled it is the *resolve target* - the multisampled texture returned by
+    /// [`Frame::resolve_target_view`] is resolved into it. Prefer [`Frame::color_attachment`],
+    /// which wires this up for you, over targeting these views by hand.
     ///
     /// See `texture` for details.
     pub fn texture_view(&self) -> &wgpu::TextureView {
         self.view_target.main_texture_view()
     }
 
-    /// Returns the resolve target texture in the case that MSAA is enabled.
+    /// Returns the multisampled texture in the case that MSAA is enabled.
+    ///
+    /// This is the texture a render pass should draw *into* when MSAA is enabled; it is
+    /// resolved into the single-sample [`Frame::texture`] before presentation.
     pub fn resolve_target(&self) -> Option<&wgpu::Texture> {
         self.view_target.sampled_main_texture().map(|x| x.deref())
     }
 
-    /// Returns the resolve target texture view in the case that MSAA is enabled.
+    /// Returns the multisampled texture view in the case that MSAA is enabled.
+    ///
+    /// This is the view a render pass should draw *into* when MSAA is enabled; it is resolved
+    /// into the single-sample [`Frame::texture_view`] before presentation. Prefer
+    /// [`Frame::color_attachment`], which wires this up for you.
     pub fn resolve_target_view(&self) -> Option<&wgpu::TextureView> {
         self.view_target
             .sampled_main_texture_view()
@@ -189,15 +201,36 @@ impl<'a, 'r, 'w, 's> Frame<'a, 'r, 'w, 's> {
         [width, height]
     }
 
-    /// Short-hand for constructing a `wgpu::RenderPassColorAttachment` for use within a
-    /// render pass that targets this frame's texture. The returned descriptor's `attachment` will
-    /// the same `wgpu::TextureView` returned by the `Frame::texture` method.
+    /// A [`wgpu::RenderPassColorAttachment`] that targets this frame, with the MSAA resolve
+    /// already wired up.
     ///
-    /// Note that this method will not perform any resolving. In the case that `msaa_samples` is
-    /// greater than `1`, a render pass will be automatically added after the `view` completes and
-    /// before the texture is drawn to the window's surface.
-    pub fn color_attachment_descriptor(&self) -> wgpu::RenderPassColorAttachment<'_> {
-        self.view_target.get_color_attachment()
+    /// This is the recommended way to target the frame from a custom render pass. When MSAA is
+    /// enabled the frame's multisampled texture is used as the attachment and is automatically
+    /// resolved into the single-sample texture presented to the window's surface; when MSAA is
+    /// disabled the single-sample texture is targeted directly. Either way the result is read
+    /// by Bevy's tonemapping pass and drawn to the surface.
+    ///
+    /// `load` selects how the target is initialised at the start of the pass - e.g.
+    /// [`wgpu::LoadOp::Clear`] to clear it each frame, or [`wgpu::LoadOp::Load`] to build upon
+    /// the previous frame's contents.
+    pub fn color_attachment(
+        &self,
+        load: wgpu::LoadOp<wgpu::Color>,
+    ) -> wgpu::RenderPassColorAttachment<'_> {
+        let (view, resolve_target): (&wgpu::TextureView, Option<&wgpu::TextureView>) =
+            match self.view_target.sampled_main_texture_view() {
+                Some(sampled) => (sampled, Some(self.view_target.main_texture_view())),
+                None => (self.view_target.main_texture_view(), None),
+            };
+        wgpu::RenderPassColorAttachment {
+            view,
+            resolve_target,
+            ops: wgpu::Operations {
+                load,
+                store: wgpu::StoreOp::Store,
+            },
+            depth_slice: None,
+        }
     }
 
     /// Clear the texture with the given color.

--- a/nannou_wgpu/src/render_pass.rs
+++ b/nannou_wgpu/src/render_pass.rs
@@ -174,6 +174,20 @@ impl<'a> Builder<'a> {
         self
     }
 
+    /// Add a prebuilt color attachment descriptor to the render pass descriptor.
+    ///
+    /// Useful for attachments configured elsewhere, e.g. the one returned by
+    /// `Frame::color_attachment`, which already wires up the MSAA resolve target.
+    ///
+    /// Call this multiple times in succession to add multiple color attachments.
+    pub fn color_attachment_descriptor(
+        mut self,
+        descriptor: wgpu::RenderPassColorAttachment<'a>,
+    ) -> Self {
+        self.color_attachments.push(Some(descriptor));
+        self
+    }
+
     /// Add a depth stencil attachment to the render pass.
     ///
     /// This should only be called once, as only a single depth stencil attachment is valid. Only


### PR DESCRIPTION
Part of #1008

## Problem

The `examples/wgpu/*` examples render black on the Bevy 0.19 backend. They open their own render pass and draw into the frame's **multisampled** texture, but never resolve it into the single-sample texture that Bevy tonemaps to the surface, so nothing reaches the screen.

The `Frame` API made this easy to get wrong: `resolve_target_view()` actually returns the texture you draw *into* (the MSAA texture), while `texture_view()` is the real resolve target - so the resolve was simply never wired up.

## Fix

- Add `Frame::color_attachment(load)`, which returns a `wgpu::RenderPassColorAttachment` with the MSAA resolve already wired (and falls back to the single-sample texture when MSAA is disabled). This is now the recommended way to target the frame from a custom render pass - users can't forget the resolve. Replaces the unused, mis-documented `color_attachment_descriptor()`.
- Add `RenderPassBuilder::color_attachment_descriptor(..)` to accept a prebuilt attachment.
- Update all five wgpu examples to the one-liner
    `.color_attachment_descriptor(frame.color_attachment(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)))`.
- Clarify the `texture_view` / `resolve_target_view` docs (they were semantically inverted vs. wgpu conventions).

## Testing

Ran all five examples and visually confirmed correct output: `wgpu_triangle` (red triangle), `wgpu_teapot` (3D + depth), `wgpu_instancing` (geodesic spheres), `wgpu_image` (logo), `wgpu_image_sequence` (dancer). No other code paths use the raw-frame render path (everything else renders via `nannou_draw`).