### PR TITLE
fix(draw): account for MeshAllocator slab offsets in indirect draws

### DIFF
--- a/nannou_draw/src/draw/indirect.rs
+++ b/nannou_draw/src/draw/indirect.rs
@@ -206,7 +206,16 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshIndirect {
             return RenderCommandResult::Skip;
         };
 
-        pass.set_vertex_buffer(0, vertex_buffer_slice.buffer.slice(..));
+        // The mesh shares a `MeshAllocator` slab with other meshes, so its vertex and
+        // index data generally sit at a non-zero offset within the slab buffers. The
+        // indirect args buffer (written on the GPU / CPU without knowledge of those
+        // offsets) uses `first_index`/`base_vertex`/`first_vertex` of `0`, so we slice
+        // the bound buffers to start at the mesh's data. That makes the zero-based args
+        // address this mesh's geometry rather than whatever happens to sit at slab
+        // offset 0. (`MeshBufferSlice::range` is measured in elements, not bytes.)
+        let vertex_stride = gpu_mesh.layout.0.layout().array_stride;
+        let vertex_offset = vertex_buffer_slice.range.start as u64 * vertex_stride;
+        pass.set_vertex_buffer(0, vertex_buffer_slice.buffer.slice(vertex_offset..));
 
         match &gpu_mesh.buffer_info {
             RenderMeshBufferInfo::Indexed { index_format, .. } => {
@@ -216,7 +225,12 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshIndirect {
                     return RenderCommandResult::Skip;
                 };
 
-                pass.set_index_buffer(index_buffer_slice.buffer.slice(..), *index_format);
+                let index_offset =
+                    index_buffer_slice.range.start as u64 * index_format.byte_size() as u64;
+                pass.set_index_buffer(
+                    index_buffer_slice.buffer.slice(index_offset..),
+                    *index_format,
+                );
                 pass.draw_indexed_indirect(&indirect_buffer.buffer, 0);
             }
             RenderMeshBufferInfo::NonIndexed => {


### PR DESCRIPTION
Part of #1008 

## Problem

`DrawMeshIndirect` bound the full shared MeshAllocator vertex and index slabs and issued `draw_indexed_indirect`/`draw_indirect` with args whose `first_index`/`base_vertex`/`first_vertex` are `0`. When a mesh is not the first allocation in its slab (the common case once other meshes exist), the zero-based args addressed whatever sits at slab offset 0 rather than the mesh's own data, so nothing rendered.

This caused `compute/particle_sdf` example to render blank.

## Solution

Slice the bound vertex and index buffers to the mesh's slab ranges so the zero-based indirect args address this mesh's geometry. `MeshBufferSlice::range` is measured in elements, so convert to bytes via the vertex stride and the index format size. Meshes at slab offset 0 slice from 0, so behaviour is unchanged for them.

Fixes the `compute/particle_sdf` example, which rendered blank.