### PR TITLE
Update noise dependency to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,12 +79,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,7 +240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
  "clipboard-win",
- "image 0.25.8",
+ "image",
  "log",
  "objc2 0.6.3",
  "objc2-app-kit 0.3.2",
@@ -471,7 +465,7 @@ dependencies = [
  "arrayvec 0.7.6",
  "log",
  "nom 8.0.0",
- "num-rational 0.4.2",
+ "num-rational",
  "v_frame",
 ]
 
@@ -881,7 +875,7 @@ dependencies = [
  "egui",
  "encase",
  "getrandom 0.4.2",
- "image 0.25.8",
+ "image",
  "itertools 0.14.0",
  "js-sys",
  "smithay-clipboard",
@@ -1017,7 +1011,7 @@ dependencies = [
  "futures-lite",
  "guillotiere",
  "half",
- "image 0.25.8",
+ "image",
  "ktx2",
  "rectangle-pack",
  "ruzstd",
@@ -1449,7 +1443,7 @@ dependencies = [
  "downcast-rs 2.0.2",
  "encase",
  "glam",
- "image 0.25.8",
+ "image",
  "indexmap 2.12.0",
  "itertools 0.14.0",
  "js-sys",
@@ -2713,16 +2707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
-name = "deflate"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
-dependencies = [
- "adler32",
- "byteorder",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,7 +3081,7 @@ dependencies = [
  "bit_field",
  "half",
  "lebe",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "rayon-core",
  "smallvec 1.15.1",
  "zune-inflate",
@@ -3212,7 +3196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3498,17 +3482,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.4",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
@@ -3516,7 +3489,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -3547,16 +3520,6 @@ dependencies = [
  "wasip2",
  "wasip3",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gif"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06"
-dependencies = [
- "color_quant",
- "weezl",
 ]
 
 [[package]]
@@ -4142,25 +4105,6 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "gif 0.11.4",
- "jpeg-decoder",
- "num-iter",
- "num-rational 0.3.2",
- "num-traits",
- "png 0.16.8",
- "scoped_threadpool",
- "tiff 0.6.1",
-]
-
-[[package]]
-name = "image"
 version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
@@ -4169,16 +4113,16 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "exr",
- "gif 0.13.3",
+ "gif",
  "image-webp",
  "moxcms",
  "num-traits",
- "png 0.18.0",
+ "png",
  "qoi",
  "ravif",
  "rayon",
  "rgb",
- "tiff 0.10.3",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -4414,15 +4358,6 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
-]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
-dependencies = [
- "rayon",
 ]
 
 [[package]]
@@ -4838,25 +4773,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
@@ -4873,7 +4789,7 @@ checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -4977,7 +4893,7 @@ dependencies = [
  "bevy_common_assets",
  "bevy_egui",
  "find_folder",
- "image 0.25.8",
+ "image",
  "lyon",
  "nannou_core",
  "nannou_derive",
@@ -5111,7 +5027,7 @@ name = "nannou_wgpu"
 version = "0.19.0"
 dependencies = [
  "futures",
- "image 0.25.8",
+ "image",
  "tokio",
  "wgpu",
 ]
@@ -5284,12 +5200,12 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noise"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82051dd6745d5184c6efb7bc8be14892a7f6d4f3ad6dbf754d1c7d7d5fe24b43"
+checksum = "6da45c8333f2e152fc665d78a380be060eb84fad8ca4c9f7ac8ca29216cff0cc"
 dependencies = [
- "image 0.23.14",
- "rand 0.7.3",
+ "num-traits",
+ "rand 0.8.5",
  "rand_xorshift",
 ]
 
@@ -5300,7 +5216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cae50786bfa1214ed441f98addbea51ca1b9aaa9e4bf5369cda36654b3efaa"
 dependencies = [
  "flume",
- "image 0.25.8",
+ "image",
  "nokhwa-bindings-linux",
  "nokhwa-bindings-macos",
  "nokhwa-bindings-windows",
@@ -5354,7 +5270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "109975552bbd690894f613bce3d408222911e317197c72b2e8b9a1912dc261ae"
 dependencies = [
  "bytes",
- "image 0.25.8",
+ "image",
  "mozjpeg",
  "thiserror 2.0.17",
 ]
@@ -5495,28 +5411,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -6277,18 +6171,6 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
-version = "0.16.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "deflate",
- "miniz_oxide 0.3.7",
-]
-
-[[package]]
-name = "png"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
@@ -6297,7 +6179,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -6536,19 +6418,6 @@ checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -6580,16 +6449,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -6606,15 +6465,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -6652,21 +6502,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "rand_xorshift"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7165,12 +7006,6 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "scoped_threadpool"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 
 [[package]]
 name = "scopeguard"
@@ -7864,17 +7699,6 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
-dependencies = [
- "jpeg-decoder",
- "miniz_oxide 0.4.4",
- "weezl",
-]
-
-[[package]]
-name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
@@ -8532,12 +8356,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ lasy = "0.4"
 lyon = "1.0"
 midir = "0.10"
 nokhwa = { version = "0.10", features = ["input-native", "camera-sync-impl"] }
-noise = "0.7"
+noise = "0.9"
 notosans = "0.1"
 num-traits = {version = "0.2", default-features = false }
 parley = { version = "0.7.0", default-features = false, features = ["std", "system"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,12 +13,6 @@ homepage.workspace = true
 license.workspace = true
 edition.workspace = true
 
-[lints.rust]
-# `noise` 0.7.0 defines `Perlin` in two modules (perlin and perlin_surflet),
-# both glob-exported, so `noise::Perlin` trips `ambiguous_glob_imports` - a hard
-# error on recent rustc. Allow it until the `noise` dependency is updated.
-ambiguous_glob_imports = "allow"
-
 [dev-dependencies]
 audrey.workspace = true
 bevy.workspace = true

--- a/examples/draw/draw_loop.rs
+++ b/examples/draw/draw_loop.rs
@@ -19,8 +19,7 @@ struct Model {
 
 fn model(app: &App) -> Model {
     let _window = app.new_window().size_pixels(1024, 1024).view(view).build();
-    let mut noise = Perlin::new();
-    noise = noise.set_seed(1);
+    let noise = Perlin::new(1);
     Model { noise }
 }
 

--- a/generative_design/Cargo.toml
+++ b/generative_design/Cargo.toml
@@ -13,12 +13,6 @@ homepage.workspace = true
 license.workspace = true
 edition.workspace = true
 
-[lints.rust]
-# `noise` 0.7.0 defines `Perlin` in two modules (perlin and perlin_surflet),
-# both glob-exported, so `noise::Perlin` trips `ambiguous_glob_imports` - a hard
-# error on recent rustc. Allow it until the `noise` dependency is updated.
-ambiguous_glob_imports = "allow"
-
 [dev-dependencies]
 nannou = { version = "0.19.0", path = "../nannou" }
 usvg.workspace = true

--- a/generative_design/random_and_noise/m_1_3_01.rs
+++ b/generative_design/random_and_noise/m_1_3_01.rs
@@ -28,7 +28,6 @@
  * s                   : save png
  */
 use nannou::noise::NoiseFn;
-use nannou::noise::Seedable;
 use nannou::prelude::*;
 
 fn main() {
@@ -59,7 +58,7 @@ fn view(app: &App, model: &Model) {
 
     draw.background().color(WHITE);
 
-    let noise = nannou::noise::Perlin::new().set_seed(model.act_random_seed);
+    let noise = nannou::noise::Perlin::new(model.act_random_seed);
 
     let noise_x_range = map_range(app.mouse().x, win.left(), win.right(), 0.0, win.w()) / 10.0;
 

--- a/generative_design/random_and_noise/m_1_3_03.rs
+++ b/generative_design/random_and_noise/m_1_3_03.rs
@@ -32,7 +32,7 @@
  * s                   : save png
  */
 use nannou::image;
-use nannou::noise::{MultiFractal, NoiseFn, Seedable};
+use nannou::noise::{MultiFractal, NoiseFn};
 use nannou::prelude::bevy_asset::RenderAssetUsages;
 use nannou::prelude::*;
 
@@ -83,8 +83,7 @@ fn model(app: &App) -> Model {
 
 fn view(app: &App, model: &Model) {
     let win = app.window_rect();
-    let noise = nannou::noise::Fbm::new()
-        .set_seed(model.noise_random_seed)
+    let noise = nannou::noise::Fbm::<nannou::noise::Perlin>::new(model.noise_random_seed)
         .set_octaves(model.octaves)
         .set_persistence(model.falloff as f64);
 

--- a/generative_design/random_and_noise/m_1_5_02.rs
+++ b/generative_design/random_and_noise/m_1_5_02.rs
@@ -25,7 +25,7 @@
  * backspace           : clear screen
  * s                   : save png
  */
-use nannou::noise::{NoiseFn, Perlin, Seedable};
+use nannou::noise::{NoiseFn, Perlin};
 use nannou::prelude::*;
 
 fn main() {
@@ -138,7 +138,7 @@ fn model(app: &App) -> Model {
 }
 
 fn update(_app: &App, model: &mut Model) {
-    let noise = Perlin::new().set_seed(model.noise_seed);
+    let noise = Perlin::new(model.noise_seed);
 
     for agent in &mut model.agents {
         match model.draw_mode {

--- a/generative_design/random_and_noise/m_1_5_03.rs
+++ b/generative_design/random_and_noise/m_1_5_03.rs
@@ -25,7 +25,7 @@
  * backspace           : clear screen
  * s                   : save png
  */
-use nannou::noise::{NoiseFn, Perlin, Seedable};
+use nannou::noise::{NoiseFn, Perlin};
 use nannou::prelude::*;
 
 fn main() {
@@ -149,7 +149,7 @@ fn model(app: &App) -> Model {
 }
 
 fn update(_app: &App, model: &mut Model) {
-    let noise = Perlin::new().set_seed(model.noise_seed);
+    let noise = Perlin::new(model.noise_seed);
 
     for agent in &mut model.agents {
         match model.draw_mode {

--- a/generative_design/random_and_noise/m_1_5_04.rs
+++ b/generative_design/random_and_noise/m_1_5_04.rs
@@ -26,7 +26,7 @@
  * backspace           : clear screen
  * s                   : save png
  */
-use nannou::noise::{NoiseFn, Perlin, Seedable};
+use nannou::noise::{NoiseFn, Perlin};
 use nannou::prelude::*;
 
 fn main() {
@@ -205,7 +205,7 @@ fn model(app: &App) -> Model {
 }
 
 fn update(_app: &App, model: &mut Model) {
-    let noise = Perlin::new().set_seed(model.noise_seed);
+    let noise = Perlin::new(model.noise_seed);
 
     for agent in &mut model.agents {
         agent.update(noise, model.draw_mode);


### PR DESCRIPTION
Closes #1050

Updates noise dependency to 0.9 and drops the now redundant `ambiguous_glob_imports = "allow"` lints.