### PR TITLE
feat(draw): render text via `bevy_text`'s glyph atlases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
  "clipboard-win",
  "image 0.25.8",
  "log",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -1653,7 +1653,7 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
- "parley 0.9.0",
+ "parley",
  "serde",
  "smallvec 1.15.1",
  "smol_str",
@@ -1725,7 +1725,7 @@ dependencies = [
  "bevy_utils",
  "bevy_window",
  "derive_more",
- "parley 0.9.0",
+ "parley",
  "smallvec 1.15.1",
  "swash",
  "taffy",
@@ -1787,7 +1787,7 @@ dependencies = [
  "bevy_text",
  "bevy_ui",
  "bevy_window",
- "parley 0.9.0",
+ "parley",
  "smol_str",
 ]
 
@@ -2000,7 +2000,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2767,7 +2767,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -3280,29 +3280,6 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bbc252c93499b6d3635d692f892a637db0dbb130ce9b32bf20b28e0dcc470b"
-dependencies = [
- "bytemuck",
- "hashbrown 0.16.1",
- "icu_locale_core",
- "linebender_resource_handle",
- "memmap2",
- "objc2 0.6.3",
- "objc2-core-foundation",
- "objc2-core-text",
- "objc2-foundation 0.3.2",
- "read-fonts 0.35.0",
- "roxmltree 0.21.1",
- "smallvec 1.15.1",
- "windows 0.58.0",
- "windows-core 0.58.0",
- "yeslogic-fontconfig-sys",
-]
-
-[[package]]
-name = "fontique"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c20b425addb8661e97fe1d51c4d8bcec3ec29ed6ad0db983976a7521276b8f7"
@@ -3310,9 +3287,17 @@ dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
  "memmap2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
  "parlance",
  "read-fonts 0.39.2",
+ "roxmltree 0.21.1",
  "smallvec 1.15.1",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "yeslogic-fontconfig-sys",
 ]
 
 [[package]]
@@ -3710,19 +3695,6 @@ dependencies = [
  "crunchy",
  "num-traits",
  "zerocopy 0.8.27",
-]
-
-[[package]]
-name = "harfrust"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
-dependencies = [
- "bitflags 2.11.1",
- "bytemuck",
- "core_maths",
- "read-fonts 0.35.0",
- "smallvec 1.15.1",
 ]
 
 [[package]]
@@ -5033,9 +5005,10 @@ dependencies = [
  "lyon",
  "nannou_core",
  "notosans",
- "parley 0.7.0",
+ "parley",
  "rayon",
- "skrifa 0.37.0",
+ "skrifa 0.42.1",
+ "swash",
  "uuid",
 ]
 
@@ -5622,9 +5595,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -5652,7 +5625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
 ]
@@ -5701,7 +5674,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -5712,7 +5685,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -5777,7 +5750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -5788,7 +5761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.1",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -5824,7 +5797,7 @@ checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -5848,7 +5821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.1",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
@@ -6099,26 +6072,12 @@ checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
 
 [[package]]
 name = "parley"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada5338c3a9794af7342e6f765b6e78740db37378aced034d7bf72c96b94ed94"
-dependencies = [
- "fontique 0.7.0",
- "harfrust 0.3.2",
- "hashbrown 0.16.1",
- "linebender_resource_handle",
- "skrifa 0.37.0",
- "swash",
-]
-
-[[package]]
-name = "parley"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fad031076f48f0d4d85ce1aea9b94b4e715a4d636a030a123038f8f5b5e4343"
 dependencies = [
- "fontique 0.9.0",
- "harfrust 0.6.2",
+ "fontique",
+ "harfrust",
  "hashbrown 0.17.1",
  "icu_normalizer",
  "icu_properties",
@@ -6737,7 +6696,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
@@ -6776,7 +6735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
- "core_maths",
  "font-types 0.10.0",
 ]
 
@@ -8839,7 +8797,7 @@ dependencies = [
  "jni 0.22.4",
  "log",
  "ndk-context",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
@@ -8980,7 +8938,7 @@ dependencies = [
  "log",
  "naga",
  "ndk-sys 0.6.0+11769913",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
@@ -9112,16 +9070,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
@@ -9150,19 +9098,6 @@ dependencies = [
  "windows-implement 0.56.0",
  "windows-interface 0.56.0",
  "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -9203,17 +9138,6 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.42",
- "syn 2.0.109",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -9228,17 +9152,6 @@ name = "windows-interface"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
-dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.42",
- "syn 2.0.109",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2 1.0.103",
  "quote 1.0.42",
@@ -9300,15 +9213,6 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -9323,16 +9227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,18 +62,24 @@ nokhwa = { version = "0.10", features = ["input-native", "camera-sync-impl"] }
 noise = "0.7"
 notosans = "0.1"
 num-traits = {version = "0.2", default-features = false }
-parley = { version = "0.7.0", default-features = false, features = ["std", "system"] }
+# Kept in lockstep with the `parley` version used by `bevy_text` so that the
+# font database can be shared. System font discovery is feature-gated via
+# `nannou_draw/system_font_discovery`.
+parley = { version = "0.9.0", default-features = false, features = ["std"] }
 pennereq = "0.3"
 quote = "1"
 rand = {version = "0.9.0", default-features = false }
 rayon = "1.10"
 ringbuf = "0.4"
 rosc = "0.11"
-skrifa = "0.37.0"
+skrifa = "0.42"
 semver = "1"
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.9"
+# Must semver-unify with `bevy_text`'s `swash` dependency: glyph rasterisation
+# goes through bevy's `ScaleCx` resource, whose types must match.
+swash = { version = "0.2.6", default-features = false, features = ["std", "scale"] }
 syn = "1"
 thiserror = "2"
 tempfile = "3"

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -56,6 +56,18 @@ ECS, renderer, asset system and plugins) is now available to nannou apps.
 - `nannou_isf` (Interactive Shader Format) rendering ported to Bevy.
 - Colour types and constants are now aligned with Bevy's `bevy_color` (e.g. the
   CSS palette colour constants such as `PLUM` and `STEEL_BLUE`).
+- `draw.text()` now renders glyphs as textured quads sampling `bevy_text`'s
+  cached glyph atlases (rasterised via `swash`) instead of tessellating glyph
+  outlines every frame: dense or small text is far cheaper and pixel-crisp, and
+  colour fonts (e.g. emoji) are supported. Note that glyphs are rasterised at
+  their font size, so text under large `draw.scale(..)` factors will blur;
+  resolution-independent vector text remains available via
+  `draw.text_layout(..).build(rect)` and `draw.path().events(..)`.
+- Text layout shares `bevy_text`'s `parley` font database: fonts loaded as Bevy
+  `Font` assets can be selected with `draw.text(..).font(<family name>)`,
+  system-installed fonts are discovered automatically (`system_font_discovery`
+  feature, enabled by default) and the bundled Noto Sans (`notosans` feature,
+  enabled by default) is the default face.
 - The `view` function no longer receives or returns a `Frame`; it is simply
   called each time a window needs to be redrawn.
 

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -53,6 +53,8 @@ default = [
     # We should use wayland instead no?
     "x11",
     "webgl2",
+    "notosans",
+    "system_font_discovery",
 ]
 config_json = ["bevy_common_assets/json"]
 config_toml = ["bevy_common_assets/toml"]
@@ -64,6 +66,12 @@ egui = ["dep:bevy_egui", "bevy_egui/immutable_ctx"]
 hot_reload = ["bevy/file_watcher", "bevy/multi_threaded"]
 isf = ["nannou_isf"]
 nightly = ["nannou_draw/nightly"]
+# Bundle Noto Sans as the default font, for deterministic rendering across
+# machines regardless of installed system fonts.
+notosans = ["nannou_draw/notosans"]
+# Discover fonts installed on the system, making them available to
+# `draw.text().font(..)` by family name.
+system_font_discovery = ["nannou_draw/system_font_discovery"]
 serde = ["dep:serde", "toml", "serde_json", "nannou_core/serde"]
 video = ["nannou_video"]
 wayland = ["bevy/wayland"]

--- a/nannou_draw/Cargo.toml
+++ b/nannou_draw/Cargo.toml
@@ -24,6 +24,7 @@ nannou_core = { path = "../nannou_core" }
 notosans = { workspace = true, optional = true }
 parley.workspace = true
 skrifa.workspace = true
+swash.workspace = true
 rayon.workspace = true
 uuid.workspace = true
 bitflags.workspace = true
@@ -31,3 +32,6 @@ bitflags.workspace = true
 [features]
 nightly = []
 notosans = ["dep:notosans"]
+# Discover fonts installed on the system (e.g. via fontconfig on Linux),
+# making them available to `draw.text().font(..)` by family name.
+system_font_discovery = ["bevy/system_font_discovery", "parley/system"]

--- a/nannou_draw/src/draw/primitive/text.rs
+++ b/nannou_draw/src/draw/primitive/text.rs
@@ -1,3 +1,5 @@
+use core::hash::BuildHasher;
+
 use crate::draw::drawing::DrawingContext;
 use crate::draw::mesh::MeshExt;
 use crate::draw::primitive::Primitive;
@@ -6,8 +8,13 @@ use crate::draw::properties::{SetColor, SetDimensions, SetOrientation, SetPositi
 use crate::draw::{self, Drawing};
 use crate::render::ShaderModel;
 use crate::text::{self, Align, FontSize, Justify, Layout, Scalar, Wrap};
+use bevy::platform::hash::FixedHasher;
 use bevy::prelude::*;
-use lyon::tessellation::{BuffersBuilder, FillOptions, VertexBuffers};
+use bevy::text::{
+    FontAtlasKey, FontAtlasSet, FontHinting, FontSmoothing, GlyphCacheKey, ScaleCx,
+    add_glyph_to_atlas, get_glyph_atlas_info,
+};
+use swash::FontRef;
 
 /// Properties related to drawing the **Text** primitive.
 #[derive(Clone, Debug)]
@@ -242,21 +249,35 @@ where
     }
 }
 
-impl draw::render::RenderPrimitive for Text {
-    fn render_primitive(self, ctxt: draw::render::RenderContext, mesh: &mut Mesh) {
-        let draw::render::RenderContext {
-            text_buffer,
-            theme,
-            transform,
-            fill_tessellator,
-            output_attachment_size,
-            text_cx,
-            ..
-        } = ctxt;
+/// A run of glyph quads sampling a single font atlas texture.
+pub(crate) struct TextQuadBatch {
+    pub texture: Handle<Image>,
+    pub mesh: Mesh,
+}
 
+impl Text {
+    /// Lay out the text and emit one textured quad per glyph, rasterising glyphs into
+    /// `bevy_text`'s cached font atlases as required.
+    ///
+    /// Glyph positions are computed at physical-pixel resolution (`scale_factor`) so that
+    /// rasterised glyphs map 1:1 to screen pixels, then converted back to logical points.
+    /// A new batch is started whenever consecutive glyphs sample different atlas textures.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn render_atlas_quads(
+        self,
+        text_buffer: &str,
+        theme: &draw::Theme,
+        transform: &Mat4,
+        output_attachment_size: Vec2,
+        scale_factor: f32,
+        text_cx: &crate::text::font::SharedTextCx,
+        font_atlas_set: &mut FontAtlasSet,
+        images: &mut Assets<Image>,
+        scale_cx: &mut ScaleCx,
+    ) -> Vec<TextQuadBatch> {
         let s = &text_buffer[self.text.clone()];
         if s.is_empty() {
-            return;
+            return Vec::new();
         }
 
         let layout_params = self.style.layout.build();
@@ -275,60 +296,163 @@ impl draw::render::RenderPrimitive for Text {
         let rect = nannou_core::geom::Rect::from_x_y_w_h(x, y, w, h);
 
         let mut inner = text_cx.0.lock().unwrap();
-        let text_obj = text::Text::layout_with_inner(&mut inner, s, &layout_params, rect);
+        let text_obj =
+            text::Text::layout_with_inner(&mut inner, s, &layout_params, rect, scale_factor);
         drop(inner);
 
         let default_color = self
             .style
             .color
             .unwrap_or_else(|| theme.fill(&draw::theme::Primitive::Text));
+        let glyph_colors = &self.style.glyph_colors;
 
         let rect_center = Vec2::new(x, y);
         let pos_offset = text_obj.position_offset_value() + rect_center;
 
-        let glyph_colors = &self.style.glyph_colors;
-        let per_glyph = text::glyph::per_glyph_path_events(text_obj.parley_layout(), pos_offset);
+        // Rasterise with bevy's defaults so atlas entries are shared with bevy UI text.
+        let font_smoothing = FontSmoothing::AntiAliased;
+        let hinting = FontHinting::default();
 
-        for (i, glyph_events) in per_glyph.iter().enumerate() {
-            if glyph_events.is_empty() {
-                continue;
-            }
+        let mut batches: Vec<TextQuadBatch> = Vec::new();
+        // Counts every positioned glyph (rendered or not) so `glyph_colors` indices
+        // are stable regardless of which glyphs make it into an atlas.
+        let mut glyph_index = 0;
 
-            let color = glyph_colors.get(i).copied().unwrap_or(default_color);
-            let color_arr: [f32; 4] = LinearRgba::from(color).to_f32_array();
+        for line in text_obj.parley_layout().lines() {
+            for item in line.items() {
+                let parley::PositionedLayoutItem::GlyphRun(glyph_run) = item else {
+                    continue;
+                };
 
-            let mut buffers: VertexBuffers<[f32; 3], u32> = VertexBuffers::new();
-            {
-                let mut builder =
-                    BuffersBuilder::new(&mut buffers, |vertex: lyon::tessellation::FillVertex| {
-                        let p = vertex.position();
-                        let transformed = *transform * Vec4::new(p.x, p.y, 0.0, 1.0);
-                        [transformed.x, transformed.y, transformed.z]
-                    });
+                let run = glyph_run.run();
+                let font = run.font();
+                let font_size = run.font_size();
+                let coords = run.normalized_coords();
+                let font_atlas_key = FontAtlasKey {
+                    id: font.data.id() as u32,
+                    index: font.index,
+                    font_size_bits: font_size.to_bits(),
+                    variations_hash: FixedHasher.hash_one(coords),
+                    hinting,
+                    font_smoothing,
+                };
 
-                let _ = fill_tessellator.tessellate(
-                    glyph_events.iter().copied(),
-                    &FillOptions::default(),
-                    &mut builder,
-                );
-            }
+                let Some(font_ref) = FontRef::from_index(font.data.as_ref(), font.index as usize)
+                else {
+                    glyph_index += glyph_run.positioned_glyphs().count();
+                    continue;
+                };
 
-            if buffers.vertices.is_empty() {
-                continue;
-            }
+                let hint = hinting.is_enabled() && font_smoothing == FontSmoothing::AntiAliased;
+                let mut scaler = scale_cx
+                    .0
+                    .builder(font_ref)
+                    .size(font_size)
+                    .hint(hint)
+                    .normalized_coords(coords)
+                    .build();
 
-            let base_idx = mesh.points().len() as u32;
-            mesh.points_mut().extend(buffers.vertices.iter());
-            mesh.normals_mut()
-                .extend(std::iter::repeat_n([0.0, 0.0, 1.0], buffers.vertices.len()));
-            mesh.colors_mut()
-                .extend(std::iter::repeat_n(color_arr, buffers.vertices.len()));
-            mesh.tex_coords_mut()
-                .extend(std::iter::repeat_n([0.0, 0.0], buffers.vertices.len()));
-            for idx in &buffers.indices {
-                mesh.push_index(idx + base_idx);
+                for glyph in glyph_run.positioned_glyphs() {
+                    let i = glyph_index;
+                    glyph_index += 1;
+
+                    let Ok(glyph_id) = u16::try_from(glyph.id) else {
+                        continue;
+                    };
+
+                    let font_atlases = font_atlas_set.entry(font_atlas_key).or_default();
+                    let atlas_info = get_glyph_atlas_info(font_atlases, GlyphCacheKey { glyph_id })
+                        .map(Ok)
+                        .unwrap_or_else(|| {
+                            add_glyph_to_atlas(
+                                font_atlases,
+                                images,
+                                &mut scaler,
+                                font_smoothing,
+                                glyph_id,
+                            )
+                        });
+                    let Ok(atlas_info) = atlas_info else {
+                        continue;
+                    };
+
+                    let size = atlas_info.rect.size();
+                    if size.x <= 0.0 || size.y <= 0.0 {
+                        continue;
+                    }
+
+                    let Some(atlas) = font_atlases
+                        .iter()
+                        .find(|atlas| atlas.texture.id() == atlas_info.texture)
+                    else {
+                        continue;
+                    };
+
+                    // Glyph centre in parley's y-down physical-pixel layout space,
+                    // converted to nannou's y-up logical points.
+                    let centre = size / 2.0 + Vec2::new(glyph.x, glyph.y) + atlas_info.offset;
+                    let cx = pos_offset.x + centre.x / scale_factor;
+                    let cy = pos_offset.y - centre.y / scale_factor;
+                    let hw = size.x / (2.0 * scale_factor);
+                    let hh = size.y / (2.0 * scale_factor);
+
+                    // Monochrome glyphs are white-on-alpha in the atlas and tinted by
+                    // vertex colour; colour glyphs (e.g. emoji) are sampled as-is.
+                    let color = if atlas_info.is_alpha_mask {
+                        glyph_colors.get(i).copied().unwrap_or(default_color)
+                    } else {
+                        Color::WHITE
+                    };
+                    let color_arr: [f32; 4] = LinearRgba::from(color).to_f32_array();
+
+                    // UVs over the atlas; the image's y-down texel space performs the
+                    // vertical flip relative to the y-up quad corners.
+                    let atlas_size = atlas.texture_atlas.size.as_vec2();
+                    let (uv_l, uv_r) = (
+                        atlas_info.rect.min.x / atlas_size.x,
+                        atlas_info.rect.max.x / atlas_size.x,
+                    );
+                    let (uv_t, uv_b) = (
+                        atlas_info.rect.min.y / atlas_size.y,
+                        atlas_info.rect.max.y / atlas_size.y,
+                    );
+
+                    let batch = match batches.last_mut() {
+                        Some(batch) if batch.texture.id() == atlas_info.texture => batch,
+                        _ => {
+                            batches.push(TextQuadBatch {
+                                texture: atlas.texture.clone(),
+                                mesh: Mesh::init(),
+                            });
+                            batches.last_mut().unwrap()
+                        }
+                    };
+
+                    let mesh = &mut batch.mesh;
+                    let base = mesh.points().len() as u32;
+                    // Corners ordered top-left, top-right, bottom-right, bottom-left.
+                    let corners = [
+                        (cx - hw, cy + hh, uv_l, uv_t),
+                        (cx + hw, cy + hh, uv_r, uv_t),
+                        (cx + hw, cy - hh, uv_r, uv_b),
+                        (cx - hw, cy - hh, uv_l, uv_b),
+                    ];
+                    for (px, py, u, v) in corners {
+                        let p = *transform * Vec4::new(px, py, 0.0, 1.0);
+                        mesh.points_mut().push([p.x, p.y, p.z]);
+                        mesh.colors_mut().push(color_arr);
+                        mesh.tex_coords_mut().push([u, v]);
+                        mesh.normals_mut().push([0.0, 0.0, 1.0]);
+                    }
+                    // Two triangles wound counter-clockwise in y-up space.
+                    for idx in [0, 3, 2, 0, 2, 1] {
+                        mesh.push_index(base + idx);
+                    }
+                }
             }
         }
+
+        batches
     }
 }
 

--- a/nannou_draw/src/draw/render/mod.rs
+++ b/nannou_draw/src/draw/render/mod.rs
@@ -3,7 +3,6 @@ use lyon::path::PathEvent;
 use lyon::tessellation::{FillTessellator, StrokeTessellator};
 
 use crate::draw;
-use crate::text::font::SharedTextCx;
 
 /// Draw API primitives that may be rendered via the **Renderer** type.
 pub trait RenderPrimitive {
@@ -23,7 +22,6 @@ pub struct RenderContext<'a> {
     pub stroke_tessellator: &'a mut StrokeTessellator,
     pub output_attachment_size: Vec2, // logical coords
     pub output_attachment_scale_factor: f32,
-    pub text_cx: &'a SharedTextCx,
 }
 
 /// The position and dimensions of the scissor.
@@ -48,7 +46,10 @@ impl RenderPrimitive for draw::Primitive {
             draw::Primitive::Quad(prim) => prim.render_primitive(ctxt, mesh),
             draw::Primitive::Rect(prim) => prim.render_primitive(ctxt, mesh),
             draw::Primitive::Line(prim) => prim.render_primitive(ctxt, mesh),
-            draw::Primitive::Text(prim) => prim.render_primitive(ctxt, mesh),
+            // `Text` is handled by the renderer directly (it renders as quads
+            // textured by the glyph atlas rather than into the shared mesh), so it
+            // falls through to the catch-all here, e.g. for instanced/indirect
+            // commands where atlas-textured text is not supported.
             _ => {}
         }
     }

--- a/nannou_draw/src/lib.rs
+++ b/nannou_draw/src/lib.rs
@@ -26,10 +26,13 @@ pub struct NannouDrawPlugin;
 
 impl Plugin for NannouDrawPlugin {
     fn build(&self, app: &mut App) {
+        // Text rendering rasterises glyphs via `bevy_text`'s atlas machinery.
+        if !app.is_plugin_added::<bevy::text::TextPlugin>() {
+            app.add_plugins(bevy::text::TextPlugin);
+        }
+        text::font::init_shared_text_cx(app);
         app.add_plugins(NannouRenderPlugin)
-            .init_resource::<SharedTextCx>()
-            .add_systems(First, (spawn_draw, reset_draw).chain())
-            .add_systems(PostUpdate, text::font::sync_bevy_fonts_to_nannou);
+            .add_systems(First, (spawn_draw, reset_draw).chain());
     }
 }
 

--- a/nannou_draw/src/render.rs
+++ b/nannou_draw/src/render.rs
@@ -29,6 +29,7 @@ use bevy::{
     prelude::{TypePath, *},
     render::{
         RenderApp, RenderStartup, RenderSystems,
+        batching::NoAutomaticBatching,
         extract_component::{ExtractComponent, ExtractComponentPlugin},
         extract_instances::{ExtractInstance, ExtractInstancesPlugin, ExtractedInstances},
         mesh::RenderMesh,
@@ -698,6 +699,7 @@ fn update_draw_mesh(
                             ShaderModelMesh,
                             NannouTransient,
                             NoFrustumCulling,
+                            NoAutomaticBatching,
                             DrawIndex(idx),
                             window_layers.clone(),
                         ));
@@ -741,6 +743,7 @@ fn update_draw_mesh(
                         ViewVisibility::default(),
                         NannouTransient,
                         NoFrustumCulling,
+                        NoAutomaticBatching,
                         DrawIndex(idx),
                         window_layers.clone(),
                     ));
@@ -779,6 +782,7 @@ fn update_draw_mesh(
                         ViewVisibility::default(),
                         NannouTransient,
                         NoFrustumCulling,
+                        NoAutomaticBatching,
                         DrawIndex(idx),
                         window_layers.clone(),
                     ));

--- a/nannou_draw/src/render.rs
+++ b/nannou_draw/src/render.rs
@@ -126,14 +126,18 @@ impl Plugin for NannouRenderPlugin {
             ExtractComponentPlugin::<ShaderBufferHandle>::default(),
             NannouShaderModelPlugin::<DefaultNannouShaderModel>::default(),
         ))
+        .init_resource::<TextModelKeepalive>()
         .add_systems(First, clear_previous_frame)
         // `update_draw_mesh` (re)spawns the draw meshes each frame, so it must run
         // before Bevy computes visibility - otherwise the freshly spawned meshes
         // have `ViewVisibility == false` when the render-world extraction runs and
-        // get skipped (no draw output).
+        // get skipped (no draw output). It must also run after bevy has registered
+        // newly loaded font assets so that text laid out this frame can use them.
         .add_systems(
             PostUpdate,
-            update_draw_mesh.before(VisibilitySystems::VisibilityPropagate),
+            update_draw_mesh
+                .before(VisibilitySystems::VisibilityPropagate)
+                .after(bevy::text::load_font_assets_into_font_collection),
         );
     }
 }
@@ -617,6 +621,7 @@ fn update_shader_model<SM>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn update_draw_mesh(
     mut commands: Commands,
     draw_q: Query<&Draw>,
@@ -624,6 +629,11 @@ fn update_draw_mesh(
     windows: Query<(&Window, Has<PrimaryWindow>)>,
     mut meshes: ResMut<Assets<Mesh>>,
     text_cx: Res<crate::text::font::SharedTextCx>,
+    mut font_atlas_set: ResMut<bevy::text::FontAtlasSet>,
+    mut images: ResMut<Assets<Image>>,
+    mut scale_cx: ResMut<bevy::text::ScaleCx>,
+    mut text_models: ResMut<Assets<DefaultNannouShaderModel>>,
+    mut text_model_keepalive: ResMut<TextModelKeepalive>,
 ) {
     for draw in draw_q.iter() {
         let Some((mut window_camera, _, window_layers)) =
@@ -667,6 +677,62 @@ fn update_draw_mesh(
 
         for (idx, cmd) in draw_cmds.enumerate() {
             match cmd {
+                // Text renders as glyph-atlas-textured quads, so it cannot join the
+                // current batch: each run of glyphs gets its own mesh entity bound to
+                // the atlas texture it samples.
+                DrawCommand::Primitive(crate::draw::primitive::Primitive::Text(prim)) => {
+                    // End the current batch so that primitives drawn after this text
+                    // get a fresh mesh entity with a higher `DrawIndex`.
+                    current_mesh.take();
+
+                    let batches = prim.render_atlas_quads(
+                        &intermediary_state.text_buffer,
+                        &draw_state.theme,
+                        &curr_ctx.transform,
+                        Vec2::new(window.width(), window.height()),
+                        window.scale_factor(),
+                        &text_cx,
+                        &mut font_atlas_set,
+                        &mut images,
+                        &mut scale_cx,
+                    );
+
+                    // Base the text material on the active shader model when it is the
+                    // default nannou model, preserving e.g. the current blend mode.
+                    // Text drawn with a custom shader model type falls back to the
+                    // default model.
+                    let base = last_shader_model
+                        .as_ref()
+                        .and_then(|id| draw_state.shader_models.get(id))
+                        .and_then(|model| model.downcast_ref::<DefaultNannouShaderModel>())
+                        .cloned()
+                        .unwrap_or_default();
+
+                    for crate::draw::primitive::text::TextQuadBatch { texture, mesh } in batches {
+                        let mut model = base.clone();
+                        // Glyph colour is carried per-vertex; the model tints white so
+                        // it passes through.
+                        model.color = Color::WHITE;
+                        model.texture = Some(texture);
+                        let handle = text_models.add(model);
+                        commands.spawn((
+                            UntypedShaderModelId(handle.id().untyped()),
+                            Mesh3d(meshes.add(mesh)),
+                            Transform::default(),
+                            GlobalTransform::default(),
+                            Visibility::default(),
+                            InheritedVisibility::default(),
+                            ViewVisibility::default(),
+                            ShaderModelMesh,
+                            NannouTransient,
+                            NoFrustumCulling,
+                            NoAutomaticBatching,
+                            DrawIndex(idx),
+                            window_layers.clone(),
+                        ));
+                        text_model_keepalive.0.push(handle);
+                    }
+                }
                 DrawCommand::Primitive(prim) => {
                     // Info required during rendering.
                     let ctxt = RenderContext {
@@ -680,7 +746,6 @@ fn update_draw_mesh(
                         stroke_tessellator: &mut stroke_tessellator,
                         output_attachment_size: Vec2::new(window.width(), window.height()),
                         output_attachment_scale_factor: window.scale_factor(),
-                        text_cx: &text_cx,
                     };
 
                     // If no mesh is currently set, initialise a new one.
@@ -722,7 +787,6 @@ fn update_draw_mesh(
                         stroke_tessellator: &mut stroke_tessellator,
                         output_attachment_size: Vec2::new(window.width(), window.height()),
                         output_attachment_scale_factor: window.scale_factor(),
-                        text_cx: &text_cx,
                     };
 
                     // Render the primitive.
@@ -761,7 +825,6 @@ fn update_draw_mesh(
                         stroke_tessellator: &mut stroke_tessellator,
                         output_attachment_size: Vec2::new(window.width(), window.height()),
                         output_attachment_scale_factor: window.scale_factor(),
-                        text_cx: &text_cx,
                     };
 
                     // Render the primitive.
@@ -810,11 +873,18 @@ pub struct DrawIndex(pub usize);
 #[derive(Component, ExtractComponent, Clone)]
 pub struct NannouTransient;
 
+/// Keeps the shader models created for text quad batches alive for the frame they
+/// are drawn in; dropping the handles the following frame lets the assets clean up.
+#[derive(Resource, Default)]
+pub struct TextModelKeepalive(Vec<Handle<DefaultNannouShaderModel>>);
+
 fn clear_previous_frame(
     mut commands: Commands,
     bg_color_q: Query<Entity, With<BackgroundColor>>,
     meshes_q: Query<Entity, With<NannouTransient>>,
+    mut text_model_keepalive: ResMut<TextModelKeepalive>,
 ) {
+    text_model_keepalive.0.clear();
     for entity in meshes_q.iter() {
         commands.entity(entity).despawn();
     }

--- a/nannou_draw/src/text/font.rs
+++ b/nannou_draw/src/text/font.rs
@@ -2,11 +2,8 @@
 
 use std::sync::{Arc, Mutex};
 
-use bevy::asset::{AssetEvent, Assets};
-use bevy::ecs::message::MessageReader;
 use bevy::prelude::*;
-use parley::FontContext;
-use parley::LayoutContext;
+use parley::{FontContext, LayoutContext};
 
 /// Font database and layout scratch space.
 pub struct NannouTextCxInner {
@@ -18,41 +15,35 @@ pub struct NannouTextCxInner {
 #[derive(Resource, Clone)]
 pub struct SharedTextCx(pub Arc<Mutex<NannouTextCxInner>>);
 
-impl Default for SharedTextCx {
-    fn default() -> Self {
-        let font = FontContext::new();
-        let inner = NannouTextCxInner {
-            font,
-            layout: LayoutContext::new(),
-        };
-        let cx = SharedTextCx(Arc::new(Mutex::new(inner)));
-        #[cfg(feature = "notosans")]
-        {
-            cx.0.lock()
-                .unwrap()
-                .font
-                .collection
-                .register_fonts(notosans::REGULAR_TTF.to_vec().into(), None);
-        }
-        cx
-    }
-}
+/// Initialise the font database shared between the bevy and nannou text contexts.
+///
+/// The same fontique collection backs both bevy's [`bevy::text::FontCx`] (kept in sync with
+/// `Assets<Font>` by bevy's `load_font_assets_into_font_collection` system) and nannou's
+/// [`SharedTextCx`] (used by the `Draw` and `App` text APIs): the collection is made shared
+/// before cloning so that fonts registered through either context are visible to both.
+pub(crate) fn init_shared_text_cx(app: &mut App) {
+    let mut font = FontContext::default();
+    font.collection.make_shared();
 
-/// Sync bevy font assets into our font collection.
-pub fn sync_bevy_fonts_to_nannou(
-    text_cx: Res<SharedTextCx>,
-    mut events: MessageReader<AssetEvent<bevy::text::Font>>,
-    fonts: Res<Assets<bevy::text::Font>>,
-) {
-    for event in events.read() {
-        if let AssetEvent::Added { id } | AssetEvent::Modified { id } = event {
-            if let Some(font) = fonts.get(*id) {
-                let mut inner = text_cx.0.lock().unwrap();
-                inner
-                    .font
-                    .collection
-                    .register_fonts(font.data.clone(), None);
-            }
+    #[cfg(feature = "notosans")]
+    {
+        let registered = font
+            .collection
+            .register_fonts(notosans::REGULAR_TTF.to_vec().into(), None);
+        // Map the generic sans-serif family (parley's default) to the bundled Noto
+        // Sans so that default text renders identically regardless of system fonts.
+        if let Some((family_id, _)) = registered.first() {
+            font.collection.set_generic_families(
+                parley::GenericFamily::SansSerif,
+                std::iter::once(*family_id),
+            );
         }
     }
+
+    app.insert_resource(bevy::text::FontCx(font.clone()));
+    let inner = NannouTextCxInner {
+        font,
+        layout: LayoutContext::new(),
+    };
+    app.insert_resource(SharedTextCx(Arc::new(Mutex::new(inner))));
 }

--- a/nannou_draw/src/text/glyph.rs
+++ b/nannou_draw/src/text/glyph.rs
@@ -86,65 +86,34 @@ impl OutlinePen for LyonOutlinePen {
 }
 
 /// Extract lyon path events for all glyphs in a parley layout.
-pub fn text_path_events(parley_layout: &parley::Layout<Color>, pos_offset: Vec2) -> Vec<PathEvent> {
-    let mut all_events = Vec::new();
-
-    for line in parley_layout.lines() {
-        let baseline = line.metrics().baseline;
-
-        for item in line.items() {
-            let parley::PositionedLayoutItem::GlyphRun(glyph_run) = item else {
-                continue;
-            };
-
-            let run = glyph_run.run();
-            let font_data = run.font();
-            let font_size = run.font_size();
-
-            let font_blob = &font_data.data;
-            let font_index = font_data.index;
-            let Ok(font_ref) = FontRef::from_index(font_blob.as_ref(), font_index) else {
-                continue;
-            };
-
-            let outlines = font_ref.outline_glyphs();
-            let upem = font_ref
-                .head()
-                .map(|h| h.units_per_em() as f32)
-                .unwrap_or(1000.0);
-            let scale = font_size / upem;
-
-            for glyph in glyph_run.positioned_glyphs() {
-                let glyph_id = GlyphId::new(glyph.id as u32);
-                let Some(outline_glyph) = outlines.get(glyph_id) else {
-                    continue;
-                };
-
-                let gx = pos_offset.x + glyph.x;
-                let gy = pos_offset.y - baseline;
-                let origin = lyon::math::point(gx, gy);
-                let mut pen = LyonOutlinePen::new(origin, scale, false);
-                let settings = DrawSettings::unhinted(Size::unscaled(), LocationRef::default());
-                let _ = outline_glyph.draw(settings, &mut pen);
-
-                all_events.extend(pen.events);
-            }
-        }
-    }
-
-    all_events
+///
+/// `layout_scale` is the factor by which the parley layout is scaled relative to the
+/// returned (logical point) coordinates - see `text::Text`.
+pub fn text_path_events(
+    parley_layout: &parley::Layout<Color>,
+    pos_offset: Vec2,
+    layout_scale: f32,
+) -> Vec<PathEvent> {
+    per_glyph_path_events(parley_layout, pos_offset, layout_scale)
+        .into_iter()
+        .flatten()
+        .collect()
 }
 
 /// Extract lyon path events for each glyph separately, enabling per-glyph coloring.
+///
+/// Glyphs without an outline yield an empty `Vec`, preserving glyph indexing.
+///
+/// `layout_scale` is the factor by which the parley layout is scaled relative to the
+/// returned (logical point) coordinates - see `text::Text`.
 pub fn per_glyph_path_events(
     parley_layout: &parley::Layout<Color>,
     pos_offset: Vec2,
+    layout_scale: f32,
 ) -> Vec<Vec<PathEvent>> {
     let mut per_glyph = Vec::new();
 
     for line in parley_layout.lines() {
-        let baseline = line.metrics().baseline;
-
         for item in line.items() {
             let parley::PositionedLayoutItem::GlyphRun(glyph_run) = item else {
                 continue;
@@ -165,7 +134,7 @@ pub fn per_glyph_path_events(
                 .head()
                 .map(|h| h.units_per_em() as f32)
                 .unwrap_or(1000.0);
-            let scale = font_size / upem;
+            let scale = font_size / upem / layout_scale;
 
             for glyph in glyph_run.positioned_glyphs() {
                 let glyph_id = GlyphId::new(glyph.id as u32);
@@ -174,8 +143,9 @@ pub fn per_glyph_path_events(
                     continue;
                 };
 
-                let gx = pos_offset.x + glyph.x;
-                let gy = pos_offset.y - baseline;
+                // `glyph.{x,y}` already include the line offset and baseline.
+                let gx = pos_offset.x + glyph.x / layout_scale;
+                let gy = pos_offset.y - glyph.y / layout_scale;
                 let origin = lyon::math::point(gx, gy);
 
                 let mut pen = LyonOutlinePen::new(origin, scale, false);

--- a/nannou_draw/src/text/mod.rs
+++ b/nannou_draw/src/text/mod.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use bevy::prelude::*;
 use nannou_core::geom;
 use parley::Alignment;
-use parley::style::{FontStack, StyleProperty};
+use parley::style::{FontFamily, FontFamilyName, StyleProperty, WordBreak};
 
 pub use self::layout::Layout;
 
@@ -63,6 +63,10 @@ pub struct Text {
     parley_layout: parley::Layout<Color>,
     layout: Layout,
     rect: geom::Rect,
+    // The factor by which the parley layout is scaled relative to `rect`, e.g. the window
+    // scale factor when rasterising glyphs at physical pixel resolution. All public
+    // measurements are divided by this so that the API always works in logical points.
+    scale: f32,
 }
 
 impl<'a> Builder<'a> {
@@ -168,7 +172,7 @@ impl<'a> Builder<'a> {
     pub fn build(self, rect: geom::Rect) -> Text {
         let layout = self.layout_builder.build();
         let mut inner = self.text_cx.0.lock().unwrap();
-        Text::layout_with_inner(&mut inner, &self.text, &layout, rect)
+        Text::layout_with_inner(&mut inner, &self.text, &layout, rect, 1.0)
     }
 }
 
@@ -179,9 +183,9 @@ impl Text {
         text: &str,
         layout: &Layout,
         rect: geom::Rect,
+        scale: f32,
     ) -> Self {
         let font_size = layout.font_size as f32;
-        let scale = 1.0;
 
         let mut builder = inner
             .layout
@@ -190,9 +194,10 @@ impl Text {
         builder.push_default(StyleProperty::FontSize(font_size));
 
         if let Some(ref family) = layout.font_family {
-            builder.push_default(StyleProperty::FontStack(FontStack::Single(
-                parley::style::FontFamily::Named(family.into()),
-            )));
+            // `parse` resolves generic names like "monospace"; fall back to treating
+            // the whole string as a family name.
+            let name = FontFamilyName::parse(family).unwrap_or(FontFamilyName::named(family));
+            builder.push_default(StyleProperty::FontFamily(FontFamily::Single(name)));
         }
 
         if let Some(spacing) = (layout.line_spacing != 0.0).then_some(layout.line_spacing) {
@@ -201,13 +206,16 @@ impl Text {
             ));
         }
 
+        if let Some(Wrap::Character) = layout.line_wrap {
+            builder.push_default(StyleProperty::WordBreak(WordBreak::BreakAll));
+        }
+
         let mut parley_layout = builder.build(text);
 
-        let max_width = rect.w();
         match layout.line_wrap {
             None => parley_layout.break_all_lines(None),
             Some(Wrap::Whitespace) | Some(Wrap::Character) => {
-                parley_layout.break_all_lines(Some(max_width));
+                parley_layout.break_all_lines(Some(rect.w() * scale));
             }
         }
         let alignment = match layout.justify {
@@ -215,17 +223,14 @@ impl Text {
             Justify::Center => Alignment::Center,
             Justify::Right => Alignment::End,
         };
-        parley_layout.align(
-            Some(max_width),
-            alignment,
-            parley::AlignmentOptions::default(),
-        );
+        parley_layout.align(alignment, parley::AlignmentOptions::default());
 
         Text {
             string: text.to_string(),
             parley_layout,
             layout: layout.clone(),
             rect,
+            scale,
         }
     }
 
@@ -241,12 +246,12 @@ impl Text {
 
     /// The width of the laid-out text.
     pub fn width(&self) -> Scalar {
-        self.parley_layout.width()
+        self.parley_layout.width() / self.scale
     }
 
     /// The height of the laid-out text.
     pub fn height(&self) -> Scalar {
-        self.parley_layout.height()
+        self.parley_layout.height() / self.scale
     }
 
     /// The number of lines in the text.
@@ -271,14 +276,15 @@ impl Text {
     /// Per-line bounding rects in nannou coordinate space.
     pub fn line_rects(&self) -> Vec<geom::Rect> {
         let offset = self.position_offset();
+        let scale = self.scale;
         self.parley_layout
             .lines()
             .map(|line| {
                 let metrics = line.metrics();
-                let top = offset.y - metrics.baseline + metrics.ascent;
-                let bottom = offset.y - metrics.baseline - metrics.descent;
-                let line_x = offset.x + metrics.offset;
-                let line_w = metrics.advance - metrics.trailing_whitespace;
+                let top = offset.y + (metrics.ascent - metrics.baseline) / scale;
+                let bottom = offset.y - (metrics.baseline + metrics.descent) / scale;
+                let line_x = offset.x + metrics.offset / scale;
+                let line_w = (metrics.advance - metrics.trailing_whitespace) / scale;
                 let x = geom::Range::new(line_x, line_x + line_w);
                 let y = geom::Range::new(bottom, top);
                 geom::Rect { x, y }
@@ -300,19 +306,22 @@ impl Text {
     /// Per-glyph bounding rects (one per glyph cluster).
     pub fn glyphs(&self) -> Vec<geom::Rect> {
         let offset = self.position_offset();
+        let scale = self.scale;
         let mut rects = Vec::new();
         for line in self.parley_layout.lines() {
-            let baseline = line.metrics().baseline;
             for item in line.items() {
                 let parley::PositionedLayoutItem::GlyphRun(glyph_run) = item else {
                     continue;
                 };
                 let run_metrics = glyph_run.run().metrics();
                 for glyph in glyph_run.positioned_glyphs() {
-                    let gx = offset.x + glyph.x;
-                    let gy = offset.y - baseline;
-                    let x = geom::Range::new(gx, gx + glyph.advance);
-                    let y = geom::Range::new(gy - run_metrics.descent, gy + run_metrics.ascent);
+                    let gx = offset.x + glyph.x / scale;
+                    let gy = offset.y - glyph.y / scale;
+                    let x = geom::Range::new(gx, gx + glyph.advance / scale);
+                    let y = geom::Range::new(
+                        gy - run_metrics.descent / scale,
+                        gy + run_metrics.ascent / scale,
+                    );
                     rects.push(geom::Rect { x, y });
                 }
             }
@@ -322,7 +331,7 @@ impl Text {
 
     /// Path events for every glyph, relative to the center of the layout rect.
     pub fn path_events(&self) -> Vec<lyon::path::PathEvent> {
-        glyph::text_path_events(&self.parley_layout, self.position_offset())
+        glyph::text_path_events(&self.parley_layout, self.position_offset(), self.scale)
     }
 
     pub(crate) fn parley_layout(&self) -> &parley::Layout<Color> {
@@ -344,7 +353,21 @@ impl Text {
             Align::Middle => text_h / 2.0,
             Align::Start => -rect_h / 2.0 + text_h,
         };
-        let x_offset = -rect_w / 2.0;
+        // When line breaking is unbounded, parley aligns lines within the widest line
+        // rather than the layout rect, so shift the whole block to restore
+        // rect-relative justification.
+        let x_offset = match self.layout.line_wrap {
+            Some(_) => -rect_w / 2.0,
+            None => {
+                let align_w = rect_w - self.width();
+                let factor = match self.layout.justify {
+                    Justify::Left => 0.0,
+                    Justify::Center => 0.5,
+                    Justify::Right => 1.0,
+                };
+                -rect_w / 2.0 + align_w * factor
+            }
+        };
         Vec2::new(x_offset, y_offset)
     }
 }


### PR DESCRIPTION
Closes #1003 

## Summary

`draw.text()` now renders glyphs as textured quads sampling `bevy_text`'s cached glyph atlases instead of tessellating outlines every frame:

- Each unique glyph rasterises once per (font, size) at physical-pixel resolution, so dense text is far cheaper and small text is crisp on hidpi.
- Colour fonts (e.g. emoji) now render; `glyph_colors` still works via vertex colours over the alpha-mask atlas.
- The vector API (`draw.text_layout(..).build(rect)`, `path_events()`, `glyphs()`, `line_rects()`) is unchanged and remains the tool for resolution-independent text - atlas text blurs under large `draw.scale(..)`.

## Batching fix

Bevy's automatic batching merges consecutive phase items that share a pipeline, so the per-item shader-model bind group only applied to the first item - every mesh rendered with the first entity's material, breaking e.g. `draw.texture()`. Draw meshes now opt out via `NoAutomaticBatching` (standalone commit, reviewable independently).

## Font stack unification

bevy_text 0.19 moved from cosmic-text to parley + swash, so nannou now shares its stack instead of carrying a parallel one:

- parley 0.7 -> 0.9, skrifa 0.37 -> 0.42 (lockfile deduplicated).
- One shared fontique collection backs bevy's `FontCx` and nannou's `SharedTextCx`; bevy `Font` assets resolve in `.font(..)` by family name.
- New default-on features: `system_font_discovery` (installed fonts work) and `notosans` (bundled deterministic default face).
- `wrap_by_character()` now genuinely differs from `wrap_by_word()`, and generic family names like `"monospace"` work in `.font(..)`.