### PR TITLE
fix(draw): culling, mesh textures, camera z range and compute startup

### DIFF
--- a/nannou/src/lib.rs
+++ b/nannou/src/lib.rs
@@ -23,7 +23,7 @@
 //! with no `unsafe` and no builder machinery. See the [`context`] module and the `system_param`
 //! example for details.
 use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
-use bevy::prelude::{App as BevyApp, Plugin};
+use bevy::prelude::{App as BevyApp, IntoScheduleConfigs, Plugin, PostUpdate};
 use bevy::winit::WinitSettings;
 
 pub use find_folder;
@@ -56,6 +56,11 @@ pub struct NannouPlugin;
 impl Plugin for NannouPlugin {
     fn build(&self, app: &mut BevyApp) {
         app.add_plugins(nannou_draw::NannouDrawPlugin);
+        // Keep each default window camera's orthographic z range sized to its window.
+        app.add_systems(
+            PostUpdate,
+            window::update_default_camera_z_range.before(bevy::camera::CameraUpdateSystems),
+        );
         // `FramePlugin` extracts per-window scale factors so a `Frame` can be constructed from a
         // (custom or classic) render-world system.
         app.add_plugins(crate::frame::FramePlugin);

--- a/nannou/src/render/compute.rs
+++ b/nannou/src/render/compute.rs
@@ -9,8 +9,9 @@ use bevy::{
         Render, RenderSystems,
         extract_component::ExtractComponentPlugin,
         render_resource::{
-            BindGroupLayoutDescriptor, CachedComputePipelineId, ComputePipelineDescriptor,
-            PipelineCache, SpecializedComputePipeline, SpecializedComputePipelines,
+            AsBindGroupError, BindGroupLayoutDescriptor, CachedComputePipelineId,
+            ComputePipelineDescriptor, PipelineCache, SpecializedComputePipeline,
+            SpecializedComputePipelines,
         },
         renderer::{RenderContext, RenderDevice, ViewQuery},
     },
@@ -148,15 +149,22 @@ fn prepare_bind_group<CM>(
     CM: Compute,
 {
     for (view, compute_model) in views_q.iter() {
-        let bind_group = compute_model
-            .0
-            .as_bind_group(
-                &pipeline.layout_descriptor,
-                &render_device,
-                &pipeline_cache,
-                &mut bind_group_param,
-            )
-            .expect("Failed to create bind group");
+        let bind_group = match compute_model.0.as_bind_group(
+            &pipeline.layout_descriptor,
+            &render_device,
+            &pipeline_cache,
+            &mut bind_group_param,
+        ) {
+            Ok(bind_group) => bind_group,
+            // Assets referenced by the bind group (e.g. `ShaderBuffer`s created this
+            // frame) may not have been prepared yet. Drop any stale bind group so
+            // nothing is dispatched for this view, and retry next frame.
+            Err(AsBindGroupError::RetryNextUpdate) => {
+                commands.entity(view).remove::<ComputeBindGroup>();
+                continue;
+            }
+            Err(e) => panic!("Failed to create compute bind group: {e:?}"),
+        };
         commands
             .entity(view)
             .insert(ComputeBindGroup(bind_group.bind_group));

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -383,6 +383,7 @@ where
         let user_functions = WindowUserFunctions(user_functions);
         // Remember the window so it can be read back before the deferred spawn is applied.
         let window_for_cache = window.clone();
+        let half_z_range = default_camera_half_z_range(&window_for_cache);
 
         // On wasm we reuse the existing primary window (created up-front so the renderer has a
         // canvas) rather than spawning a new one.
@@ -427,9 +428,14 @@ where
                         },
                         RenderTarget::Window(WindowRef::Entity(window_entity)),
                         Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-                        Projection::Orthographic(OrthographicProjection::default_3d()),
+                        Projection::Orthographic(OrthographicProjection {
+                            near: -half_z_range,
+                            far: half_z_range,
+                            ..OrthographicProjection::default_3d()
+                        }),
                         layer.clone(),
                         NannouCamera,
+                        WindowDefaultCamera,
                     ));
                     if hdr {
                         camera.insert(Hdr);
@@ -609,5 +615,51 @@ impl<M> fmt::Debug for View<M> {
         };
 
         write!(f, "View::{}", variant)
+    }
+}
+
+/// Marks the default camera spawned for a window when none was provided via the window
+/// builder. Nannou manages this camera's orthographic projection to match its window.
+#[derive(Component)]
+pub(crate) struct WindowDefaultCamera;
+
+// The half-extent of the z range visible to a window's default camera, matching the
+// pre-bevy renderer: content within +-max(width, height) of the xy plane is visible.
+fn default_camera_half_z_range(window: &bevy::window::Window) -> f32 {
+    window.width().max(window.height())
+}
+
+/// Keep each default window camera's orthographic z range sized to its window, so that
+/// 3D draw content up to the size of the window renders without near/far clipping while
+/// depth precision stays proportionate to the scene.
+pub(crate) fn update_default_camera_z_range(
+    mut cameras: Query<(&mut Projection, &RenderTarget), With<WindowDefaultCamera>>,
+    windows: Query<&bevy::window::Window>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+) {
+    for (mut projection, target) in cameras.iter_mut() {
+        let window = match target {
+            RenderTarget::Window(WindowRef::Entity(entity)) => *entity,
+            RenderTarget::Window(WindowRef::Primary) => match primary_window.single() {
+                Ok(entity) => entity,
+                Err(_) => continue,
+            },
+            _ => continue,
+        };
+        let Ok(window) = windows.get(window) else {
+            continue;
+        };
+        let half_z_range = default_camera_half_z_range(window);
+        let Projection::Orthographic(ortho) = projection.as_ref() else {
+            continue;
+        };
+        // Only write through the `Mut` when the range actually changes, to avoid
+        // triggering change detection every frame.
+        if ortho.near != -half_z_range || ortho.far != half_z_range {
+            if let Projection::Orthographic(ortho) = &mut *projection {
+                ortho.near = -half_z_range;
+                ortho.far = half_z_range;
+            }
+        }
     }
 }

--- a/nannou_draw/src/draw/primitive/mesh.rs
+++ b/nannou_draw/src/draw/primitive/mesh.rs
@@ -37,12 +37,7 @@ impl Vertexless {
     /// coordinates in that order, e.g. `(point, tex_coords)`. `point` may be of any type that
     /// implements `Into<Vec3>` and `tex_coords` may be of any type that implements
     /// `Into<Vec2>`.
-    pub fn points_textured<I, P, T>(
-        self,
-        inner_mesh: &mut Mesh,
-        texture_handle: Handle<Image>,
-        points: I,
-    ) -> PrimitiveMesh
+    pub fn points_textured<I, P, T>(self, inner_mesh: &mut Mesh, points: I) -> PrimitiveMesh
     where
         I: IntoIterator<Item = (P, T)>,
         P: Into<Vec3>,
@@ -54,7 +49,7 @@ impl Vertexless {
             let tex_coords = t.into();
             (point, color, tex_coords)
         });
-        self.points_inner(inner_mesh, points, Some(texture_handle))
+        self.points_inner(inner_mesh, points)
     }
 
     /// Describe the mesh with a sequence of colored points.
@@ -74,7 +69,7 @@ impl Vertexless {
             let tex_coords = Vec2::ZERO;
             (point, color, tex_coords)
         });
-        self.points_inner(inner_mesh, vertices, None)
+        self.points_inner(inner_mesh, vertices)
     }
 
     /// Describe the mesh with a sequence of points.
@@ -95,17 +90,12 @@ impl Vertexless {
             let tex_coords = Vec2::ZERO;
             (point, color, tex_coords)
         });
-        let mut mesh = self.points_inner(inner_mesh, vertices, None);
+        let mut mesh = self.points_inner(inner_mesh, vertices);
         mesh.fill_color = Some(FillColor(None));
         mesh
     }
 
-    fn points_inner<I>(
-        self,
-        inner_mesh: &mut Mesh,
-        vertices: I,
-        texture_handle: Option<Handle<Image>>,
-    ) -> PrimitiveMesh
+    fn points_inner<I>(self, inner_mesh: &mut Mesh, vertices: I) -> PrimitiveMesh
     where
         I: Iterator<Item = Vertex>,
     {
@@ -122,7 +112,7 @@ impl Vertexless {
         }
         let v_end = inner_mesh.count_vertices();
         let i_end = inner_mesh.count_indices();
-        PrimitiveMesh::new(v_start..v_end, i_start..i_end, texture_handle)
+        PrimitiveMesh::new(v_start..v_end, i_start..i_end)
     }
 
     /// Describe the mesh with a sequence of textured triangles.
@@ -131,12 +121,7 @@ impl Vertexless {
     /// coordinates in that order, e.g. `(point, tex_coords)`. `point` may be of any type that
     /// implements `Into<Vec3>` and `tex_coords` may be of any type that implements
     /// `Into<Vec2>`.
-    pub fn tris_textured<I, P, T>(
-        self,
-        inner_mesh: &mut Mesh,
-        texture_handle: Handle<Image>,
-        tris: I,
-    ) -> PrimitiveMesh
+    pub fn tris_textured<I, P, T>(self, inner_mesh: &mut Mesh, tris: I) -> PrimitiveMesh
     where
         I: IntoIterator<Item = geom::Tri<(P, T)>>,
         P: Into<Vec3>,
@@ -146,7 +131,7 @@ impl Vertexless {
             .into_iter()
             .map(|t| t.map_vertices(|(p, t)| (p.into(), t.into())))
             .flat_map(geom::Tri::vertices);
-        self.points_textured(inner_mesh, texture_handle, points)
+        self.points_textured(inner_mesh, points)
     }
 
     /// Describe the mesh with a sequence of colored triangles.
@@ -198,7 +183,6 @@ impl Vertexless {
     pub fn indexed_textured<V, I, P, T>(
         self,
         inner_mesh: &mut Mesh,
-        texture_handle: Handle<Image>,
         points: V,
         indices: I,
     ) -> PrimitiveMesh
@@ -214,7 +198,7 @@ impl Vertexless {
             let tex_coords = t.into();
             (point, color, tex_coords)
         });
-        self.indexed_inner(inner_mesh, vertices, indices, Some(texture_handle))
+        self.indexed_inner(inner_mesh, vertices, indices)
     }
 
     /// Describe the mesh with the given indexed, colored points.
@@ -242,7 +226,7 @@ impl Vertexless {
             let tex_coords = Vec2::ZERO;
             (point, color, tex_coords)
         });
-        self.indexed_inner(inner_mesh, vertices, indices, None)
+        self.indexed_inner(inner_mesh, vertices, indices)
     }
 
     /// Describe the mesh with the given indexed points.
@@ -262,18 +246,12 @@ impl Vertexless {
             let tex_coords = Vec2::ZERO;
             (point, color, tex_coords)
         });
-        let mut mesh = self.indexed_inner(inner_mesh, vertices, indices, None);
+        let mut mesh = self.indexed_inner(inner_mesh, vertices, indices);
         mesh.fill_color = Some(FillColor(None));
         mesh
     }
 
-    fn indexed_inner<V, I>(
-        self,
-        inner_mesh: &mut Mesh,
-        vertices: V,
-        indices: I,
-        texture_handle: Option<Handle<Image>>,
-    ) -> PrimitiveMesh
+    fn indexed_inner<V, I>(self, inner_mesh: &mut Mesh, vertices: V, indices: I) -> PrimitiveMesh
     where
         V: IntoIterator<Item = Vertex>,
         I: IntoIterator<Item = usize>,
@@ -295,18 +273,13 @@ impl Vertexless {
 
         let v_end = inner_mesh.count_vertices();
         let i_end = inner_mesh.count_indices();
-        PrimitiveMesh::new(v_start..v_end, i_start..i_end, texture_handle)
+        PrimitiveMesh::new(v_start..v_end, i_start..i_end)
     }
 }
 
 impl PrimitiveMesh {
     // Initialise a new `Mesh` with its ranges into the intermediary mesh, ready for drawing.
-    fn new(
-        vertex_range: ops::Range<usize>,
-        index_range: ops::Range<usize>,
-        // TODO: remove this?
-        _texture_handle: Option<Handle<Image>>,
-    ) -> Self {
+    fn new(vertex_range: ops::Range<usize>, index_range: ops::Range<usize>) -> Self {
         let orientation = Default::default();
         let position = Default::default();
         let fill_color = None;
@@ -369,7 +342,11 @@ where
         P: Into<Vec3>,
         T: Into<Vec2>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.points_textured(ctxt.mesh, texture_handle, points))
+        self.map_shader_model(|mut model| {
+            model.set_texture(texture_handle);
+            model
+        })
+        .map_ty_with_context(|ty, ctxt| ty.points_textured(ctxt.mesh, points))
     }
 
     /// Describe the mesh with a sequence of triangles.
@@ -418,7 +395,11 @@ where
         P: Into<Vec3>,
         T: Into<Vec2>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.tris_textured(ctxt.mesh, texture_handle, tris))
+        self.map_shader_model(|mut model| {
+            model.set_texture(texture_handle);
+            model
+        })
+        .map_ty_with_context(|ty, ctxt| ty.tris_textured(ctxt.mesh, tris))
     }
 
     /// Describe the mesh with the given indexed points.
@@ -472,9 +453,11 @@ where
         P: Into<Vec3>,
         T: Into<Vec2>,
     {
-        self.map_ty_with_context(|ty, ctxt| {
-            ty.indexed_textured(ctxt.mesh, texture_handle, points, indices)
+        self.map_shader_model(|mut model| {
+            model.set_texture(texture_handle);
+            model
         })
+        .map_ty_with_context(|ty, ctxt| ty.indexed_textured(ctxt.mesh, points, indices))
     }
 }
 

--- a/nannou_draw/src/render.rs
+++ b/nannou_draw/src/render.rs
@@ -79,6 +79,13 @@ pub trait ShaderModel:
         ShaderRef::Default
     }
 
+    /// Set the model's primary texture, e.g. as provided via draw API methods like
+    /// `draw.mesh().points_textured(..)`.
+    ///
+    /// The default implementation ignores the texture; models with a texture slot (like
+    /// [`NannouShaderModel`]) bind it for sampling in their fragment shader.
+    fn set_texture(&mut self, _texture: Handle<Image>) {}
+
     /// Specializes the render pipeline descriptor for this shader model.
     fn specialize(
         _pipeline: &ShaderModelPipeline<Self>,
@@ -576,6 +583,10 @@ where
 }
 
 impl ShaderModel for NannouShaderModel {
+    fn set_texture(&mut self, texture: Handle<Image>) {
+        self.texture = Some(texture);
+    }
+
     fn specialize(
         _pipeline: &ShaderModelPipeline<Self>,
         descriptor: &mut RenderPipelineDescriptor,

--- a/nannou_draw/src/render.rs
+++ b/nannou_draw/src/render.rs
@@ -536,6 +536,11 @@ where
     ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
         let mut descriptor = self.mesh_pipeline.specialize(key.mesh_key, layout)?;
 
+        // The draw API makes no winding-order guarantees - e.g. 2D primitives may wind
+        // either way depending on their orientation - so, like the pre-bevy nannou
+        // renderer, cull nothing. Models may override this in their `specialize`.
+        descriptor.primitive.cull_mode = None;
+
         if let Some(vertex_shader) = &self.vertex_shader {
             descriptor.vertex.shader = vertex_shader.clone();
             descriptor.vertex.shader_defs.push(ShaderDefVal::UInt(


### PR DESCRIPTION
Related to #1008 

Four framework fixes surfaced by running through the examples post bevy-refactor (`draw_mesh`, `draw_textured_mesh`, `particle_sdf`), each in its own commit:

## Disable back-face culling in the draw renderer

Bevy's mesh pipeline culls back faces by default, but the draw API makes no winding-order guarantees - e.g. `draw_mesh`'s sine wave builds quads whose winding flips with the sign of the wave, so the entire positive half was culled. Set `cull_mode = None` when specialising the shader model pipeline, matching the pre-bevy renderer; custom models may still override it in `specialize`.

## Bind textures passed to the mesh drawing API

`draw.mesh().points_textured(..)` (and `tris_textured`/`indexed_textured`) accepted a texture handle but dropped it on the floor, so textured meshes rendered flat white. The handle now routes into the drawing's shader model via a new `ShaderModel::set_texture` hook (no-op by default, binds the texture slot on `NannouShaderModel`) - the same mechanism `Drawing::texture` uses.

## Size the default camera's ortho z range to the window

The default window camera used `OrthographicProjection::default_3d()` (near 0, far 1000) at z = 10, so everything in front of the xy plane was near-clipped - `draw_textured_mesh`'s rotating cube always appeared cut open. Match the pre-bevy renderer's symmetric +-max(width, height) range, kept up to date on resize. Only cameras spawned by the window builder are managed (new `WindowDefaultCamera` marker); user-built cameras keep their projections.

## Retry compute bind group creation instead of panicking

`prepare_bind_group` panicked on `AsBindGroupError::RetryNextUpdate`, which just means an asset the compute model references (e.g. a `ShaderBuffer` created the same frame) isn't prepared in the render world yet. This raced at startup and reliably killed `particle_sdf` on launch. Skip the view and retry next frame instead, removing any stale bind group; other errors still panic.