### PR TITLE
refactor(draw)!: de-generify `Draw` and `Drawing` (dynamic drawing representation)

### DIFF
--- a/examples/compute/particle_mouse.rs
+++ b/examples/compute/particle_mouse.rs
@@ -178,19 +178,19 @@ fn view(app: &App, model: &Model) {
     }
 }
 
-fn draw_particles_circle(draw: &Draw<ShaderModel>) {
+fn draw_particles_circle(draw: &Draw) {
     draw.instanced()
         .primitive(draw.ellipse().w_h(5.0, 5.0))
         .range(0..NUM_PARTICLES);
 }
 
-fn draw_particles_square(draw: &Draw<ShaderModel>) {
+fn draw_particles_square(draw: &Draw) {
     draw.instanced()
         .primitive(draw.rect().w_h(5.0, 5.0))
         .range(0..NUM_PARTICLES);
 }
 
-fn draw_particles_triangle(draw: &Draw<ShaderModel>) {
+fn draw_particles_triangle(draw: &Draw) {
     draw.instanced()
         .primitive(draw.tri().w_h(5.0, 5.0))
         .range(0..NUM_PARTICLES);

--- a/examples/draw/draw_custom_shader_model.rs
+++ b/examples/draw/draw_custom_shader_model.rs
@@ -32,7 +32,7 @@ fn view(app: &App, _model: &Model, _window: Entity) {
 
     // We can also map the shader model manually
     draw.ellipse()
-        .map_shader_model(|mut mat| {
+        .map_shader_model(|mut mat: ShaderModel| {
             mat.color = BLUE.into();
             mat
         })

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -70,6 +70,24 @@ ECS, renderer, asset system and plugins) is now available to nannou apps.
   enabled by default) is the default face.
 - The `view` function no longer receives or returns a `Frame`; it is simply
   called each time a window needs to be redrawn.
+- `Draw` and `Drawing` no longer carry a shader-model type parameter
+  ([#1054](https://github.com/nannou-org/nannou/issues/1054)). The drawing
+  state was already stored type-erased, so the parameter only bloated
+  monomorphisation in downstream sketches. `Draw<SM>` is now `Draw`,
+  `Drawing<'a, T, SM>` is `Drawing<'a, T>` (where `T` is a zero-cost marker
+  gating the per-primitive builder methods), and likewise for `Background`,
+  `Instanced` and `Indirect`. Consequences:
+  - `Drawing::map_shader_model::<SM>(..)` is checked at runtime: the closure
+    parameter now needs a type annotation (e.g. `|mut mat: MyModel|`), and if
+    the active model is not an `SM` a warning is emitted once and the mapping
+    is skipped.
+  - `Draw::{alpha_blend,color_blend,blend,polygon_mode}` and
+    `Drawing::base_color` only apply to the default nannou shader model; with
+    a custom model active they warn once and no-op.
+  - `Drawing::texture(..)` now works with *any* shader model via
+    `ShaderModel::set_texture` (previously restricted to the default model).
+  - `Drawing::map_ty` and the `Into<Option<T>>` conversions on `Primitive`
+    are removed; builder methods now mutate the stored primitive in place.
 
 ### Dependencies & toolchain
 

--- a/nannou_draw/Cargo.toml
+++ b/nannou_draw/Cargo.toml
@@ -35,3 +35,7 @@ notosans = ["dep:notosans"]
 # Discover fonts installed on the system (e.g. via fontconfig on Linux),
 # making them available to `draw.text().font(..)` by family name.
 system_font_discovery = ["bevy/system_font_discovery", "parley/system"]
+
+[[bench]]
+name = "drawing"
+harness = false

--- a/nannou_draw/benches/drawing.rs
+++ b/nannou_draw/benches/drawing.rs
@@ -1,0 +1,64 @@
+//! A simple timing benchmark for building a frame's worth of draw commands.
+//!
+//! Run with `cargo bench -p nannou_draw`.
+
+use std::hint::black_box;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use bevy::prelude::*;
+use nannou_draw::draw::Draw;
+use nannou_draw::text::font::{NannouTextCxInner, SharedTextCx};
+use parley::{FontContext, LayoutContext};
+
+const ITERS: usize = 20;
+const ELLIPSES: usize = 10_000;
+const POLYLINES: usize = 1_000;
+const POLYLINE_POINTS: usize = 100;
+
+fn main() {
+    let text_cx = SharedTextCx(Arc::new(Mutex::new(NannouTextCxInner {
+        font: FontContext::default(),
+        layout: LayoutContext::new(),
+    })));
+    let mut draw: Draw = Draw::new(Entity::PLACEHOLDER, text_cx);
+
+    let mut times = Vec::with_capacity(ITERS);
+    for _ in 0..ITERS {
+        draw.reset();
+        let start = Instant::now();
+        build_frame(&draw);
+        let cmds = draw.drain_commands().count();
+        times.push(start.elapsed());
+        black_box(cmds);
+    }
+
+    times.sort();
+    let median = times[times.len() / 2];
+    let min = times[0];
+    let max = times[times.len() - 1];
+    println!(
+        "build_frame ({ELLIPSES} ellipses x 6 props + {POLYLINES} polylines x {POLYLINE_POINTS} \
+         points): median {median:?}, min {min:?}, max {max:?} over {ITERS} iters"
+    );
+}
+
+fn build_frame(draw: &Draw) {
+    for i in 0..ELLIPSES {
+        let f = i as f32;
+        draw.ellipse()
+            .x_y(f % 100.0, f % 50.0)
+            .radius(5.0 + (f % 10.0))
+            .color(Color::srgb(0.5, 0.2, 0.8))
+            .stroke(Color::WHITE)
+            .stroke_weight(2.0)
+            .rotate(f * 0.01);
+    }
+    for i in 0..POLYLINES {
+        let f = i as f32;
+        draw.polyline()
+            .weight(2.0)
+            .color(Color::srgb(0.1, 0.9, 0.4))
+            .points((0..POLYLINE_POINTS).map(|p| Vec2::new(p as f32, (p as f32 + f).sin())));
+    }
+}

--- a/nannou_draw/src/draw/background.rs
+++ b/nannou_draw/src/draw/background.rs
@@ -1,28 +1,18 @@
 use bevy::prelude::Color;
 
 use crate::draw::{Draw, DrawCommand};
-use crate::render::ShaderModel;
 
 /// A type used to update the background colour.
-pub struct Background<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
-    draw: &'a Draw<SM>,
+pub struct Background<'a> {
+    draw: &'a Draw,
 }
 
 /// Begin coloring the background.
-pub fn new<SM>(draw: &Draw<SM>) -> Background<'_, SM>
-where
-    SM: ShaderModel + Default,
-{
+pub fn new(draw: &Draw) -> Background<'_> {
     Background { draw }
 }
 
-impl<'a, SM> Background<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> Background<'a> {
     /// Clear the background with the given color.
     ///
     /// This method supports any color type that can be converted into RGBA.

--- a/nannou_draw/src/draw/drawing.rs
+++ b/nannou_draw/src/draw/drawing.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 
 use crate::draw::primitive::Primitive;
 use crate::draw::properties::{
-    SetColor, SetDimensions, SetFill, SetOrientation, SetPosition, SetStroke,
+    SetColor, SetDimensions, SetFill, SetOrientation, SetPosition, SetStroke, color, fill,
+    spatial::{dimension, orientation, position},
+    stroke,
 };
 use crate::draw::{Draw, DrawCommand, DrawRef};
 use crate::render::{DefaultNannouShaderModel, ErasedShaderModel, ShaderModel};
@@ -25,7 +27,7 @@ use crate::render::{DefaultNannouShaderModel, ErasedShaderModel, ShaderModel};
 /// **Drawing** can be thought of as a way of specifying properties for a node.
 pub struct Drawing<'a, T> {
     // The `Draw` instance used to create this drawing.
-    draw: DrawRef<'a>,
+    pub(crate) draw: DrawRef<'a>,
     // The draw command index of the primitive being drawn.
     pub(crate) index: usize,
     // The draw command index of the shader model being used.
@@ -69,7 +71,7 @@ where
 impl<'a, T> Drop for Drawing<'a, T> {
     fn drop(&mut self) {
         if self.finish_on_drop {
-            self.finish_inner()
+            finish_drawing(&self.draw, self.index, self.shader_model_index)
         }
     }
 }
@@ -93,39 +95,33 @@ impl<'a> DrawingContext<'a> {
 }
 
 impl<'a, T> Drawing<'a, T> {
-    // Shared between the **finish** method and the **Drawing**'s **Drop** implementation.
-    //
-    // 1. Create vertices based on node-specific position, points, etc.
-    // 2. Insert edges into geom graph based on
-    fn finish_inner(&mut self) {
-        match (*self.draw).state.try_write() {
-            Err(err) => eprintln!("drawing failed to borrow state and finish: {}", err),
-            Ok(mut state) => {
-                match &self.draw {
-                    // If we are "Owned", that means we mutated our shader model and so need to
-                    // spawn a new entity just for this primitive.
-                    DrawRef::Owned(draw) => {
-                        let id = draw.shader_model.clone();
-                        let shader_model_cmd = state
-                            .draw_commands
-                            .get_mut(self.shader_model_index)
-                            .expect("Expected a valid shdaer model index");
-                        if let None = shader_model_cmd {
-                            *shader_model_cmd = Some(DrawCommand::ShaderModel(id));
-                        }
-                    }
-                    DrawRef::Borrowed(_) => (),
-                }
-                state.finish_drawing(self.index);
-            }
-        }
-    }
-
     /// Complete the drawing and insert it into the parent **Draw** instance.
     ///
     /// This will be called when the **Drawing** is **Drop**ped if it has not yet been called.
     pub fn finish(mut self) {
-        self.finish_inner()
+        self.finish_on_drop = false;
+        finish_drawing(&self.draw, self.index, self.shader_model_index)
+    }
+
+    // Consume the drawing, producing an equivalent drawing for the next type-state `U`.
+    //
+    // The conversion of the stored primitive itself is expected to have already been performed
+    // (e.g. via `with_primitive`).
+    pub(crate) fn transition<U>(mut self) -> Drawing<'a, U> {
+        self.finish_on_drop = false;
+        let Drawing {
+            ref draw,
+            index,
+            shader_model_index,
+            ..
+        } = self;
+        Drawing {
+            draw: draw.clone(),
+            index,
+            shader_model_index,
+            finish_on_drop: true,
+            _ty: PhantomData,
+        }
     }
 
     /// Map the parent's shader model to a new instance, drawing this primitive and any
@@ -200,116 +196,13 @@ impl<'a, T> Drawing<'a, T> {
             _ty: PhantomData,
         }
     }
-
-    // Map the given function onto the primitive stored within **Draw** at `index`.
-    //
-    // The functionn is only applied if the node has not yet been **Drawn**.
-    fn map_primitive<F, T2>(mut self, map: F) -> Drawing<'a, T2>
-    where
-        F: FnOnce(Primitive) -> Primitive,
-        T2: Into<Primitive> + Clone,
-    {
-        if let Ok(mut state) = self.draw.state.try_write() {
-            if let Some(mut primitive) = state.drawing.remove(&self.index) {
-                primitive = map(primitive);
-                state.drawing.insert(self.index, primitive);
-            }
-        }
-        self.finish_on_drop = false;
-        let Drawing {
-            ref draw,
-            index,
-            shader_model_index,
-            ..
-        } = self;
-        Drawing {
-            draw: draw.clone(),
-            index,
-            shader_model_index,
-            finish_on_drop: true,
-            _ty: PhantomData,
-        }
-    }
-
-    // The same as `map_primitive` but also passes a mutable reference to the vertex data to the
-    // map function. This is useful for types that may have an unknown number of arbitrary
-    // vertices.
-    fn map_primitive_with_context<F, T2>(mut self, map: F) -> Drawing<'a, T2>
-    where
-        F: FnOnce(Primitive, DrawingContext) -> Primitive,
-        T2: Into<Primitive> + Clone,
-    {
-        if let Ok(mut state) = self.draw.state.try_write() {
-            if let Some(mut primitive) = state.drawing.remove(&self.index) {
-                {
-                    let mut intermediary_state = state.intermediary_state.write().unwrap();
-                    let ctxt = DrawingContext::from_intermediary_state(&mut *intermediary_state);
-                    primitive = map(primitive, ctxt);
-                }
-                state.drawing.insert(self.index, primitive);
-            }
-        }
-        self.finish_on_drop = false;
-        let Drawing {
-            ref draw,
-            index,
-            shader_model_index,
-            ..
-        } = self;
-        Drawing {
-            draw: draw.clone(),
-            index,
-            shader_model_index,
-            finish_on_drop: true,
-            _ty: PhantomData,
-        }
-    }
-
-    /// Apply the given function to the type stored within **Draw**.
-    ///
-    /// The function is only applied if the node has not yet been **Drawn**.
-    ///
-    /// **Panics** if the primitive does not contain type **T**.
-    pub fn map_ty<F, T2>(self, map: F) -> Drawing<'a, T2>
-    where
-        F: FnOnce(T) -> T2,
-        T2: Into<Primitive> + Clone,
-        Primitive: Into<Option<T>>,
-    {
-        self.map_primitive(|prim| {
-            let maybe_ty: Option<T> = prim.into();
-            let ty = maybe_ty.expect("expected `T` but primitive contained different type");
-            let ty2 = map(ty);
-            ty2.into()
-        })
-    }
-
-    /// Apply the given function to the type stored within **Draw**.
-    ///
-    /// The function is only applied if the node has not yet been **Drawn**.
-    ///
-    /// **Panics** if the primitive does not contain type **T**.
-    pub(crate) fn map_ty_with_context<F, T2>(self, map: F) -> Drawing<'a, T2>
-    where
-        F: FnOnce(T, DrawingContext) -> T2,
-        T2: Into<Primitive> + Clone,
-        Primitive: Into<Option<T>>,
-    {
-        self.map_primitive_with_context(|prim, ctxt| {
-            let maybe_ty: Option<T> = prim.into();
-            let ty = maybe_ty.expect("expected `T` but primitive contained different type");
-            let ty2 = map(ty, ctxt);
-            ty2.into()
-        })
-    }
 }
 
 // SetColor implementations.
 
 impl<'a, T> Drawing<'a, T>
 where
-    T: SetColor + Into<Primitive> + Clone,
-    Primitive: Into<Option<T>>,
+    T: SetColor,
 {
     /// Specify a color.
     ///
@@ -320,35 +213,36 @@ where
     where
         C: Into<Color>,
     {
-        self.map_ty(|ty| SetColor::color(ty, color))
+        color::set_color(&self.draw, self.index, color.into());
+        self
     }
 
     /// Specify the color via red, green and blue channels.
     pub fn srgb(self, r: f32, g: f32, b: f32) -> Self {
-        self.map_ty(|ty| SetColor::srgb(ty, r, g, b))
+        self.color(Color::srgb(r, g, b))
     }
 
     /// Specify the color via red, green and blue channels as bytes
     pub fn srgb_u8(self, r: u8, g: u8, b: u8) -> Self {
-        self.map_ty(|ty| SetColor::srgb_u8(ty, r, g, b))
+        self.color(Color::srgb_u8(r, g, b))
     }
 
     /// Specify the color via red, green, blue and alpha channels.
     pub fn srgba(self, r: f32, g: f32, b: f32, a: f32) -> Self {
-        self.map_ty(|ty| SetColor::srgba(ty, r, g, b, a))
+        self.color(Color::srgba(r, g, b, a))
     }
 
     /// Specify the color via red, green, blue and alpha channels as bytes.
     pub fn srgba_u8(self, r: u8, g: u8, b: u8, a: u8) -> Self {
-        self.map_ty(|ty| SetColor::srgba_u8(ty, r, g, b, a))
+        self.color(Color::srgba_u8(r, g, b, a))
     }
 
     pub fn linear_rgb(self, r: f32, g: f32, b: f32) -> Self {
-        self.map_ty(|ty| SetColor::linear_rgb(ty, r, g, b))
+        self.color(Color::linear_rgb(r, g, b))
     }
 
     pub fn linear_rgba(self, r: f32, g: f32, b: f32, a: f32) -> Self {
-        self.map_ty(|ty| SetColor::linear_rgba(ty, r, g, b, a))
+        self.color(Color::linear_rgba(r, g, b, a))
     }
 
     /// Specify the color via hue, saturation and luminance.
@@ -361,7 +255,7 @@ where
     /// See the [wikipedia entry](https://en.wikipedia.org/wiki/HSL_and_HSV) for more details on
     /// this color space.
     pub fn hsl(self, h: f32, s: f32, l: f32) -> Self {
-        self.map_ty(|ty| SetColor::hsl(ty, h, s, l))
+        self.color(Color::hsl(h * 360.0, s, l))
     }
 
     /// Specify the color via hue, saturation, luminance and an alpha channel.
@@ -374,7 +268,7 @@ where
     /// See the [wikipedia entry](https://en.wikipedia.org/wiki/HSL_and_HSV) for more details on
     /// this color space.
     pub fn hsla(self, h: f32, s: f32, l: f32, a: f32) -> Self {
-        self.map_ty(|ty| SetColor::hsla(ty, h, s, l, a))
+        self.color(Color::hsla(h * 360.0, s, l, a))
     }
 
     /// Specify the color via hue, saturation and *value* (brightness).
@@ -387,7 +281,7 @@ where
     /// See the [wikipedia entry](https://en.wikipedia.org/wiki/HSL_and_HSV) for more details on
     /// this color space.
     pub fn hsv(self, h: f32, s: f32, v: f32) -> Self {
-        self.map_ty(|ty| SetColor::hsv(ty, h, s, v))
+        self.color(Color::hsv(h * 360.0, s, v))
     }
 
     /// Specify the color via hue, saturation, *value* (brightness) and an alpha channel.
@@ -400,62 +294,62 @@ where
     /// See the [wikipedia entry](https://en.wikipedia.org/wiki/HSL_and_HSV) for more details on
     /// this color space.
     pub fn hsva(self, h: f32, s: f32, v: f32, a: f32) -> Self {
-        self.map_ty(|ty| SetColor::hsva(ty, h, s, v, a))
+        self.color(Color::hsva(h * 360.0, s, v, a))
     }
 
     pub fn hwb(self, h: f32, w: f32, b: f32) -> Self {
-        self.map_ty(|ty| SetColor::hwb(ty, h, w, b))
+        self.color(Color::hwb(h * 360.0, w, b))
     }
 
     pub fn hwba(self, h: f32, w: f32, b: f32, a: f32) -> Self {
-        self.map_ty(|ty| SetColor::hwba(ty, h, w, b, a))
+        self.color(Color::hwba(h * 360.0, w, b, a))
     }
 
     pub fn lab(self, l: f32, a: f32, b: f32) -> Self {
-        self.map_ty(|ty| SetColor::lab(ty, l, a, b))
+        self.color(Color::lab(l, a, b))
     }
 
     pub fn laba(self, l: f32, a: f32, b: f32, alpha: f32) -> Self {
-        self.map_ty(|ty| SetColor::laba(ty, l, a, b, alpha))
+        self.color(Color::laba(l, a, b, alpha))
     }
 
     pub fn lch(self, l: f32, c: f32, h: f32) -> Self {
-        self.map_ty(|ty| SetColor::lch(ty, l, c, h))
+        self.color(Color::lch(l, c, h))
     }
 
     pub fn lcha(self, l: f32, c: f32, h: f32, alpha: f32) -> Self {
-        self.map_ty(|ty| SetColor::lcha(ty, l, c, h, alpha))
+        self.color(Color::lcha(l, c, h, alpha))
     }
 
     pub fn oklab(self, l: f32, a: f32, b: f32) -> Self {
-        self.map_ty(|ty| SetColor::oklab(ty, l, a, b))
+        self.color(Color::oklab(l, a, b))
     }
 
     pub fn oklaba(self, l: f32, a: f32, b: f32, alpha: f32) -> Self {
-        self.map_ty(|ty| SetColor::oklaba(ty, l, a, b, alpha))
+        self.color(Color::oklaba(l, a, b, alpha))
     }
 
     pub fn oklch(self, l: f32, c: f32, h: f32) -> Self {
-        self.map_ty(|ty| SetColor::oklch(ty, l, c, h))
+        self.color(Color::oklch(l, c, h))
     }
 
     pub fn oklcha(self, l: f32, c: f32, h: f32, alpha: f32) -> Self {
-        self.map_ty(|ty| SetColor::oklcha(ty, l, c, h, alpha))
+        self.color(Color::oklcha(l, c, h, alpha))
     }
 
     pub fn cie_xyz(self, x: f32, y: f32, z: f32) -> Self {
-        self.map_ty(|ty| SetColor::cie_xyz(ty, x, y, z))
+        self.color(Color::xyz(x, y, z))
     }
 
     pub fn cie_xyza(self, x: f32, y: f32, z: f32, alpha: f32) -> Self {
-        self.map_ty(|ty| SetColor::cie_xyza(ty, x, y, z, alpha))
+        self.color(Color::xyza(x, y, z, alpha))
     }
 
     /// Specify the color as gray scale
     ///
     /// The given g expects a value between `0.0` and `1.0` where `0.0` is black and `1.0` is white
     pub fn gray(self, g: f32) -> Self {
-        self.map_ty(|ty| SetColor::gray(ty, g))
+        self.color(Color::srgb(g, g, g))
     }
 }
 
@@ -463,57 +357,63 @@ where
 
 impl<'a, T> Drawing<'a, T>
 where
-    T: SetDimensions + Into<Primitive> + Clone,
-    Primitive: Into<Option<T>>,
+    T: SetDimensions,
 {
     /// Set the absolute width for the node.
     pub fn width(self, w: f32) -> Self {
-        self.map_ty(|ty| SetDimensions::width(ty, w))
+        dimension::set_dimensions(&self.draw, self.index, Some(w), None, None);
+        self
     }
 
     /// Set the absolute height for the node.
     pub fn height(self, h: f32) -> Self {
-        self.map_ty(|ty| SetDimensions::height(ty, h))
+        dimension::set_dimensions(&self.draw, self.index, None, Some(h), None);
+        self
     }
 
     /// Set the absolute depth for the node.
     pub fn depth(self, d: f32) -> Self {
-        self.map_ty(|ty| SetDimensions::depth(ty, d))
+        dimension::set_dimensions(&self.draw, self.index, None, None, Some(d));
+        self
     }
 
     /// Short-hand for the **width** method.
     pub fn w(self, w: f32) -> Self {
-        self.map_ty(|ty| SetDimensions::w(ty, w))
+        self.width(w)
     }
 
     /// Short-hand for the **height** method.
     pub fn h(self, h: f32) -> Self {
-        self.map_ty(|ty| SetDimensions::h(ty, h))
+        self.height(h)
     }
 
     /// Short-hand for the **depth** method.
     pub fn d(self, d: f32) -> Self {
-        self.map_ty(|ty| SetDimensions::d(ty, d))
+        self.depth(d)
     }
 
     /// Set the **x** and **y** dimensions for the node.
     pub fn wh(self, v: Vec2) -> Self {
-        self.map_ty(|ty| SetDimensions::wh(ty, v))
+        dimension::set_dimensions(&self.draw, self.index, Some(v.x), Some(v.y), None);
+        self
     }
 
     /// Set the **x**, **y** and **z** dimensions for the node.
     pub fn whd(self, v: Vec3) -> Self {
-        self.map_ty(|ty| SetDimensions::whd(ty, v))
+        dimension::set_dimensions(&self.draw, self.index, Some(v.x), Some(v.y), Some(v.z));
+        self
     }
 
     /// Set the width and height for the node.
     pub fn w_h(self, x: f32, y: f32) -> Self {
-        self.map_ty(|ty| SetDimensions::w_h(ty, x, y))
+        dimension::set_dimensions(&self.draw, self.index, Some(x), Some(y), None);
+        self
     }
 
     /// Set the width and height for the node.
     pub fn w_h_d(self, x: f32, y: f32, z: f32) -> Self {
-        self.map_ty(|ty| SetDimensions::w_h_d(ty, x, y, z))
+        dimension::set_dimensions(&self.draw, self.index, Some(x), Some(y), Some(z));
+        self
     }
 }
 
@@ -521,42 +421,48 @@ where
 
 impl<'a, T> Drawing<'a, T>
 where
-    T: SetPosition + Into<Primitive> + Clone,
-    Primitive: Into<Option<T>>,
+    T: SetPosition,
 {
     /// Build with the given **Absolute** **Position** along the *x* axis.
     pub fn x(self, x: f32) -> Self {
-        self.map_ty(|ty| SetPosition::x(ty, x))
+        position::set_position(&self.draw, self.index, Some(x), None, None);
+        self
     }
 
     /// Build with the given **Absolute** **Position** along the *y* axis.
     pub fn y(self, y: f32) -> Self {
-        self.map_ty(|ty| SetPosition::y(ty, y))
+        position::set_position(&self.draw, self.index, None, Some(y), None);
+        self
     }
 
     /// Build with the given **Absolute** **Position** along the *z* axis.
     pub fn z(self, z: f32) -> Self {
-        self.map_ty(|ty| SetPosition::z(ty, z))
+        position::set_position(&self.draw, self.index, None, None, Some(z));
+        self
     }
 
     /// Set the **Position** with some two-dimensional point.
     pub fn xy(self, p: Vec2) -> Self {
-        self.map_ty(|ty| SetPosition::xy(ty, p))
+        position::set_position(&self.draw, self.index, Some(p.x), Some(p.y), None);
+        self
     }
 
     /// Set the **Position** with some three-dimensional point.
     pub fn xyz(self, p: Vec3) -> Self {
-        self.map_ty(|ty| SetPosition::xyz(ty, p))
+        position::set_position(&self.draw, self.index, Some(p.x), Some(p.y), Some(p.z));
+        self
     }
 
     /// Set the **Position** with *x* *y* coordinates.
     pub fn x_y(self, x: f32, y: f32) -> Self {
-        self.map_ty(|ty| SetPosition::x_y(ty, x, y))
+        position::set_position(&self.draw, self.index, Some(x), Some(y), None);
+        self
     }
 
     /// Set the **Position** with *x* *y* *z* coordinates.
     pub fn x_y_z(self, x: f32, y: f32, z: f32) -> Self {
-        self.map_ty(|ty| SetPosition::x_y_z(ty, x, y, z))
+        position::set_position(&self.draw, self.index, Some(x), Some(y), Some(z));
+        self
     }
 }
 
@@ -564,90 +470,99 @@ where
 
 impl<'a, T> Drawing<'a, T>
 where
-    T: SetOrientation + Into<Primitive> + Clone,
-    Primitive: Into<Option<T>>,
+    T: SetOrientation,
 {
     /// Describe orientation via the vector that points to the given target.
     pub fn look_at(self, target: Vec3) -> Self {
-        self.map_ty(|ty| SetOrientation::look_at(ty, target))
+        orientation::set_orientation(&self.draw, self.index, orientation::Update::LookAt(target));
+        self
     }
 
     /// Specify the orientation around the *x* axis as an absolute value in radians.
     pub fn x_radians(self, x: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::x_radians(ty, x))
+        orientation::set_orientation(&self.draw, self.index, orientation::Update::XRadians(x));
+        self
     }
 
     /// Specify the orientation around the *y* axis as an absolute value in radians.
     pub fn y_radians(self, y: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::y_radians(ty, y))
+        orientation::set_orientation(&self.draw, self.index, orientation::Update::YRadians(y));
+        self
     }
 
     /// Specify the orientation around the *z* axis as an absolute value in radians.
     pub fn z_radians(self, z: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::z_radians(ty, z))
+        orientation::set_orientation(&self.draw, self.index, orientation::Update::ZRadians(z));
+        self
     }
 
     /// Specify the orientation around the *x* axis as an absolute value in degrees.
     pub fn x_degrees(self, x: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::x_degrees(ty, x))
+        self.x_radians(x.to_radians())
     }
 
     /// Specify the orientation around the *y* axis as an absolute value in degrees.
     pub fn y_degrees(self, y: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::y_degrees(ty, y))
+        self.y_radians(y.to_radians())
     }
 
     /// Specify the orientation around the *z* axis as an absolute value in degrees.
     pub fn z_degrees(self, z: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::z_degrees(ty, z))
+        self.z_radians(z.to_radians())
     }
 
     /// Specify the orientation around the *x* axis as a number of turns around the axis.
     pub fn x_turns(self, x: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::x_turns(ty, x))
+        self.x_radians(x * std::f32::consts::TAU)
     }
 
     /// Specify the orientation around the *y* axis as a number of turns around the axis.
     pub fn y_turns(self, y: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::y_turns(ty, y))
+        self.y_radians(y * std::f32::consts::TAU)
     }
 
     /// Specify the orientation around the *z* axis as a number of turns around the axis.
     pub fn z_turns(self, z: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::z_turns(ty, z))
+        self.z_radians(z * std::f32::consts::TAU)
     }
 
     /// Specify the orientation along each axis with the given **Vector** of radians.
     ///
     /// This has the same affect as calling `self.x_radians(v.x).y_radians(v.y).z_radians(v.z)`.
     pub fn radians(self, v: Vec3) -> Self {
-        self.map_ty(|ty| SetOrientation::radians(ty, v))
+        orientation::set_orientation(&self.draw, self.index, orientation::Update::Radians(v));
+        self
     }
 
     /// Specify the orientation along each axis with the given **Vector** of degrees.
     ///
     /// This has the same affect as calling `self.x_degrees(v.x).y_degrees(v.y).z_degrees(v.z)`.
     pub fn degrees(self, v: Vec3) -> Self {
-        self.map_ty(|ty| SetOrientation::degrees(ty, v))
+        self.radians(Vec3::new(
+            v.x.to_radians(),
+            v.y.to_radians(),
+            v.z.to_radians(),
+        ))
     }
 
     /// Specify the orientation along each axis with the given **Vector** of "turns".
     ///
     /// This has the same affect as calling `self.x_turns(v.x).y_turns(v.y).z_turns(v.z)`.
     pub fn turns(self, v: Vec3) -> Self {
-        self.map_ty(|ty| SetOrientation::turns(ty, v))
+        self.radians(v * std::f32::consts::TAU)
     }
 
     /// Specify the orientation with the given **Euler**.
     ///
     /// The euler must be specified in radians.
     pub fn euler(self, e: Vec3) -> Self {
-        self.map_ty(|ty| SetOrientation::euler(ty, e))
+        self.radians(e)
     }
 
     /// Specify the orientation with the given **Quaternion**.
     pub fn quaternion(self, q: Quat) -> Self {
-        self.map_ty(|ty| SetOrientation::quaternion(ty, q))
+        orientation::set_orientation(&self.draw, self.index, orientation::Update::Quat(q));
+        self
     }
 
     // Higher level methods.
@@ -656,21 +571,21 @@ where
     ///
     /// This has the same effect as calling `x_radians`.
     pub fn pitch(self, pitch: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::pitch(ty, pitch))
+        self.x_radians(pitch)
     }
 
     /// Specify the "yaw" of the orientation in radians.
     ///
     /// This has the same effect as calling `y_radians`.
     pub fn yaw(self, yaw: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::yaw(ty, yaw))
+        self.y_radians(yaw)
     }
 
     /// Specify the "roll" of the orientation in radians.
     ///
     /// This has the same effect as calling `z_radians`.
     pub fn roll(self, roll: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::roll(ty, roll))
+        self.z_radians(roll)
     }
 
     /// Assuming we're looking at a 2D plane, positive values cause a clockwise rotation where the
@@ -678,7 +593,7 @@ where
     ///
     /// This is equivalent to calling the `z_radians` or `roll` methods.
     pub fn rotate(self, radians: f32) -> Self {
-        self.map_ty(|ty| SetOrientation::rotate(ty, radians))
+        self.z_radians(radians)
     }
 }
 
@@ -686,31 +601,38 @@ where
 
 impl<'a, T> Drawing<'a, T>
 where
-    T: SetFill + Into<Primitive> + Clone,
-    Primitive: Into<Option<T>>,
+    T: SetFill,
 {
     /// Specify the whole set of fill tessellation options.
     pub fn fill_opts(self, opts: FillOptions) -> Self {
-        self.map_ty(|ty| ty.fill_opts(opts))
+        fill::set_fill(&self.draw, self.index, fill::Update::Opts(opts));
+        self
     }
 
     /// Maximum allowed distance to the path when building an approximation.
     pub fn fill_tolerance(self, tolerance: f32) -> Self {
-        self.map_ty(|ty| ty.fill_tolerance(tolerance))
+        fill::set_fill(&self.draw, self.index, fill::Update::Tolerance(tolerance));
+        self
     }
 
     /// Specify the rule used to determine what is inside and what is outside of the shape.
     ///
     /// Currently, only the `EvenOdd` rule is implemented.
     pub fn fill_rule(self, rule: lyon::tessellation::FillRule) -> Self {
-        self.map_ty(|ty| ty.fill_rule(rule))
+        fill::set_fill(&self.draw, self.index, fill::Update::Rule(rule));
+        self
     }
 
     /// Whether to perform a vertical or horizontal traversal of the geometry.
     ///
     /// Default value: `Vertical`.
     pub fn fill_sweep_orientation(self, orientation: lyon::tessellation::Orientation) -> Self {
-        self.map_ty(|ty| ty.fill_sweep_orientation(orientation))
+        fill::set_fill(
+            &self.draw,
+            self.index,
+            fill::Update::SweepOrientation(orientation),
+        );
+        self
     }
 
     /// A fast path to avoid some expensive operations if the path is known to not have any
@@ -721,7 +643,8 @@ where
     ///
     /// Default value: `true`.
     pub fn handle_intersections(self, b: bool) -> Self {
-        self.map_ty(|ty| ty.handle_intersections(b))
+        fill::set_fill(&self.draw, self.index, fill::Update::HandleIntersections(b));
+        self
     }
 }
 
@@ -729,28 +652,30 @@ where
 
 impl<'a, T> Drawing<'a, T>
 where
-    T: SetStroke + Into<Primitive> + Clone,
-    Primitive: Into<Option<T>>,
+    T: SetStroke,
 {
     /// The start line cap as specified by the SVG spec.
     pub fn start_cap(self, cap: LineCap) -> Self {
-        self.map_ty(|ty| ty.start_cap(cap))
+        stroke::set_stroke(&self.draw, self.index, stroke::Update::StartCap(cap));
+        self
     }
 
     /// The end line cap as specified by the SVG spec.
     pub fn end_cap(self, cap: LineCap) -> Self {
-        self.map_ty(|ty| ty.end_cap(cap))
+        stroke::set_stroke(&self.draw, self.index, stroke::Update::EndCap(cap));
+        self
     }
 
     /// The start and end line cap as specified by the SVG spec.
     pub fn caps(self, cap: LineCap) -> Self {
-        self.map_ty(|ty| ty.caps(cap))
+        stroke::set_stroke(&self.draw, self.index, stroke::Update::Caps(cap));
+        self
     }
 
     /// The stroke for each sub-path does not extend beyond its two endpoints. A zero length
     /// sub-path will therefore not have any stroke.
     pub fn start_cap_butt(self) -> Self {
-        self.map_ty(|ty| ty.start_cap_butt())
+        self.start_cap(LineCap::Butt)
     }
 
     /// At the end of each sub-path, the shape representing the stroke will be extended by a
@@ -759,7 +684,7 @@ where
     /// sub-path consists solely of a square with side length equal to the stroke width, centered
     /// at the sub-path's point.
     pub fn start_cap_square(self) -> Self {
-        self.map_ty(|ty| ty.start_cap_square())
+        self.start_cap(LineCap::Square)
     }
 
     /// At each end of each sub-path, the shape representing the stroke will be extended by a half
@@ -767,13 +692,13 @@ where
     /// resulting effect is that the stroke for that sub-path consists solely of a full circle
     /// centered at the sub-path's point.
     pub fn start_cap_round(self) -> Self {
-        self.map_ty(|ty| ty.start_cap_round())
+        self.start_cap(LineCap::Round)
     }
 
     /// The stroke for each sub-path does not extend beyond its two endpoints. A zero length
     /// sub-path will therefore not have any stroke.
     pub fn end_cap_butt(self) -> Self {
-        self.map_ty(|ty| ty.end_cap_butt())
+        self.end_cap(LineCap::Butt)
     }
 
     /// At the end of each sub-path, the shape representing the stroke will be extended by a
@@ -782,7 +707,7 @@ where
     /// sub-path consists solely of a square with side length equal to the stroke width, centered
     /// at the sub-path's point.
     pub fn end_cap_square(self) -> Self {
-        self.map_ty(|ty| ty.end_cap_square())
+        self.end_cap(LineCap::Square)
     }
 
     /// At each end of each sub-path, the shape representing the stroke will be extended by a half
@@ -790,13 +715,13 @@ where
     /// resulting effect is that the stroke for that sub-path consists solely of a full circle
     /// centered at the sub-path's point.
     pub fn end_cap_round(self) -> Self {
-        self.map_ty(|ty| ty.end_cap_round())
+        self.end_cap(LineCap::Round)
     }
 
     /// The stroke for each sub-path does not extend beyond its two endpoints. A zero length
     /// sub-path will therefore not have any stroke.
     pub fn caps_butt(self) -> Self {
-        self.map_ty(|ty| ty.caps_butt())
+        self.caps(LineCap::Butt)
     }
 
     /// At the end of each sub-path, the shape representing the stroke will be extended by a
@@ -805,7 +730,7 @@ where
     /// sub-path consists solely of a square with side length equal to the stroke width, centered
     /// at the sub-path's point.
     pub fn caps_square(self) -> Self {
-        self.map_ty(|ty| ty.caps_square())
+        self.caps(LineCap::Square)
     }
 
     /// At each end of each sub-path, the shape representing the stroke will be extended by a half
@@ -813,58 +738,67 @@ where
     /// resulting effect is that the stroke for that sub-path consists solely of a full circle
     /// centered at the sub-path's point.
     pub fn caps_round(self) -> Self {
-        self.map_ty(|ty| ty.caps_round())
+        self.caps(LineCap::Round)
     }
 
     /// The way in which lines are joined at the vertices, matching the SVG spec.
     ///
     /// Default value is `MiterClip`.
     pub fn join(self, join: LineJoin) -> Self {
-        self.map_ty(|ty| ty.join(join))
+        stroke::set_stroke(&self.draw, self.index, stroke::Update::Join(join));
+        self
     }
 
     /// A sharp corner is to be used to join path segments.
     pub fn join_miter(self) -> Self {
-        self.map_ty(|ty| ty.join_miter())
+        self.join(LineJoin::Miter)
     }
 
     /// Same as a `join_miter`, but if the miter limit is exceeded, the miter is clipped at a miter
     /// length equal to the miter limit value multiplied by the stroke width.
     pub fn join_miter_clip(self) -> Self {
-        self.map_ty(|ty| ty.join_miter_clip())
+        self.join(LineJoin::MiterClip)
     }
 
     /// A round corner is to be used to join path segments.
     pub fn join_round(self) -> Self {
-        self.map_ty(|ty| ty.join_round())
+        self.join(LineJoin::Round)
     }
 
     /// A bevelled corner is to be used to join path segments. The bevel shape is a triangle that
     /// fills the area between the two stroked segments.
     pub fn join_bevel(self) -> Self {
-        self.map_ty(|ty| ty.join_bevel())
+        self.join(LineJoin::Bevel)
     }
 
     /// The total stroke_weight (aka width) of the line.
     pub fn stroke_weight(self, stroke_weight: f32) -> Self {
-        self.map_ty(|ty| ty.stroke_weight(stroke_weight))
+        stroke::set_stroke(
+            &self.draw,
+            self.index,
+            stroke::Update::Weight(stroke_weight),
+        );
+        self
     }
 
     /// Describes the limit before miter lines will clip, as described in the SVG spec.
     ///
     /// Must be greater than or equal to `1.0`.
     pub fn miter_limit(self, limit: f32) -> Self {
-        self.map_ty(|ty| ty.miter_limit(limit))
+        stroke::set_stroke(&self.draw, self.index, stroke::Update::MiterLimit(limit));
+        self
     }
 
     /// Maximum allowed distance to the path when building an approximation.
     pub fn stroke_tolerance(self, tolerance: f32) -> Self {
-        self.map_ty(|ty| ty.stroke_tolerance(tolerance))
+        stroke::set_stroke(&self.draw, self.index, stroke::Update::Tolerance(tolerance));
+        self
     }
 
     /// Specify the full set of stroke options for the path tessellation.
     pub fn stroke_opts(self, opts: StrokeOptions) -> Self {
-        self.map_ty(|ty| ty.stroke_opts(opts))
+        stroke::set_stroke(&self.draw, self.index, stroke::Update::Opts(opts));
+        self
     }
 }
 
@@ -894,3 +828,61 @@ impl<'a, T> Drawing<'a, T> {
         self.with_new_shader_model(model)
     }
 }
+// Finish the drawing at the given index.
+//
+// Shared between the **finish** method and the **Drawing**'s **Drop** implementation.
+fn finish_drawing(draw: &DrawRef, index: usize, shader_model_index: usize) {
+    match draw.state.try_write() {
+        Err(err) => eprintln!("drawing failed to borrow state and finish: {}", err),
+        Ok(mut state) => {
+            // If we are "Owned", that means we mutated our shader model and so need to
+            // spawn a new entity just for this primitive.
+            if let DrawRef::Owned(draw) = draw {
+                let id = draw.shader_model.clone();
+                let shader_model_cmd = state
+                    .draw_commands
+                    .get_mut(shader_model_index)
+                    .expect("expected a valid shader model index");
+                if shader_model_cmd.is_none() {
+                    *shader_model_cmd = Some(DrawCommand::ShaderModel(id));
+                }
+            }
+            state.finish_drawing(index);
+        }
+    }
+}
+
+// Mutate the primitive stored within **Draw** at `index` in place.
+//
+// The function is only applied if the node has not yet been **Drawn** and the draw state is not
+// locked elsewhere.
+pub(crate) fn with_primitive(draw: &Draw, index: usize, f: impl FnOnce(&mut Primitive)) {
+    if let Ok(mut state) = draw.state.try_write() {
+        if let Some(primitive) = state.drawing.get_mut(&index) {
+            f(primitive);
+        }
+    }
+}
+
+// The same as `with_primitive`, but passes ownership of the primitive to the given function
+// along with mutable access to the intermediary vertex buffers. This is useful for type-state
+// transitions and for primitives with an arbitrary number of vertices.
+pub(crate) fn with_primitive_ctxt(
+    draw: &Draw,
+    index: usize,
+    f: impl FnOnce(Primitive, DrawingContext) -> Primitive,
+) {
+    if let Ok(mut state) = draw.state.try_write() {
+        let state = &mut *state;
+        if let Some(primitive) = state.drawing.get_mut(&index) {
+            let prim = std::mem::take(primitive);
+            let new = {
+                let mut intermediary_state = state.intermediary_state.write().unwrap();
+                let ctxt = DrawingContext::from_intermediary_state(&mut intermediary_state);
+                f(prim, ctxt)
+            };
+            *primitive = new;
+        }
+    }
+}
+

--- a/nannou_draw/src/draw/drawing.rs
+++ b/nannou_draw/src/draw/drawing.rs
@@ -1,4 +1,3 @@
-use std::any::TypeId;
 use std::marker::PhantomData;
 
 use bevy::asset::UntypedAssetId;
@@ -12,7 +11,7 @@ use crate::draw::properties::{
     SetColor, SetDimensions, SetFill, SetOrientation, SetPosition, SetStroke,
 };
 use crate::draw::{Draw, DrawCommand, DrawRef};
-use crate::render::{DefaultNannouShaderModel, ShaderModel};
+use crate::render::{DefaultNannouShaderModel, ErasedShaderModel, ShaderModel};
 
 /// A **Drawing** in progress.
 ///
@@ -24,12 +23,9 @@ use crate::render::{DefaultNannouShaderModel, ShaderModel};
 /// inner **geom::Graph**. This ensures the correct instantiation order is maintained within the
 /// graph. As a result, each **Drawing** is associated with a single, unique node. Thus a
 /// **Drawing** can be thought of as a way of specifying properties for a node.
-pub struct Drawing<'a, T, SM>
-where
-    SM: ShaderModel + Default,
-{
+pub struct Drawing<'a, T> {
     // The `Draw` instance used to create this drawing.
-    draw: DrawRef<'a, SM>,
+    draw: DrawRef<'a>,
     // The draw command index of the primitive being drawn.
     pub(crate) index: usize,
     // The draw command index of the shader model being used.
@@ -55,14 +51,9 @@ pub struct DrawingContext<'a> {
 }
 
 /// Construct a new **Drawing** instance.
-pub fn new<T, SM: ShaderModel>(
-    draw: &Draw<SM>,
-    index: usize,
-    model_index: usize,
-) -> Drawing<'_, T, SM>
+pub fn new<T>(draw: &Draw, index: usize, model_index: usize) -> Drawing<'_, T>
 where
     T: Into<Primitive>,
-    SM: ShaderModel + Default,
 {
     let _ty = PhantomData;
     let finish_on_drop = true;
@@ -75,10 +66,7 @@ where
     }
 }
 
-impl<'a, T, SM> Drop for Drawing<'a, T, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a, T> Drop for Drawing<'a, T> {
     fn drop(&mut self) {
         if self.finish_on_drop {
             self.finish_inner()
@@ -104,10 +92,7 @@ impl<'a> DrawingContext<'a> {
     }
 }
 
-impl<'a, T, SM> Drawing<'a, T, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a, T> Drawing<'a, T> {
     // Shared between the **finish** method and the **Drawing**'s **Drop** implementation.
     //
     // 1. Create vertices based on node-specific position, points, etc.
@@ -143,12 +128,41 @@ where
         self.finish_inner()
     }
 
-    // Map the the parent's shader model to a new shader model type, taking ownership over the
-    // draw instance clone.
-    pub fn map_shader_model<F>(mut self, map: F) -> Drawing<'a, T, SM>
+    /// Map the parent's shader model to a new instance, drawing this primitive and any
+    /// subsequent drawings with the result.
+    ///
+    /// The active shader model must be of type `SM`; if it is not, a warning is emitted and the
+    /// mapping is skipped.
+    pub fn map_shader_model<SM, F>(self, map: F) -> Drawing<'a, T>
     where
+        SM: ShaderModel,
         F: FnOnce(SM) -> SM,
     {
+        let shader_model = {
+            let state = self.draw.state.read().unwrap();
+            state.shader_models[&self.draw.shader_model]
+                .as_any()
+                .downcast_ref::<SM>()
+                .cloned()
+        };
+        match shader_model {
+            Some(shader_model) => {
+                let shader_model = map(shader_model);
+                self.with_new_shader_model(Box::new(shader_model))
+            }
+            None => {
+                bevy::log::warn_once!(
+                    "`map_shader_model`: the active shader model is not of the requested type; \
+                     the mapping has been skipped"
+                );
+                self
+            }
+        }
+    }
+
+    // Insert the given model under a fresh id, drawing this primitive and any subsequent
+    // drawings with it. Takes ownership over the draw instance clone.
+    fn with_new_shader_model(mut self, model: Box<dyn ErasedShaderModel>) -> Drawing<'a, T> {
         self.finish_on_drop = false;
 
         let Drawing {
@@ -158,22 +172,14 @@ where
             ..
         } = self;
 
-        let state = draw.state.clone();
-        let shader_model = state.read().unwrap().shader_models[&self.draw.shader_model]
-            .downcast_ref::<SM>()
-            .unwrap()
-            .clone();
-
         let new_id = UntypedAssetId::Uuid {
-            type_id: TypeId::of::<SM>(),
+            type_id: model.as_any().type_id(),
             uuid: Uuid::new_v4(),
         };
 
-        let shader_model = map(shader_model.clone());
+        let state = draw.state.clone();
         let mut state = state.write().unwrap();
-        state
-            .shader_models
-            .insert(new_id.clone(), Box::new(shader_model));
+        state.shader_models.insert(new_id.clone(), model);
         // Mark the last shader model as the new model so that further drawings use the same model
         // as the parent draw ref.
         state.last_shader_model = Some(new_id.clone());
@@ -184,7 +190,6 @@ where
             shader_model: new_id.clone(),
             window: draw.window,
             text_cx: draw.text_cx.clone(),
-            _shader_model: Default::default(),
         };
 
         Drawing {
@@ -199,7 +204,7 @@ where
     // Map the given function onto the primitive stored within **Draw** at `index`.
     //
     // The functionn is only applied if the node has not yet been **Drawn**.
-    fn map_primitive<F, T2>(mut self, map: F) -> Drawing<'a, T2, SM>
+    fn map_primitive<F, T2>(mut self, map: F) -> Drawing<'a, T2>
     where
         F: FnOnce(Primitive) -> Primitive,
         T2: Into<Primitive> + Clone,
@@ -229,7 +234,7 @@ where
     // The same as `map_primitive` but also passes a mutable reference to the vertex data to the
     // map function. This is useful for types that may have an unknown number of arbitrary
     // vertices.
-    fn map_primitive_with_context<F, T2>(mut self, map: F) -> Drawing<'a, T2, SM>
+    fn map_primitive_with_context<F, T2>(mut self, map: F) -> Drawing<'a, T2>
     where
         F: FnOnce(Primitive, DrawingContext) -> Primitive,
         T2: Into<Primitive> + Clone,
@@ -265,7 +270,7 @@ where
     /// The function is only applied if the node has not yet been **Drawn**.
     ///
     /// **Panics** if the primitive does not contain type **T**.
-    pub fn map_ty<F, T2>(self, map: F) -> Drawing<'a, T2, SM>
+    pub fn map_ty<F, T2>(self, map: F) -> Drawing<'a, T2>
     where
         F: FnOnce(T) -> T2,
         T2: Into<Primitive> + Clone,
@@ -284,7 +289,7 @@ where
     /// The function is only applied if the node has not yet been **Drawn**.
     ///
     /// **Panics** if the primitive does not contain type **T**.
-    pub(crate) fn map_ty_with_context<F, T2>(self, map: F) -> Drawing<'a, T2, SM>
+    pub(crate) fn map_ty_with_context<F, T2>(self, map: F) -> Drawing<'a, T2>
     where
         F: FnOnce(T, DrawingContext) -> T2,
         T2: Into<Primitive> + Clone,
@@ -301,10 +306,9 @@ where
 
 // SetColor implementations.
 
-impl<'a, T, SM> Drawing<'a, T, SM>
+impl<'a, T> Drawing<'a, T>
 where
     T: SetColor + Into<Primitive> + Clone,
-    SM: ShaderModel + Default,
     Primitive: Into<Option<T>>,
 {
     /// Specify a color.
@@ -457,10 +461,9 @@ where
 
 // SetDimensions implementations.
 
-impl<'a, T, SM> Drawing<'a, T, SM>
+impl<'a, T> Drawing<'a, T>
 where
     T: SetDimensions + Into<Primitive> + Clone,
-    SM: ShaderModel + Default,
     Primitive: Into<Option<T>>,
 {
     /// Set the absolute width for the node.
@@ -516,10 +519,9 @@ where
 
 // SetPosition methods.
 
-impl<'a, T, SM> Drawing<'a, T, SM>
+impl<'a, T> Drawing<'a, T>
 where
     T: SetPosition + Into<Primitive> + Clone,
-    SM: ShaderModel + Default,
     Primitive: Into<Option<T>>,
 {
     /// Build with the given **Absolute** **Position** along the *x* axis.
@@ -560,10 +562,9 @@ where
 
 // SetOrientation methods.
 
-impl<'a, T, SM> Drawing<'a, T, SM>
+impl<'a, T> Drawing<'a, T>
 where
     T: SetOrientation + Into<Primitive> + Clone,
-    SM: ShaderModel + Default,
     Primitive: Into<Option<T>>,
 {
     /// Describe orientation via the vector that points to the given target.
@@ -683,10 +684,9 @@ where
 
 // SetFill methods
 
-impl<'a, T, SM> Drawing<'a, T, SM>
+impl<'a, T> Drawing<'a, T>
 where
     T: SetFill + Into<Primitive> + Clone,
-    SM: ShaderModel + Default,
     Primitive: Into<Option<T>>,
 {
     /// Specify the whole set of fill tessellation options.
@@ -727,10 +727,9 @@ where
 
 // SetStroke methods
 
-impl<'a, T, SM> Drawing<'a, T, SM>
+impl<'a, T> Drawing<'a, T>
 where
     T: SetStroke + Into<Primitive> + Clone,
-    SM: ShaderModel + Default,
     Primitive: Into<Option<T>>,
 {
     /// The start line cap as specified by the SVG spec.
@@ -869,29 +868,29 @@ where
     }
 }
 
-impl<'a, T, SM> Drawing<'a, T, SM>
-where
-    T: Into<Primitive> + Clone,
-    SM: ShaderModel + Default,
-    Primitive: Into<Option<T>>,
-{
-}
-
-impl<'a, T> Drawing<'a, T, DefaultNannouShaderModel>
-where
-    T: Into<Primitive>,
-{
+impl<'a, T> Drawing<'a, T> {
+    /// Set the base color of the shader model used to draw this primitive.
+    ///
+    /// This only applies to the default nannou shader model; if a custom shader model is active,
+    /// a warning is emitted and the color is ignored.
     pub fn base_color<C: Into<Color>>(self, color: C) -> Self {
-        self.map_shader_model(|mut model| {
-            model.color = color.into();
+        let color = color.into();
+        self.map_shader_model(|mut model: DefaultNannouShaderModel| {
+            model.color = color;
             model
         })
     }
 
+    /// Set the texture of the shader model used to draw this primitive.
+    ///
+    /// The texture is applied via [`ShaderModel::set_texture`], so this works with any shader
+    /// model type. Models without a texture slot ignore it.
     pub fn texture(self, texture: &Handle<Image>) -> Self {
-        self.map_shader_model(|mut model| {
-            model.texture = Some(texture.clone());
-            model
-        })
+        let mut model = {
+            let state = self.draw.state.read().unwrap();
+            state.shader_models[&self.draw.shader_model].clone_erased()
+        };
+        model.set_texture_erased(texture.clone());
+        self.with_new_shader_model(model)
     }
 }

--- a/nannou_draw/src/draw/drawing.rs
+++ b/nannou_draw/src/draw/drawing.rs
@@ -25,6 +25,13 @@ use crate::render::{DefaultNannouShaderModel, ErasedShaderModel, ShaderModel};
 /// inner **geom::Graph**. This ensures the correct instantiation order is maintained within the
 /// graph. As a result, each **Drawing** is associated with a single, unique node. Thus a
 /// **Drawing** can be thought of as a way of specifying properties for a node.
+///
+/// The type parameter `T` is a zero-cost marker: the primitive itself is stored type-erased as a
+/// [`Primitive`] within the **Draw**'s state, and `T` only determines which builder methods are
+/// available (via bounds like `T: SetColor`) and tracks type-state transitions (e.g.
+/// `PathInit -> PathFill -> Path`). The method bodies delegate to non-generic functions that
+/// mutate the stored primitive in place, keeping monomorphisation in downstream crates to a
+/// minimum.
 pub struct Drawing<'a, T> {
     // The `Draw` instance used to create this drawing.
     pub(crate) draw: DrawRef<'a>,
@@ -885,4 +892,3 @@ pub(crate) fn with_primitive_ctxt(
         }
     }
 }
-

--- a/nannou_draw/src/draw/indirect.rs
+++ b/nannou_draw/src/draw/indirect.rs
@@ -26,19 +26,13 @@ use bevy::{
 };
 use std::{hash::Hash, marker::PhantomData};
 
-pub struct Indirect<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
-    draw: &'a Draw<SM>,
+pub struct Indirect<'a> {
+    draw: &'a Draw,
     primitive_index: Option<usize>,
     indirect_buffer: Option<Handle<ShaderBuffer>>,
 }
 
-impl<'a, SM> Drop for Indirect<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> Drop for Indirect<'a> {
     fn drop(&mut self) {
         if let Some((index, ssbo)) = self.primitive_index.take().zip(self.indirect_buffer.take()) {
             self.insert_indirect_draw_command(index, ssbo);
@@ -46,10 +40,7 @@ where
     }
 }
 
-pub fn new<SM>(draw: &Draw<SM>) -> Indirect<'_, SM>
-where
-    SM: ShaderModel + Default,
-{
+pub fn new(draw: &Draw) -> Indirect<'_> {
     Indirect {
         draw,
         primitive_index: None,
@@ -57,11 +48,8 @@ where
     }
 }
 
-impl<'a, SM> Indirect<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
-    pub fn primitive<T>(mut self, drawing: Drawing<T, SM>) -> Indirect<'a, SM>
+impl<'a> Indirect<'a> {
+    pub fn primitive<T>(mut self, drawing: Drawing<T>) -> Indirect<'a>
     where
         T: Into<Primitive>,
     {
@@ -75,7 +63,7 @@ where
         self
     }
 
-    pub fn buffer(mut self, ssbo: Handle<ShaderBuffer>) -> Indirect<'a, SM> {
+    pub fn buffer(mut self, ssbo: Handle<ShaderBuffer>) -> Indirect<'a> {
         self.indirect_buffer = Some(ssbo);
         self
     }

--- a/nannou_draw/src/draw/instanced.rs
+++ b/nannou_draw/src/draw/instanced.rs
@@ -25,19 +25,13 @@ use bevy::{
 };
 use std::{hash::Hash, marker::PhantomData, ops::Range};
 
-pub struct Instanced<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
-    draw: &'a Draw<SM>,
+pub struct Instanced<'a> {
+    draw: &'a Draw,
     primitive_index: Option<usize>,
     range: Option<Range<u32>>,
 }
 
-impl<'a, SM> Drop for Instanced<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> Drop for Instanced<'a> {
     fn drop(&mut self) {
         if let Some((index, data)) = self.primitive_index.take().zip(self.range.take()) {
             self.insert_instanced_draw_command(index, data);
@@ -45,10 +39,7 @@ where
     }
 }
 
-pub fn new<SM>(draw: &Draw<SM>) -> Instanced<'_, SM>
-where
-    SM: ShaderModel + Default,
-{
+pub fn new(draw: &Draw) -> Instanced<'_> {
     Instanced {
         draw,
         primitive_index: None,
@@ -56,11 +47,8 @@ where
     }
 }
 
-impl<'a, SM> Instanced<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
-    pub fn primitive<T>(mut self, drawing: Drawing<T, SM>) -> Instanced<'a, SM>
+impl<'a> Instanced<'a> {
+    pub fn primitive<T>(mut self, drawing: Drawing<T>) -> Instanced<'a>
     where
         T: Into<Primitive>,
     {
@@ -74,7 +62,7 @@ where
         self
     }
 
-    pub fn range(mut self, range: Range<u32>) -> Instanced<'a, SM> {
+    pub fn range(mut self, range: Range<u32>) -> Instanced<'a> {
         self.range = Some(range);
         self
     }

--- a/nannou_draw/src/draw/mod.rs
+++ b/nannou_draw/src/draw/mod.rs
@@ -3,8 +3,7 @@
 //! See the [Draw] for more details.
 
 use std::{
-    any::{Any, TypeId},
-    marker::PhantomData,
+    any::TypeId,
     ops::{Deref, Range},
     sync::{Arc, RwLock},
 };
@@ -17,7 +16,7 @@ pub use self::{
 };
 use crate::{
     draw::{indirect::Indirect, instanced::Instanced, mesh::MeshExt},
-    render::{DefaultNannouShaderModel, ShaderModel},
+    render::{DefaultNannouShaderModel, ErasedShaderModel, ShaderModel},
     text::font::SharedTextCx,
 };
 use bevy::{
@@ -58,10 +57,7 @@ pub mod theme;
 /// See the [draw](https://github.com/nannou-org/nannou/blob/master/examples) examples for a
 /// variety of demonstrations of how the [Draw] type can be used!
 #[derive(Component, Clone)]
-pub struct Draw<SM = DefaultNannouShaderModel>
-where
-    SM: ShaderModel + Default,
-{
+pub struct Draw {
     /// The state of the [Draw].
     ///
     /// State is shared between this [Draw] instance and all other [Draw] instances that were
@@ -75,30 +71,22 @@ where
     /// The current context of this [Draw] instance.
     context: DrawContext,
     /// The current type erased shader model of this [Draw] instance.
-    shader_model: UntypedAssetId,
+    pub(crate) shader_model: UntypedAssetId,
     /// The window to which this [Draw] instance is associated.
     pub(crate) window: Entity,
     /// Shared text context.
     pub(crate) text_cx: SharedTextCx,
-    /// The type of shader model used by this [Draw] instance.
-    _shader_model: PhantomData<SM>,
 }
 
 /// A reference to a [Draw] instance that is either borrowed or owned.
 #[derive(Clone)]
-pub enum DrawRef<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
-    Borrowed(&'a Draw<SM>),
-    Owned(Draw<SM>),
+pub enum DrawRef<'a> {
+    Borrowed(&'a Draw),
+    Owned(Draw),
 }
 
-impl<'a, SM> Deref for DrawRef<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
-    type Target = Draw<SM>;
+impl<'a> Deref for DrawRef<'a> {
+    type Target = Draw;
 
     fn deref(&self) -> &Self::Target {
         match self {
@@ -160,7 +148,7 @@ pub struct State {
     /// Keys are indices into the `draw_commands` Vec.
     drawing: HashMap<usize, Primitive>,
     /// A map of all type erased shader models used by the draw.
-    pub(crate) shader_models: HashMap<UntypedAssetId, Box<dyn Any + Send + Sync>>,
+    pub(crate) shader_models: HashMap<UntypedAssetId, Box<dyn ErasedShaderModel>>,
     /// A list of indices of primitives that are being drawn via an alternate method and
     /// should not be drawn
     ignored_drawings: HashSet<usize>,
@@ -237,16 +225,13 @@ impl State {
     }
 }
 
-impl<SM> Draw<SM>
-where
-    SM: ShaderModel + Default,
-{
+impl Draw {
     pub fn new(window: Entity, text_cx: SharedTextCx) -> Self {
         let mut state = State::default();
         let context = DrawContext::default();
-        let model = SM::default();
+        let model = DefaultNannouShaderModel::default();
         let model_id = UntypedAssetId::Uuid {
-            type_id: TypeId::of::<SM>(),
+            type_id: TypeId::of::<DefaultNannouShaderModel>(),
             uuid: Uuid::new_v4(),
         };
         state.shader_models.insert(model_id, Box::new(model));
@@ -257,7 +242,6 @@ where
             shader_model: model_id,
             window,
             text_cx,
-            _shader_model: PhantomData,
         }
     }
 
@@ -269,9 +253,9 @@ where
 
     fn insert_default_shader_model(&mut self) {
         let mut state = self.state.write().unwrap();
-        let model = SM::default();
+        let model = DefaultNannouShaderModel::default();
         let model_id = UntypedAssetId::Uuid {
-            type_id: TypeId::of::<SM>(),
+            type_id: TypeId::of::<DefaultNannouShaderModel>(),
             uuid: Uuid::new_v4(),
         };
         state.shader_models.insert(model_id, Box::new(model));
@@ -468,7 +452,7 @@ where
     }
 
     /// Produce a new [Draw] instance with the given context.
-    fn context(&self, context: DrawContext) -> Draw<SM> {
+    fn context(&self, context: DrawContext) -> Draw {
         let state = self.state.clone();
         let shader_model = self.shader_model.clone();
         let window = self.window;
@@ -479,21 +463,23 @@ where
             shader_model,
             window,
             text_cx,
-            _shader_model: PhantomData,
         }
     }
 
-    fn clone_shader_model(&self) -> SM {
-        let mut state = self.state.write().unwrap();
-        let shader_model = state.shader_models.get_mut(&self.shader_model).unwrap();
+    /// Clone the active shader model if it is the default nannou shader model.
+    ///
+    /// Returns `None` if a custom shader model type is active.
+    fn clone_default_shader_model(&self) -> Option<DefaultNannouShaderModel> {
+        let state = self.state.read().unwrap();
+        let shader_model = state.shader_models.get(&self.shader_model)?;
         shader_model
-            .downcast_ref::<SM>()
-            .expect("Expected shader model to be of the correct type")
-            .clone()
+            .as_any()
+            .downcast_ref::<DefaultNannouShaderModel>()
+            .cloned()
     }
 
-    /// Produce a new [Draw] instance with a new shader model type.
-    pub fn shader_model<SM2: ShaderModel + Default>(&self, model: SM2) -> Draw<SM2> {
+    /// Produce a new [Draw] instance that will draw with the given shader model.
+    pub fn shader_model<SM: ShaderModel>(&self, model: SM) -> Draw {
         let context = self.context.clone();
         let DrawContext { transform, .. } = context;
         let context = DrawContext { transform };
@@ -501,7 +487,7 @@ where
         let window = self.window;
         let text_cx = self.text_cx.clone();
         let model_id = UntypedAssetId::Uuid {
-            type_id: TypeId::of::<SM2>(),
+            type_id: TypeId::of::<SM>(),
             uuid: Uuid::new_v4(),
         };
 
@@ -517,28 +503,27 @@ where
             shader_model: model_id,
             window,
             text_cx,
-            _shader_model: PhantomData,
         }
     }
 
     // Primitives.
 
     /// Specify a color with which the background should be cleared.
-    pub fn background<'a>(&'a self) -> Background<'a, SM> {
+    pub fn background<'a>(&'a self) -> Background<'a> {
         background::new(self)
     }
 
     /// Draw an instanced drawing
-    pub fn instanced<'a>(&'a self) -> Instanced<'a, SM> {
+    pub fn instanced<'a>(&'a self) -> Instanced<'a> {
         instanced::new(self)
     }
 
-    pub fn indirect<'a>(&'a self) -> Indirect<'a, SM> {
+    pub fn indirect<'a>(&'a self) -> Indirect<'a> {
         indirect::new(self)
     }
 
     /// Add the given type to be drawn.
-    pub fn a<T>(&self, primitive: T) -> Drawing<'_, T, SM>
+    pub fn a<T>(&self, primitive: T) -> Drawing<'_, T>
     where
         T: Into<Primitive>,
         Primitive: Into<Option<T>>,
@@ -576,59 +561,59 @@ where
     }
 
     /// Begin drawing a **Path**.
-    pub fn path(&self) -> Drawing<'_, primitive::PathInit, SM> {
+    pub fn path(&self) -> Drawing<'_, primitive::PathInit> {
         self.a(Default::default())
     }
 
     /// Begin drawing an **Ellipse**.
-    pub fn ellipse(&self) -> Drawing<'_, primitive::Ellipse, SM> {
+    pub fn ellipse(&self) -> Drawing<'_, primitive::Ellipse> {
         self.a(Default::default())
     }
 
     /// Begin drawing a **Line**.
-    pub fn line(&self) -> Drawing<'_, primitive::Line, SM> {
+    pub fn line(&self) -> Drawing<'_, primitive::Line> {
         self.a(Default::default())
     }
 
     /// Begin drawing an **Arrow**.
-    pub fn arrow(&self) -> Drawing<'_, primitive::Arrow, SM> {
+    pub fn arrow(&self) -> Drawing<'_, primitive::Arrow> {
         self.a(Default::default())
     }
 
     /// Begin drawing a **Quad**.
-    pub fn quad(&self) -> Drawing<'_, primitive::Quad, SM> {
+    pub fn quad(&self) -> Drawing<'_, primitive::Quad> {
         self.a(Default::default())
     }
 
     /// Begin drawing a **Rect**.
-    pub fn rect(&self) -> Drawing<'_, primitive::Rect, SM> {
+    pub fn rect(&self) -> Drawing<'_, primitive::Rect> {
         self.a(Default::default())
     }
 
     /// Begin drawing a **Triangle**.
-    pub fn tri(&self) -> Drawing<'_, primitive::Tri, SM> {
+    pub fn tri(&self) -> Drawing<'_, primitive::Tri> {
         self.a(Default::default())
     }
 
     /// Begin drawing a **Polygon**.
-    pub fn polygon(&self) -> Drawing<'_, primitive::PolygonInit, SM> {
+    pub fn polygon(&self) -> Drawing<'_, primitive::PolygonInit> {
         self.a(Default::default())
     }
 
     /// Begin drawing a **Mesh**.
-    pub fn mesh(&self) -> Drawing<'_, primitive::mesh::Vertexless, SM> {
+    pub fn mesh(&self) -> Drawing<'_, primitive::mesh::Vertexless> {
         self.a(Default::default())
     }
 
     /// Begin drawing a **Polyline**.
     ///
     /// Note that this is simply short-hand for `draw.path().stroke()`
-    pub fn polyline(&self) -> Drawing<'_, primitive::PathStroke, SM> {
+    pub fn polyline(&self) -> Drawing<'_, primitive::PathStroke> {
         self.path().stroke()
     }
 
     /// Begin drawing a **Text**.
-    pub fn text(&self, s: &str) -> Drawing<'_, primitive::Text, SM> {
+    pub fn text(&self, s: &str) -> Drawing<'_, primitive::Text> {
         let text = {
             let state = self.state.read().expect("lock poisoned");
             let mut intermediary_state = state.intermediary_state.write().expect("lock poisoned");
@@ -663,29 +648,50 @@ where
         let mut state = self.state.write().unwrap();
         state.finish_remaining_drawings()
     }
-}
 
-impl Draw<DefaultNannouShaderModel> {
+    // Map the default nannou shader model to a new instance, drawing with the result.
+    //
+    // These methods only apply to the default nannou shader model; if a custom shader model is
+    // active, a warning is emitted and the operation is skipped.
+    fn map_default_shader_model<F>(&self, map: F) -> Self
+    where
+        F: FnOnce(&mut DefaultNannouShaderModel),
+    {
+        match self.clone_default_shader_model() {
+            Some(mut model) => {
+                map(&mut model);
+                self.shader_model(model)
+            }
+            None => {
+                bevy::log::warn_once!(
+                    "this operation only applies to the default nannou shader model; \
+                     a custom shader model is active, so it has been skipped"
+                );
+                self.clone()
+            }
+        }
+    }
+
     /// Produce a new [Draw] instance that will draw with the given alpha blend descriptor.
     pub fn alpha_blend(&self, blend_descriptor: wgpu::BlendComponent) -> Self {
         // TODO: check if blend is already set and only update if necessary
-        let mut model = self.clone_shader_model().clone();
-        model.blend = Some(BlendState {
-            color: BlendComponent::REPLACE,
-            alpha: blend_descriptor,
-        });
-        self.shader_model(model)
+        self.map_default_shader_model(|model| {
+            model.blend = Some(BlendState {
+                color: BlendComponent::REPLACE,
+                alpha: blend_descriptor,
+            });
+        })
     }
 
     /// Produce a new [Draw] instance that will draw with the given color blend descriptor.
     pub fn color_blend(&self, blend_descriptor: wgpu::BlendComponent) -> Self {
         // TODO: check if blend is already set and only update if necessary
-        let mut model = self.clone_shader_model().clone();
-        model.blend = Some(BlendState {
-            color: blend_descriptor,
-            alpha: BlendComponent::REPLACE,
-        });
-        self.shader_model(model)
+        self.map_default_shader_model(|model| {
+            model.blend = Some(BlendState {
+                color: blend_descriptor,
+                alpha: BlendComponent::REPLACE,
+            });
+        })
     }
 
     /// Short-hand for `color_blend`, the common use-case.
@@ -695,9 +701,7 @@ impl Draw<DefaultNannouShaderModel> {
 
     /// Produce a new [Draw] instance that will use the given polygon mode.
     pub fn polygon_mode(&self, polygon_mode: wgpu::PolygonMode) -> Self {
-        let mut model = self.clone_shader_model().clone();
-        model.polygon_mode = polygon_mode;
-        self.shader_model(model)
+        self.map_default_shader_model(|model| model.polygon_mode = polygon_mode)
     }
 }
 

--- a/nannou_draw/src/draw/mod.rs
+++ b/nannou_draw/src/draw/mod.rs
@@ -526,38 +526,40 @@ impl Draw {
     pub fn a<T>(&self, primitive: T) -> Drawing<'_, T>
     where
         T: Into<Primitive>,
-        Primitive: Into<Option<T>>,
     {
-        let (index, model_index) = {
-            let mut state = self.state.write().unwrap();
-            // If drawing with a different context, insert the necessary command to update it.
-            if state.last_draw_context.as_ref() != Some(&self.context) {
-                state
-                    .draw_commands
-                    .push(Some(DrawCommand::Context(self.context.clone())));
-                state.last_draw_context = Some(self.context.clone());
-            }
-
-            let id = &self.shader_model;
-            if state.last_shader_model.as_ref() != Some(id) {
-                state
-                    .draw_commands
-                    .push(Some(DrawCommand::ShaderModel(id.clone())));
-                state.last_shader_model = Some(id.clone());
-            }
-
-            // Insert a model slot to be used if the drawing switches models.
-            let shader_model_index = state.draw_commands.len();
-            state.draw_commands.push(None);
-
-            // The primitive will be inserted in the next element.
-            let index = state.draw_commands.len();
-            let primitive: Primitive = primitive.into();
-            state.draw_commands.push(None);
-            state.drawing.insert(index, primitive);
-            (index, shader_model_index)
-        };
+        let (index, model_index) = self.insert_primitive(primitive.into());
         drawing::new(self, index, model_index)
+    }
+
+    // Record the primitive in the draw state, returning the indices of the draw command slots
+    // reserved for the primitive and for a potential shader model change.
+    fn insert_primitive(&self, primitive: Primitive) -> (usize, usize) {
+        let mut state = self.state.write().unwrap();
+        // If drawing with a different context, insert the necessary command to update it.
+        if state.last_draw_context.as_ref() != Some(&self.context) {
+            state
+                .draw_commands
+                .push(Some(DrawCommand::Context(self.context.clone())));
+            state.last_draw_context = Some(self.context.clone());
+        }
+
+        let id = &self.shader_model;
+        if state.last_shader_model.as_ref() != Some(id) {
+            state
+                .draw_commands
+                .push(Some(DrawCommand::ShaderModel(id.clone())));
+            state.last_shader_model = Some(id.clone());
+        }
+
+        // Insert a model slot to be used if the drawing switches models.
+        let shader_model_index = state.draw_commands.len();
+        state.draw_commands.push(None);
+
+        // The primitive will be inserted in the next element.
+        let index = state.draw_commands.len();
+        state.draw_commands.push(None);
+        state.drawing.insert(index, primitive);
+        (index, shader_model_index)
     }
 
     /// Begin drawing a **Path**.

--- a/nannou_draw/src/draw/primitive/arrow.rs
+++ b/nannou_draw/src/draw/primitive/arrow.rs
@@ -7,7 +7,6 @@ use crate::draw::primitive::path;
 use crate::draw::properties::spatial::{orientation, position};
 use crate::draw::properties::{SetColor, SetOrientation, SetPosition, SetStroke};
 use crate::draw::{self, Drawing};
-use crate::render::ShaderModel;
 
 /// A path containing only two points - a start and end.
 ///
@@ -20,7 +19,7 @@ pub struct Arrow {
 }
 
 /// The drawing context for a line.
-pub type DrawingArrow<'a, SM> = Drawing<'a, Arrow, SM>;
+pub type DrawingArrow<'a> = Drawing<'a, Arrow>;
 
 impl Arrow {
     /// Short-hand for the `stroke_weight` method.
@@ -85,10 +84,7 @@ impl Arrow {
     }
 }
 
-impl<'a, SM> DrawingArrow<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingArrow<'a> {
     /// Short-hand for the `stroke_weight` method.
     pub fn weight(self, weight: f32) -> Self {
         self.map_ty(|ty| ty.weight(weight))

--- a/nannou_draw/src/draw/primitive/arrow.rs
+++ b/nannou_draw/src/draw/primitive/arrow.rs
@@ -87,27 +87,31 @@ impl Arrow {
 impl<'a> DrawingArrow<'a> {
     /// Short-hand for the `stroke_weight` method.
     pub fn weight(self, weight: f32) -> Self {
-        self.map_ty(|ty| ty.weight(weight))
+        self.stroke_weight(weight)
     }
 
     /// Short-hand for the `stroke_tolerance` method.
     pub fn tolerance(self, tolerance: f32) -> Self {
-        self.map_ty(|ty| ty.tolerance(tolerance))
+        self.stroke_tolerance(tolerance)
     }
 
     /// Specify the start point of the arrow.
     pub fn start(self, start: Vec2) -> Self {
-        self.map_ty(|ty| ty.start(start))
+        update_arrow(&self.draw, self.index, |arrow| {
+            arrow.line.start = Some(start)
+        });
+        self
     }
 
     /// Specify the end point of the arrow.
     pub fn end(self, end: Vec2) -> Self {
-        self.map_ty(|ty| ty.end(end))
+        update_arrow(&self.draw, self.index, |arrow| arrow.line.end = Some(end));
+        self
     }
 
     /// Specify the start and end points of the arrow.
     pub fn points(self, start: Vec2, end: Vec2) -> Self {
-        self.map_ty(|ty| ty.points(start, end))
+        self.start(start).end(end)
     }
 
     /// The length of the arrow head.
@@ -116,14 +120,20 @@ impl<'a> DrawingArrow<'a> {
     ///
     /// This value will be clamped to the length of the line itself.
     pub fn head_length(self, length: f32) -> Self {
-        self.map_ty(|ty| ty.head_length(length))
+        update_arrow(&self.draw, self.index, |arrow| {
+            arrow.head_length = Some(length)
+        });
+        self
     }
 
     /// The width of the arrow head.
     ///
     /// By default, this is equal to `weight * 2.0`.
     pub fn head_width(self, width: f32) -> Self {
-        self.map_ty(|ty| ty.head_width(width))
+        update_arrow(&self.draw, self.index, |arrow| {
+            arrow.head_width = Some(width)
+        });
+        self
     }
 }
 
@@ -154,15 +164,6 @@ impl SetColor for Arrow {
 impl From<Arrow> for Primitive {
     fn from(prim: Arrow) -> Self {
         Primitive::Arrow(prim)
-    }
-}
-
-impl Into<Option<Arrow>> for Primitive {
-    fn into(self) -> Option<Arrow> {
-        match self {
-            Primitive::Arrow(prim) => Some(prim),
-            _ => None,
-        }
     }
 }
 
@@ -265,4 +266,12 @@ impl Default for Arrow {
             head_width,
         }
     }
+}
+
+// Update the inner `Arrow` of the primitive being drawn at `index`.
+fn update_arrow(draw: &crate::draw::Draw, index: usize, f: impl FnOnce(&mut Arrow)) {
+    crate::draw::drawing::with_primitive(draw, index, |prim| match prim {
+        Primitive::Arrow(arrow) => f(arrow),
+        _ => bevy::log::warn_once!("expected an `Arrow` primitive"),
+    })
 }

--- a/nannou_draw/src/draw/primitive/ellipse.rs
+++ b/nannou_draw/src/draw/primitive/ellipse.rs
@@ -177,15 +177,6 @@ impl From<Ellipse> for Primitive {
     }
 }
 
-impl Into<Option<Ellipse>> for Primitive {
-    fn into(self) -> Option<Ellipse> {
-        match self {
-            Primitive::Ellipse(prim) => Some(prim),
-            _ => None,
-        }
-    }
-}
-
 // Drawing methods.
 
 impl<'a> DrawingEllipse<'a> {
@@ -194,16 +185,28 @@ impl<'a> DrawingEllipse<'a> {
     where
         C: Into<Color>,
     {
-        self.map_ty(|ty| ty.stroke(color))
+        self.stroke_color(color)
     }
 
     /// Specify the width and height of the **Ellipse** via a given **radius**.
     pub fn radius(self, radius: f32) -> Self {
-        self.map_ty(|ty| ty.radius(radius))
+        let side = radius * 2.0;
+        self.w_h(side, side)
     }
 
     /// The number of sides used to draw the ellipse.
     pub fn resolution(self, resolution: f32) -> Self {
-        self.map_ty(|ty| ty.resolution(resolution))
+        update_ellipse(&self.draw, self.index, |ellipse| {
+            ellipse.resolution = Some(resolution)
+        });
+        self
     }
+}
+
+// Update the inner `Ellipse` of the primitive being drawn at `index`.
+fn update_ellipse(draw: &crate::draw::Draw, index: usize, f: impl FnOnce(&mut Ellipse)) {
+    crate::draw::drawing::with_primitive(draw, index, |prim| match prim {
+        Primitive::Ellipse(ellipse) => f(ellipse),
+        _ => bevy::log::warn_once!("expected an `Ellipse` primitive"),
+    })
 }

--- a/nannou_draw/src/draw/primitive/ellipse.rs
+++ b/nannou_draw/src/draw/primitive/ellipse.rs
@@ -11,7 +11,6 @@ use crate::draw::properties::spatial::{dimension, orientation, position};
 use crate::draw::properties::{
     SetColor, SetDimensions, SetOrientation, SetPosition, SetStroke, spatial,
 };
-use crate::render::ShaderModel;
 
 /// Properties related to drawing an **Ellipse**.
 #[derive(Clone, Debug, Default)]
@@ -22,7 +21,7 @@ pub struct Ellipse {
 }
 
 /// The drawing context for an ellipse.
-pub type DrawingEllipse<'a, SM> = Drawing<'a, Ellipse, SM>;
+pub type DrawingEllipse<'a> = Drawing<'a, Ellipse>;
 
 // Ellipse-specific methods.
 
@@ -189,10 +188,7 @@ impl Into<Option<Ellipse>> for Primitive {
 
 // Drawing methods.
 
-impl<'a, SM> DrawingEllipse<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingEllipse<'a> {
     /// Stroke the outline with the given color.
     pub fn stroke<C>(self, color: C) -> Self
     where

--- a/nannou_draw/src/draw/primitive/line.rs
+++ b/nannou_draw/src/draw/primitive/line.rs
@@ -6,7 +6,6 @@ use crate::draw::primitive::{PathStroke, Primitive};
 use crate::draw::properties::spatial::{orientation, position};
 use crate::draw::properties::{SetColor, SetOrientation, SetPosition, SetStroke};
 use crate::draw::{self, Drawing};
-use crate::render::ShaderModel;
 
 /// A path containing only two points - a start and end.
 ///
@@ -20,7 +19,7 @@ pub struct Line {
 }
 
 /// The drawing context for a line.
-pub type DrawingLine<'a, SM> = Drawing<'a, Line, SM>;
+pub type DrawingLine<'a> = Drawing<'a, Line>;
 
 impl Line {
     /// Short-hand for the `stroke_weight` method.
@@ -61,10 +60,7 @@ impl Line {
     }
 }
 
-impl<'a, SM> DrawingLine<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingLine<'a> {
     /// Short-hand for the `stroke_weight` method.
     pub fn weight(self, weight: f32) -> Self {
         self.map_ty(|ty| ty.weight(weight))

--- a/nannou_draw/src/draw/primitive/line.rs
+++ b/nannou_draw/src/draw/primitive/line.rs
@@ -63,28 +63,38 @@ impl Line {
 impl<'a> DrawingLine<'a> {
     /// Short-hand for the `stroke_weight` method.
     pub fn weight(self, weight: f32) -> Self {
-        self.map_ty(|ty| ty.weight(weight))
+        self.stroke_weight(weight)
     }
 
     /// Short-hand for the `stroke_tolerance` method.
     pub fn tolerance(self, tolerance: f32) -> Self {
-        self.map_ty(|ty| ty.tolerance(tolerance))
+        self.stroke_tolerance(tolerance)
     }
 
     /// Specify the start point of the line.
     pub fn start(self, start: Vec2) -> Self {
-        self.map_ty(|ty| ty.start(start))
+        update_line(&self.draw, self.index, |line| line.start = Some(start));
+        self
     }
 
     /// Specify the end point of the line.
     pub fn end(self, end: Vec2) -> Self {
-        self.map_ty(|ty| ty.end(end))
+        update_line(&self.draw, self.index, |line| line.end = Some(end));
+        self
     }
 
     /// Specify the start and end points of the line.
     pub fn points(self, start: Vec2, end: Vec2) -> Self {
-        self.map_ty(|ty| ty.points(start, end))
+        self.start(start).end(end)
     }
+}
+
+// Update the inner `Line` of the primitive being drawn at `index`.
+fn update_line(draw: &crate::draw::Draw, index: usize, f: impl FnOnce(&mut Line)) {
+    crate::draw::drawing::with_primitive(draw, index, |prim| match prim {
+        Primitive::Line(line) => f(line),
+        _ => bevy::log::warn_once!("expected a `Line` primitive"),
+    })
 }
 
 impl SetStroke for Line {
@@ -114,15 +124,6 @@ impl SetColor for Line {
 impl From<Line> for Primitive {
     fn from(prim: Line) -> Self {
         Primitive::Line(prim)
-    }
-}
-
-impl Into<Option<Line>> for Primitive {
-    fn into(self) -> Option<Line> {
-        match self {
-            Primitive::Line(prim) => Some(prim),
-            _ => None,
-        }
     }
 }
 

--- a/nannou_draw/src/draw/primitive/mesh.rs
+++ b/nannou_draw/src/draw/primitive/mesh.rs
@@ -9,7 +9,6 @@ use crate::draw::primitive::{Primitive, Vertex};
 use crate::draw::properties::spatial::{orientation, position};
 use crate::draw::properties::{SetColor, SetOrientation, SetPosition};
 use crate::draw::{self, Drawing};
-use crate::render::ShaderModel;
 
 /// The mesh type prior to being initialised with vertices or indices.
 #[derive(Clone, Debug, Default)]
@@ -28,7 +27,7 @@ pub struct PrimitiveMesh {
 #[derive(Clone, Debug, Default)]
 struct FillColor(Option<Color>);
 
-pub type DrawingMesh<'a, SM> = Drawing<'a, PrimitiveMesh, SM>;
+pub type DrawingMesh<'a> = Drawing<'a, PrimitiveMesh>;
 
 impl Vertexless {
     /// Describe the mesh with a sequence of textured points.
@@ -293,10 +292,7 @@ impl PrimitiveMesh {
     }
 }
 
-impl<'a, SM> Drawing<'a, Vertexless, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> Drawing<'a, Vertexless> {
     /// Describe the mesh with a sequence of points.
     ///
     /// The given iterator may yield any type that can be converted directly into `Vec3`s.
@@ -304,7 +300,7 @@ where
     /// This method assumes that the entire mesh should be coloured with a single colour. If a
     /// colour is not specified via one of the builder methods, a default colour will be retrieved
     /// from the inner `Theme`.
-    pub fn points<I>(self, points: I) -> DrawingMesh<'a, SM>
+    pub fn points<I>(self, points: I) -> DrawingMesh<'a>
     where
         I: IntoIterator,
         I::Item: Into<Vec3>,
@@ -317,7 +313,7 @@ where
     /// Each of the points must be represented as a tuple containing the point and the color in
     /// that order, e.g. `(point, color)`. `point` may be of any type that implements
     /// `Into<Vec3>` and `color` may be of any type that implements `IntoColor`.
-    pub fn points_colored<I, P, C>(self, points: I) -> DrawingMesh<'a, SM>
+    pub fn points_colored<I, P, C>(self, points: I) -> DrawingMesh<'a>
     where
         I: IntoIterator<Item = (P, C)>,
         P: Into<Vec3>,
@@ -336,17 +332,14 @@ where
         self,
         texture_handle: Handle<Image>,
         points: I,
-    ) -> DrawingMesh<'a, SM>
+    ) -> DrawingMesh<'a>
     where
         I: IntoIterator<Item = (P, T)>,
         P: Into<Vec3>,
         T: Into<Vec2>,
     {
-        self.map_shader_model(|mut model| {
-            model.set_texture(texture_handle);
-            model
-        })
-        .map_ty_with_context(|ty, ctxt| ty.points_textured(ctxt.mesh, points))
+        self.texture(&texture_handle)
+            .map_ty_with_context(|ty, ctxt| ty.points_textured(ctxt.mesh, points))
     }
 
     /// Describe the mesh with a sequence of triangles.
@@ -357,7 +350,7 @@ where
     /// This method assumes that the entire mesh should be coloured with a single colour. If a
     /// colour is not specified via one of the builder methods, a default colour will be retrieved
     /// from the inner `Theme`.
-    pub fn tris<I, V>(self, tris: I) -> DrawingMesh<'a, SM>
+    pub fn tris<I, V>(self, tris: I) -> DrawingMesh<'a>
     where
         I: IntoIterator<Item = geom::Tri<V>>,
         V: Into<Vec3>,
@@ -370,7 +363,7 @@ where
     /// Each of the vertices must be represented as a tuple containing the point and the color in
     /// that order, e.g. `(point, color)`. `point` may be of any type that implements `Into<Vec3>`
     /// and `color` may be of any type that implements `IntoColor`.
-    pub fn tris_colored<I, P, C>(self, tris: I) -> DrawingMesh<'a, SM>
+    pub fn tris_colored<I, P, C>(self, tris: I) -> DrawingMesh<'a>
     where
         I: IntoIterator<Item = geom::Tri<(P, C)>>,
         P: Into<Vec3>,
@@ -389,17 +382,14 @@ where
         self,
         texture_handle: Handle<Image>,
         tris: I,
-    ) -> DrawingMesh<'a, SM>
+    ) -> DrawingMesh<'a>
     where
         I: IntoIterator<Item = geom::Tri<(P, T)>>,
         P: Into<Vec3>,
         T: Into<Vec2>,
     {
-        self.map_shader_model(|mut model| {
-            model.set_texture(texture_handle);
-            model
-        })
-        .map_ty_with_context(|ty, ctxt| ty.tris_textured(ctxt.mesh, tris))
+        self.texture(&texture_handle)
+            .map_ty_with_context(|ty, ctxt| ty.tris_textured(ctxt.mesh, tris))
     }
 
     /// Describe the mesh with the given indexed points.
@@ -407,7 +397,7 @@ where
     /// Each trio of `indices` describes a single triangle made up of `points`.
     ///
     /// Each point may be any type that may be converted directly into the `Vec3` type.
-    pub fn indexed<V, I>(self, points: V, indices: I) -> DrawingMesh<'a, SM>
+    pub fn indexed<V, I>(self, points: V, indices: I) -> DrawingMesh<'a>
     where
         V: IntoIterator,
         V::Item: Into<Vec3>,
@@ -423,7 +413,7 @@ where
     /// Each of the `points` must be represented as a tuple containing the point and the color in
     /// that order, e.g. `(point, color)`. `point` may be of any type that implements
     /// `Into<Vec3>` and `color` may be of any type that implements `IntoColor`.
-    pub fn indexed_colored<V, I, P, C>(self, points: V, indices: I) -> DrawingMesh<'a, SM>
+    pub fn indexed_colored<V, I, P, C>(self, points: V, indices: I) -> DrawingMesh<'a>
     where
         V: IntoIterator<Item = (P, C)>,
         I: IntoIterator<Item = usize>,
@@ -446,18 +436,15 @@ where
         texture_handle: Handle<Image>,
         points: V,
         indices: I,
-    ) -> DrawingMesh<'a, SM>
+    ) -> DrawingMesh<'a>
     where
         V: IntoIterator<Item = (P, T)>,
         I: IntoIterator<Item = usize>,
         P: Into<Vec3>,
         T: Into<Vec2>,
     {
-        self.map_shader_model(|mut model| {
-            model.set_texture(texture_handle);
-            model
-        })
-        .map_ty_with_context(|ty, ctxt| ty.indexed_textured(ctxt.mesh, points, indices))
+        self.texture(&texture_handle)
+            .map_ty_with_context(|ty, ctxt| ty.indexed_textured(ctxt.mesh, points, indices))
     }
 }
 

--- a/nannou_draw/src/draw/primitive/mesh.rs
+++ b/nannou_draw/src/draw/primitive/mesh.rs
@@ -305,7 +305,11 @@ impl<'a> Drawing<'a, Vertexless> {
         I: IntoIterator,
         I::Item: Into<Vec3>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.points(ctxt.mesh, points))
+        let mut vertices = points
+            .into_iter()
+            .map(|p| (p.into(), Color::default(), Vec2::ZERO));
+        mesh_points(&self.draw, self.index, true, &mut vertices);
+        self.transition()
     }
 
     /// Describe the mesh with a sequence of colored points.
@@ -319,7 +323,11 @@ impl<'a> Drawing<'a, Vertexless> {
         P: Into<Vec3>,
         C: Into<Color>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.points_colored(ctxt.mesh, points))
+        let mut vertices = points
+            .into_iter()
+            .map(|(p, c)| (p.into(), c.into(), Vec2::ZERO));
+        mesh_points(&self.draw, self.index, false, &mut vertices);
+        self.transition()
     }
 
     /// Describe the mesh with a sequence of textured points.
@@ -338,8 +346,12 @@ impl<'a> Drawing<'a, Vertexless> {
         P: Into<Vec3>,
         T: Into<Vec2>,
     {
-        self.texture(&texture_handle)
-            .map_ty_with_context(|ty, ctxt| ty.points_textured(ctxt.mesh, points))
+        let this = self.texture(&texture_handle);
+        let mut vertices = points
+            .into_iter()
+            .map(|(p, t)| (p.into(), Color::default(), t.into()));
+        mesh_points(&this.draw, this.index, false, &mut vertices);
+        this.transition()
     }
 
     /// Describe the mesh with a sequence of triangles.
@@ -355,7 +367,13 @@ impl<'a> Drawing<'a, Vertexless> {
         I: IntoIterator<Item = geom::Tri<V>>,
         V: Into<Vec3>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.tris(ctxt.mesh, tris))
+        let mut vertices = tris
+            .into_iter()
+            .map(|t| t.map_vertices(Into::into))
+            .flat_map(geom::Tri::vertices)
+            .map(|p| (p, Color::default(), Vec2::ZERO));
+        mesh_points(&self.draw, self.index, true, &mut vertices);
+        self.transition()
     }
 
     /// Describe the mesh with a sequence of colored triangles.
@@ -369,7 +387,13 @@ impl<'a> Drawing<'a, Vertexless> {
         P: Into<Vec3>,
         C: Into<Color>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.tris_colored(ctxt.mesh, tris))
+        let mut vertices = tris
+            .into_iter()
+            .map(|t| t.map_vertices(|(p, c)| (p.into(), c.into())))
+            .flat_map(geom::Tri::vertices)
+            .map(|(p, c)| (p, c, Vec2::ZERO));
+        mesh_points(&self.draw, self.index, false, &mut vertices);
+        self.transition()
     }
 
     /// Describe the mesh with a sequence of textured triangles.
@@ -378,18 +402,20 @@ impl<'a> Drawing<'a, Vertexless> {
     /// coordinates in that order, e.g. `(point, tex_coords)`. `point` may be of any type that
     /// implements `Into<Vec3>` and `tex_coords` may be of any type that implements
     /// `Into<Vec2>`.
-    pub fn tris_textured<I, P, T>(
-        self,
-        texture_handle: Handle<Image>,
-        tris: I,
-    ) -> DrawingMesh<'a>
+    pub fn tris_textured<I, P, T>(self, texture_handle: Handle<Image>, tris: I) -> DrawingMesh<'a>
     where
         I: IntoIterator<Item = geom::Tri<(P, T)>>,
         P: Into<Vec3>,
         T: Into<Vec2>,
     {
-        self.texture(&texture_handle)
-            .map_ty_with_context(|ty, ctxt| ty.tris_textured(ctxt.mesh, tris))
+        let this = self.texture(&texture_handle);
+        let mut vertices = tris
+            .into_iter()
+            .map(|t| t.map_vertices(|(p, t)| (p.into(), t.into())))
+            .flat_map(geom::Tri::vertices)
+            .map(|(p, t)| (p, Color::default(), t));
+        mesh_points(&this.draw, this.index, false, &mut vertices);
+        this.transition()
     }
 
     /// Describe the mesh with the given indexed points.
@@ -403,7 +429,12 @@ impl<'a> Drawing<'a, Vertexless> {
         V::Item: Into<Vec3>,
         I: IntoIterator<Item = usize>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.indexed(ctxt.mesh, points, indices))
+        let mut vertices = points
+            .into_iter()
+            .map(|p| (p.into(), Color::default(), Vec2::ZERO));
+        let mut indices = indices.into_iter();
+        mesh_indexed(&self.draw, self.index, true, &mut vertices, &mut indices);
+        self.transition()
     }
 
     /// Describe the mesh with the given indexed, colored points.
@@ -420,7 +451,12 @@ impl<'a> Drawing<'a, Vertexless> {
         P: Into<Vec3>,
         C: Into<Color>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.indexed_colored(ctxt.mesh, points, indices))
+        let mut vertices = points
+            .into_iter()
+            .map(|(p, c)| (p.into(), c.into(), Vec2::ZERO));
+        let mut indices = indices.into_iter();
+        mesh_indexed(&self.draw, self.index, false, &mut vertices, &mut indices);
+        self.transition()
     }
 
     /// Describe the mesh with the given indexed, textured points.
@@ -443,9 +479,62 @@ impl<'a> Drawing<'a, Vertexless> {
         P: Into<Vec3>,
         T: Into<Vec2>,
     {
-        self.texture(&texture_handle)
-            .map_ty_with_context(|ty, ctxt| ty.indexed_textured(ctxt.mesh, points, indices))
+        let this = self.texture(&texture_handle);
+        let mut vertices = points
+            .into_iter()
+            .map(|(p, t)| (p.into(), Color::default(), t.into()));
+        let mut indices = indices.into_iter();
+        mesh_indexed(&this.draw, this.index, false, &mut vertices, &mut indices);
+        this.transition()
     }
+}
+
+// Submit the mesh's vertices, transitioning the primitive from `Vertexless` to `Mesh`.
+//
+// `themed_fill` indicates that the vertices carry no colour of their own and the mesh should be
+// filled with a single colour (the one set via the builder methods, or the theme's default).
+fn mesh_points(
+    draw: &crate::draw::Draw,
+    index: usize,
+    themed_fill: bool,
+    vertices: &mut dyn Iterator<Item = Vertex>,
+) {
+    crate::draw::drawing::with_primitive_ctxt(draw, index, |prim, ctxt| match prim {
+        Primitive::MeshVertexless(v) => {
+            let mut mesh = v.points_inner(ctxt.mesh, vertices);
+            if themed_fill {
+                mesh.fill_color = Some(FillColor(None));
+            }
+            Primitive::Mesh(mesh)
+        }
+        other => {
+            bevy::log::warn_once!("expected a `Vertexless` mesh primitive");
+            other
+        }
+    })
+}
+
+// The same as `mesh_points`, but with explicit indices.
+fn mesh_indexed(
+    draw: &crate::draw::Draw,
+    index: usize,
+    themed_fill: bool,
+    vertices: &mut dyn Iterator<Item = Vertex>,
+    indices: &mut dyn Iterator<Item = usize>,
+) {
+    crate::draw::drawing::with_primitive_ctxt(draw, index, |prim, ctxt| match prim {
+        Primitive::MeshVertexless(v) => {
+            let mut mesh = v.indexed_inner(ctxt.mesh, vertices, indices);
+            if themed_fill {
+                mesh.fill_color = Some(FillColor(None));
+            }
+            Primitive::Mesh(mesh)
+        }
+        other => {
+            bevy::log::warn_once!("expected a `Vertexless` mesh primitive");
+            other
+        }
+    })
 }
 
 impl draw::render::RenderPrimitive for PrimitiveMesh {
@@ -544,23 +633,5 @@ impl From<Vertexless> for Primitive {
 impl From<PrimitiveMesh> for Primitive {
     fn from(prim: PrimitiveMesh) -> Self {
         Primitive::Mesh(prim)
-    }
-}
-
-impl Into<Option<Vertexless>> for Primitive {
-    fn into(self) -> Option<Vertexless> {
-        match self {
-            Primitive::MeshVertexless(prim) => Some(prim),
-            _ => None,
-        }
-    }
-}
-
-impl Into<Option<PrimitiveMesh>> for Primitive {
-    fn into(self) -> Option<PrimitiveMesh> {
-        match self {
-            Primitive::Mesh(prim) => Some(prim),
-            _ => None,
-        }
     }
 }

--- a/nannou_draw/src/draw/primitive/mod.rs
+++ b/nannou_draw/src/draw/primitive/mod.rs
@@ -1,6 +1,14 @@
 use bevy::prelude::{Color, Component};
+use lyon::tessellation::{FillOptions, StrokeOptions};
 
 use nannou_core::geom::{Vec2, Vec3};
+
+use crate::draw::primitive::polygon::{PolygonOptions, SetPolygon};
+use crate::draw::properties::spatial::{dimension, orientation, position};
+use crate::draw::properties::tex_coords::SetTexCoords;
+use crate::draw::properties::{
+    SetColor, SetDimensions, SetFill, SetOrientation, SetPosition, SetStroke,
+};
 
 pub use self::arrow::Arrow;
 pub use self::ellipse::Ellipse;
@@ -48,4 +56,151 @@ pub enum Primitive {
     Rect(Rect),
     Text(Text),
     Tri(Tri),
+}
+
+/// The cheapest possible variant, used as a placeholder when temporarily taking ownership of a
+/// stored primitive (e.g. for type-state transitions).
+impl Default for Primitive {
+    fn default() -> Self {
+        Primitive::PathInit(PathInit)
+    }
+}
+
+// Total accessors over all variants for each property channel.
+//
+// Each returns `Some` exactly for the variants whose inner type implements the corresponding
+// `Set*` trait, `None` otherwise. The marker-gated `Drawing` API only exposes a property method
+// when the marker type implements the trait, so `None` is unreachable via the public builders -
+// it exists to keep these functions total.
+impl Primitive {
+    pub(crate) fn color_mut(&mut self) -> Option<&mut Option<Color>> {
+        match self {
+            Primitive::Arrow(p) => Some(SetColor::color_mut(p)),
+            Primitive::Ellipse(p) => Some(SetColor::color_mut(p)),
+            Primitive::Line(p) => Some(SetColor::color_mut(p)),
+            Primitive::Mesh(p) => Some(SetColor::color_mut(p)),
+            Primitive::PathFill(p) => Some(SetColor::color_mut(p)),
+            Primitive::PathStroke(p) => Some(SetColor::color_mut(p)),
+            Primitive::Path(p) => Some(SetColor::color_mut(p)),
+            Primitive::PolygonInit(p) => Some(SetColor::color_mut(p)),
+            Primitive::Polygon(p) => Some(SetColor::color_mut(p)),
+            Primitive::Quad(p) => Some(SetColor::color_mut(p)),
+            Primitive::Rect(p) => Some(SetColor::color_mut(p)),
+            Primitive::Text(p) => Some(SetColor::color_mut(p)),
+            Primitive::Tri(p) => Some(SetColor::color_mut(p)),
+            Primitive::MeshVertexless(_) | Primitive::PathInit(_) => None,
+        }
+    }
+
+    pub(crate) fn position_mut(&mut self) -> Option<&mut position::Properties> {
+        match self {
+            Primitive::Arrow(p) => Some(SetPosition::properties(p)),
+            Primitive::Ellipse(p) => Some(SetPosition::properties(p)),
+            Primitive::Line(p) => Some(SetPosition::properties(p)),
+            Primitive::Mesh(p) => Some(SetPosition::properties(p)),
+            Primitive::PathFill(p) => Some(SetPosition::properties(p)),
+            Primitive::PathStroke(p) => Some(SetPosition::properties(p)),
+            Primitive::Path(p) => Some(SetPosition::properties(p)),
+            Primitive::PolygonInit(p) => Some(SetPosition::properties(p)),
+            Primitive::Polygon(p) => Some(SetPosition::properties(p)),
+            Primitive::Quad(p) => Some(SetPosition::properties(p)),
+            Primitive::Rect(p) => Some(SetPosition::properties(p)),
+            Primitive::Text(p) => Some(SetPosition::properties(p)),
+            Primitive::Tri(p) => Some(SetPosition::properties(p)),
+            Primitive::MeshVertexless(_) | Primitive::PathInit(_) => None,
+        }
+    }
+
+    pub(crate) fn orientation_mut(&mut self) -> Option<&mut orientation::Properties> {
+        match self {
+            Primitive::Arrow(p) => Some(SetOrientation::properties(p)),
+            Primitive::Ellipse(p) => Some(SetOrientation::properties(p)),
+            Primitive::Line(p) => Some(SetOrientation::properties(p)),
+            Primitive::Mesh(p) => Some(SetOrientation::properties(p)),
+            Primitive::PathFill(p) => Some(SetOrientation::properties(p)),
+            Primitive::PathStroke(p) => Some(SetOrientation::properties(p)),
+            Primitive::Path(p) => Some(SetOrientation::properties(p)),
+            Primitive::PolygonInit(p) => Some(SetOrientation::properties(p)),
+            Primitive::Polygon(p) => Some(SetOrientation::properties(p)),
+            Primitive::Quad(p) => Some(SetOrientation::properties(p)),
+            Primitive::Rect(p) => Some(SetOrientation::properties(p)),
+            Primitive::Text(p) => Some(SetOrientation::properties(p)),
+            Primitive::Tri(p) => Some(SetOrientation::properties(p)),
+            Primitive::MeshVertexless(_) | Primitive::PathInit(_) => None,
+        }
+    }
+
+    pub(crate) fn dimensions_mut(&mut self) -> Option<&mut dimension::Properties> {
+        match self {
+            Primitive::Ellipse(p) => Some(SetDimensions::properties(p)),
+            Primitive::Quad(p) => Some(SetDimensions::properties(p)),
+            Primitive::Rect(p) => Some(SetDimensions::properties(p)),
+            Primitive::Text(p) => Some(SetDimensions::properties(p)),
+            Primitive::Tri(p) => Some(SetDimensions::properties(p)),
+            Primitive::Arrow(_)
+            | Primitive::Line(_)
+            | Primitive::Mesh(_)
+            | Primitive::MeshVertexless(_)
+            | Primitive::PathInit(_)
+            | Primitive::PathFill(_)
+            | Primitive::PathStroke(_)
+            | Primitive::Path(_)
+            | Primitive::PolygonInit(_)
+            | Primitive::Polygon(_) => None,
+        }
+    }
+
+    pub(crate) fn stroke_options_mut(&mut self) -> Option<&mut StrokeOptions> {
+        match self {
+            Primitive::Arrow(p) => Some(SetStroke::stroke_options_mut(p)),
+            Primitive::Ellipse(p) => Some(SetStroke::stroke_options_mut(p)),
+            Primitive::Line(p) => Some(SetStroke::stroke_options_mut(p)),
+            Primitive::PathStroke(p) => Some(SetStroke::stroke_options_mut(p)),
+            Primitive::PolygonInit(p) => Some(SetStroke::stroke_options_mut(p)),
+            Primitive::Quad(p) => Some(SetStroke::stroke_options_mut(p)),
+            Primitive::Rect(p) => Some(SetStroke::stroke_options_mut(p)),
+            Primitive::Tri(p) => Some(SetStroke::stroke_options_mut(p)),
+            Primitive::Mesh(_)
+            | Primitive::MeshVertexless(_)
+            | Primitive::PathInit(_)
+            | Primitive::PathFill(_)
+            | Primitive::Path(_)
+            | Primitive::Polygon(_)
+            | Primitive::Text(_) => None,
+        }
+    }
+
+    pub(crate) fn fill_options_mut(&mut self) -> Option<&mut FillOptions> {
+        match self {
+            Primitive::PathFill(p) => Some(SetFill::fill_options_mut(p)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn polygon_options_mut(&mut self) -> Option<&mut PolygonOptions> {
+        match self {
+            Primitive::Ellipse(p) => Some(SetPolygon::polygon_options_mut(p)),
+            Primitive::PolygonInit(p) => Some(SetPolygon::polygon_options_mut(p)),
+            Primitive::Quad(p) => Some(SetPolygon::polygon_options_mut(p)),
+            Primitive::Rect(p) => Some(SetPolygon::polygon_options_mut(p)),
+            Primitive::Tri(p) => Some(SetPolygon::polygon_options_mut(p)),
+            Primitive::Arrow(_)
+            | Primitive::Line(_)
+            | Primitive::Mesh(_)
+            | Primitive::MeshVertexless(_)
+            | Primitive::PathInit(_)
+            | Primitive::PathFill(_)
+            | Primitive::PathStroke(_)
+            | Primitive::Path(_)
+            | Primitive::Polygon(_)
+            | Primitive::Text(_) => None,
+        }
+    }
+
+    pub(crate) fn tex_coords_mut(&mut self) -> Option<&mut Option<nannou_core::geom::Rect>> {
+        match self {
+            Primitive::Rect(p) => Some(SetTexCoords::tex_coords_mut(p)),
+            _ => None,
+        }
+    }
 }

--- a/nannou_draw/src/draw/primitive/path.rs
+++ b/nannou_draw/src/draw/primitive/path.rs
@@ -5,7 +5,7 @@ use lyon::tessellation::{FillOptions, FillTessellator, StrokeOptions, StrokeTess
 use crate::draw::primitive::Primitive;
 use crate::draw::properties::spatial::{orientation, position};
 use crate::draw::properties::{SetColor, SetFill, SetOrientation, SetPosition, SetStroke};
-use crate::draw::{self, Drawing, DrawingContext};
+use crate::draw::{self, Drawing, DrawingContext, drawing};
 
 /// A set of path tessellation options (FillOptions or StrokeOptions).
 pub trait TessellationOptions {
@@ -570,55 +570,57 @@ impl<'a> DrawingPathInit<'a> {
     ///
     /// The returned building context allows for specifying the fill tessellation options.
     pub fn fill(self) -> DrawingPathFill<'a> {
-        self.map_ty(|ty| ty.fill())
+        path_fill(&self.draw, self.index);
+        self.transition()
     }
 
     /// Specify that we want to use stroke tessellation for the path.
     ///
     /// The returned building context allows for specifying the stroke tessellation options.
     pub fn stroke(self) -> DrawingPathStroke<'a> {
-        self.map_ty(|ty| ty.stroke())
+        path_stroke(&self.draw, self.index);
+        self.transition()
     }
 }
 
 impl<'a> DrawingPathFill<'a> {
     /// Maximum allowed distance to the path when building an approximation.
     pub fn tolerance(self, tolerance: f32) -> Self {
-        self.map_ty(|ty| ty.tolerance(tolerance))
+        self.fill_tolerance(tolerance)
     }
 
     /// Specify the rule used to determine what is inside and what is outside of the shape.
     ///
     /// Currently, only the `EvenOdd` rule is implemented.
     pub fn rule(self, rule: lyon::tessellation::FillRule) -> Self {
-        self.map_ty(|ty| ty.rule(rule))
+        self.fill_rule(rule)
     }
 }
 
 impl<'a> DrawingPathStroke<'a> {
     /// Short-hand for the `stroke_weight` method.
     pub fn weight(self, weight: f32) -> Self {
-        self.map_ty(|ty| ty.stroke_weight(weight))
+        self.stroke_weight(weight)
     }
 
     /// Short-hand for the `stroke_tolerance` method.
     pub fn tolerance(self, tolerance: f32) -> Self {
-        self.map_ty(|ty| ty.stroke_tolerance(tolerance))
+        self.stroke_tolerance(tolerance)
     }
 }
 
 impl<'a, T> DrawingPathOptions<'a, T>
 where
     T: TessellationOptions,
-    PathOptions<T>: Into<Primitive> + Clone,
-    Primitive: Into<Option<PathOptions<T>>>,
 {
     /// Submit the path events to be tessellated.
     pub fn events<I>(self, events: I) -> DrawingPath<'a>
     where
         I: IntoIterator<Item = lyon::path::PathEvent>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.events(ctxt, events))
+        let mut events = events.into_iter();
+        path_events(&self.draw, self.index, &mut events);
+        self.transition()
     }
 
     /// Submit the path events as a polyline of points.
@@ -627,7 +629,9 @@ where
         I: IntoIterator,
         I::Item: Into<Vec2>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.points(ctxt, points))
+        let mut points = points.into_iter().map(Into::into);
+        path_points(&self.draw, self.index, false, &mut points);
+        self.transition()
     }
 
     /// Submit the path events as a polyline of points.
@@ -638,7 +642,9 @@ where
         I: IntoIterator,
         I::Item: Into<Vec2>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.points_closed(ctxt, points))
+        let mut points = points.into_iter().map(Into::into);
+        path_points(&self.draw, self.index, true, &mut points);
+        self.transition()
     }
 
     pub fn points_colored<I, P, C>(self, points: I) -> DrawingPath<'a>
@@ -647,9 +653,11 @@ where
         P: Into<Vec2>,
         C: Into<Color>,
     {
-        self.map_ty_with_context(|ty, ctxt| {
-            ty.vertices(ctxt, points.into_iter().map(|(p, c)| (p, c, Vec2::ZERO)))
-        })
+        let mut points = points
+            .into_iter()
+            .map(|(p, c)| (p.into(), c.into(), Vec2::ZERO));
+        path_points_vertex(&self.draw, self.index, false, &mut points);
+        self.transition()
     }
 
     pub fn points_colored_closed<I, P, C>(self, points: I) -> DrawingPath<'a>
@@ -658,9 +666,11 @@ where
         P: Into<Vec2>,
         C: Into<Color>,
     {
-        self.map_ty_with_context(|ty, ctxt| {
-            ty.vertices_closed(ctxt, points.into_iter().map(|(p, c)| (p, c, Vec2::ZERO)))
-        })
+        let mut points = points
+            .into_iter()
+            .map(|(p, c)| (p.into(), c.into(), Vec2::ZERO));
+        path_points_vertex(&self.draw, self.index, true, &mut points);
+        self.transition()
     }
 
     /// Submit path events as a polyline of vertex points.
@@ -671,7 +681,11 @@ where
         C: Into<Color>,
         U: Into<Vec2>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.vertices(ctxt, points))
+        let mut points = points
+            .into_iter()
+            .map(|(p, c, u)| (p.into(), c.into(), u.into()));
+        path_points_vertex(&self.draw, self.index, false, &mut points);
+        self.transition()
     }
 
     /// Submit path events as a polyline of vertex points.
@@ -684,8 +698,79 @@ where
         C: Into<Color>,
         U: Into<Vec2>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.vertices_closed(ctxt, points))
+        let mut points = points
+            .into_iter()
+            .map(|(p, c, u)| (p.into(), c.into(), u.into()));
+        path_points_vertex(&self.draw, self.index, true, &mut points);
+        self.transition()
     }
+}
+
+// Transition the primitive being drawn at `index` from `PathInit` to `PathFill`.
+fn path_fill(draw: &draw::Draw, index: usize) {
+    drawing::with_primitive(draw, index, |prim| match prim {
+        Primitive::PathInit(_) => *prim = Primitive::PathFill(PathInit.fill()),
+        _ => bevy::log::warn_once!("expected a `PathInit` primitive"),
+    })
+}
+
+// Transition the primitive being drawn at `index` from `PathInit` to `PathStroke`.
+fn path_stroke(draw: &draw::Draw, index: usize) {
+    drawing::with_primitive(draw, index, |prim| match prim {
+        Primitive::PathInit(_) => *prim = Primitive::PathStroke(PathInit.stroke()),
+        _ => bevy::log::warn_once!("expected a `PathInit` primitive"),
+    })
+}
+
+// Submit the path's events, transitioning the primitive from `PathFill` or `PathStroke` to
+// `Path`.
+fn path_events(draw: &draw::Draw, index: usize, events: &mut dyn Iterator<Item = PathEvent>) {
+    drawing::with_primitive_ctxt(draw, index, |prim, ctxt| match prim {
+        Primitive::PathFill(opts) => Primitive::Path(opts.events(ctxt, events)),
+        Primitive::PathStroke(opts) => Primitive::Path(opts.events(ctxt, events)),
+        other => {
+            bevy::log::warn_once!("expected a `PathFill` or `PathStroke` primitive");
+            other
+        }
+    })
+}
+
+// Submit the path's points, transitioning the primitive from `PathFill` or `PathStroke` to
+// `Path`.
+fn path_points(
+    draw: &draw::Draw,
+    index: usize,
+    close: bool,
+    points: &mut dyn Iterator<Item = Vec2>,
+) {
+    drawing::with_primitive_ctxt(draw, index, |prim, ctxt| match prim {
+        Primitive::PathFill(opts) => Primitive::Path(opts.points_inner(ctxt, close, points)),
+        Primitive::PathStroke(opts) => Primitive::Path(opts.points_inner(ctxt, close, points)),
+        other => {
+            bevy::log::warn_once!("expected a `PathFill` or `PathStroke` primitive");
+            other
+        }
+    })
+}
+
+// Submit the path's vertex points, transitioning the primitive from `PathFill` or `PathStroke`
+// to `Path`.
+fn path_points_vertex(
+    draw: &draw::Draw,
+    index: usize,
+    close: bool,
+    points: &mut dyn Iterator<Item = (Vec2, Color, Vec2)>,
+) {
+    drawing::with_primitive_ctxt(draw, index, |prim, ctxt| match prim {
+        Primitive::PathFill(opts) => Primitive::Path(opts.points_vertex_inner(ctxt, close, points)),
+        Primitive::PathStroke(opts) => {
+            Primitive::Path(opts.points_vertex_inner(ctxt, close, points))
+        }
+        other => {
+            bevy::log::warn_once!("expected a `PathFill` or `PathStroke` primitive");
+            other
+        }
+    })
 }
 
 impl SetFill for PathFill {
@@ -771,41 +856,5 @@ impl From<PathFill> for Primitive {
 impl From<Path> for Primitive {
     fn from(prim: Path) -> Self {
         Primitive::Path(prim)
-    }
-}
-
-impl Into<Option<PathInit>> for Primitive {
-    fn into(self) -> Option<PathInit> {
-        match self {
-            Primitive::PathInit(prim) => Some(prim),
-            _ => None,
-        }
-    }
-}
-
-impl Into<Option<PathFill>> for Primitive {
-    fn into(self) -> Option<PathFill> {
-        match self {
-            Primitive::PathFill(prim) => Some(prim),
-            _ => None,
-        }
-    }
-}
-
-impl Into<Option<PathStroke>> for Primitive {
-    fn into(self) -> Option<PathStroke> {
-        match self {
-            Primitive::PathStroke(prim) => Some(prim),
-            _ => None,
-        }
-    }
-}
-
-impl Into<Option<Path>> for Primitive {
-    fn into(self) -> Option<Path> {
-        match self {
-            Primitive::Path(prim) => Some(prim),
-            _ => None,
-        }
     }
 }

--- a/nannou_draw/src/draw/primitive/path.rs
+++ b/nannou_draw/src/draw/primitive/path.rs
@@ -6,7 +6,6 @@ use crate::draw::primitive::Primitive;
 use crate::draw::properties::spatial::{orientation, position};
 use crate::draw::properties::{SetColor, SetFill, SetOrientation, SetPosition, SetStroke};
 use crate::draw::{self, Drawing, DrawingContext};
-use crate::render::ShaderModel;
 
 /// A set of path tessellation options (FillOptions or StrokeOptions).
 pub trait TessellationOptions {
@@ -72,19 +71,19 @@ pub struct Path {
 }
 
 /// The initial drawing context for a path.
-pub type DrawingPathInit<'a, SM> = Drawing<'a, PathInit, SM>;
+pub type DrawingPathInit<'a> = Drawing<'a, PathInit>;
 
 /// The drawing context for a path in the tessellation options state.
-pub type DrawingPathOptions<'a, T, SM> = Drawing<'a, PathOptions<T>, SM>;
+pub type DrawingPathOptions<'a, T> = Drawing<'a, PathOptions<T>>;
 
 /// The drawing context for a stroked path, prior to path event submission.
-pub type DrawingPathStroke<'a, SM> = Drawing<'a, PathStroke, SM>;
+pub type DrawingPathStroke<'a> = Drawing<'a, PathStroke>;
 
 /// The drawing context for a filled path, prior to path event submission.
-pub type DrawingPathFill<'a, SM> = Drawing<'a, PathFill, SM>;
+pub type DrawingPathFill<'a> = Drawing<'a, PathFill>;
 
 /// The drawing context for a polyline whose vertices have been specified.
-pub type DrawingPath<'a, SM> = Drawing<'a, Path, SM>;
+pub type DrawingPath<'a> = Drawing<'a, Path>;
 
 /// Dynamically distinguish between fill and stroke tessellation options.
 #[derive(Clone, Debug)]
@@ -566,29 +565,23 @@ impl Path {
     }
 }
 
-impl<'a, SM> DrawingPathInit<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingPathInit<'a> {
     /// Specify that we want to use fill tessellation for the path.
     ///
     /// The returned building context allows for specifying the fill tessellation options.
-    pub fn fill(self) -> DrawingPathFill<'a, SM> {
+    pub fn fill(self) -> DrawingPathFill<'a> {
         self.map_ty(|ty| ty.fill())
     }
 
     /// Specify that we want to use stroke tessellation for the path.
     ///
     /// The returned building context allows for specifying the stroke tessellation options.
-    pub fn stroke(self) -> DrawingPathStroke<'a, SM> {
+    pub fn stroke(self) -> DrawingPathStroke<'a> {
         self.map_ty(|ty| ty.stroke())
     }
 }
 
-impl<'a, SM> DrawingPathFill<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingPathFill<'a> {
     /// Maximum allowed distance to the path when building an approximation.
     pub fn tolerance(self, tolerance: f32) -> Self {
         self.map_ty(|ty| ty.tolerance(tolerance))
@@ -602,10 +595,7 @@ where
     }
 }
 
-impl<'a, SM> DrawingPathStroke<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingPathStroke<'a> {
     /// Short-hand for the `stroke_weight` method.
     pub fn weight(self, weight: f32) -> Self {
         self.map_ty(|ty| ty.stroke_weight(weight))
@@ -617,15 +607,14 @@ where
     }
 }
 
-impl<'a, T, SM> DrawingPathOptions<'a, T, SM>
+impl<'a, T> DrawingPathOptions<'a, T>
 where
     T: TessellationOptions,
-    SM: ShaderModel + Default,
     PathOptions<T>: Into<Primitive> + Clone,
     Primitive: Into<Option<PathOptions<T>>>,
 {
     /// Submit the path events to be tessellated.
-    pub fn events<I>(self, events: I) -> DrawingPath<'a, SM>
+    pub fn events<I>(self, events: I) -> DrawingPath<'a>
     where
         I: IntoIterator<Item = lyon::path::PathEvent>,
     {
@@ -633,7 +622,7 @@ where
     }
 
     /// Submit the path events as a polyline of points.
-    pub fn points<I>(self, points: I) -> DrawingPath<'a, SM>
+    pub fn points<I>(self, points: I) -> DrawingPath<'a>
     where
         I: IntoIterator,
         I::Item: Into<Vec2>,
@@ -644,7 +633,7 @@ where
     /// Submit the path events as a polyline of points.
     ///
     /// An event will be generated that closes the start and end points.
-    pub fn points_closed<I>(self, points: I) -> DrawingPath<'a, SM>
+    pub fn points_closed<I>(self, points: I) -> DrawingPath<'a>
     where
         I: IntoIterator,
         I::Item: Into<Vec2>,
@@ -652,7 +641,7 @@ where
         self.map_ty_with_context(|ty, ctxt| ty.points_closed(ctxt, points))
     }
 
-    pub fn points_colored<I, P, C>(self, points: I) -> DrawingPath<'a, SM>
+    pub fn points_colored<I, P, C>(self, points: I) -> DrawingPath<'a>
     where
         I: IntoIterator<Item = (P, C)>,
         P: Into<Vec2>,
@@ -663,7 +652,7 @@ where
         })
     }
 
-    pub fn points_colored_closed<I, P, C>(self, points: I) -> DrawingPath<'a, SM>
+    pub fn points_colored_closed<I, P, C>(self, points: I) -> DrawingPath<'a>
     where
         I: IntoIterator<Item = (P, C)>,
         P: Into<Vec2>,
@@ -675,7 +664,7 @@ where
     }
 
     /// Submit path events as a polyline of vertex points.
-    pub fn points_vertex<I, P, C, U>(self, points: I) -> DrawingPath<'a, SM>
+    pub fn points_vertex<I, P, C, U>(self, points: I) -> DrawingPath<'a>
     where
         I: IntoIterator<Item = (P, C, U)>,
         P: Into<Vec2>,
@@ -688,7 +677,7 @@ where
     /// Submit path events as a polyline of vertex points.
     ///
     /// The path with automatically close from the end point to the start point.
-    pub fn points_vertex_closed<I, P, C, U>(self, points: I) -> DrawingPath<'a, SM>
+    pub fn points_vertex_closed<I, P, C, U>(self, points: I) -> DrawingPath<'a>
     where
         I: IntoIterator<Item = (P, C, U)>,
         P: Into<Vec2>,

--- a/nannou_draw/src/draw/primitive/polygon.rs
+++ b/nannou_draw/src/draw/primitive/polygon.rs
@@ -8,7 +8,6 @@ use crate::draw::primitive::path::{self, PathEventSource};
 use crate::draw::properties::spatial::{orientation, position};
 use crate::draw::properties::{SetColor, SetOrientation, SetPosition, SetStroke};
 use crate::draw::{self, Drawing};
-use crate::render::ShaderModel;
 
 /// A trait implemented for all polygon draw primitives.
 pub trait SetPolygon: Sized {
@@ -65,10 +64,10 @@ pub struct Polygon {
 }
 
 /// Initialised drawing state for a polygon.
-pub type DrawingPolygonInit<'a, SM> = Drawing<'a, PolygonInit, SM>;
+pub type DrawingPolygonInit<'a> = Drawing<'a, PolygonInit>;
 
 /// Initialised drawing state for a polygon.
-pub type DrawingPolygon<'a, SM> = Drawing<'a, Polygon, SM>;
+pub type DrawingPolygon<'a> = Drawing<'a, Polygon>;
 
 impl PolygonInit {
     /// Stroke the outline with the given color.
@@ -417,10 +416,9 @@ impl draw::render::RenderPrimitive for Polygon {
     }
 }
 
-impl<'a, T, SM> Drawing<'a, T, SM>
+impl<'a, T> Drawing<'a, T>
 where
     T: SetPolygon + Into<Primitive> + Clone,
-    SM: ShaderModel + Default,
     Primitive: Into<Option<T>>,
 {
     /// Specify no fill color and in turn no fill tessellation for the polygon.
@@ -445,10 +443,7 @@ where
     }
 }
 
-impl<'a, SM> DrawingPolygonInit<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingPolygonInit<'a> {
     /// Stroke the outline with the given color.
     pub fn stroke<C>(self, color: C) -> Self
     where
@@ -458,7 +453,7 @@ where
     }
 
     /// Describe the polygon with a sequence of path events.
-    pub fn events<I>(self, events: I) -> DrawingPolygon<'a, SM>
+    pub fn events<I>(self, events: I) -> DrawingPolygon<'a>
     where
         I: IntoIterator<Item = PathEvent>,
     {
@@ -466,7 +461,7 @@ where
     }
 
     /// Describe the polygon with a sequence of points.
-    pub fn points<I>(self, points: I) -> DrawingPolygon<'a, SM>
+    pub fn points<I>(self, points: I) -> DrawingPolygon<'a>
     where
         I: IntoIterator,
         I::Item: Into<Vec2>,
@@ -474,7 +469,7 @@ where
         self.map_ty_with_context(|ty, ctxt| ty.points(ctxt, points))
     }
 
-    pub fn points_colored<I, P, C>(self, points: I) -> DrawingPolygon<'a, SM>
+    pub fn points_colored<I, P, C>(self, points: I) -> DrawingPolygon<'a>
     where
         I: IntoIterator<Item = (P, C)>,
         P: Into<Vec2>,
@@ -486,7 +481,7 @@ where
     }
 
     /// Consumes an iterator of points and converts them to an iterator yielding path events.
-    pub fn points_vertex<I, P, C, U>(self, points: I) -> DrawingPolygon<'a, SM>
+    pub fn points_vertex<I, P, C, U>(self, points: I) -> DrawingPolygon<'a>
     where
         I: IntoIterator<Item = (P, C, U)>,
         P: Into<Vec2>,

--- a/nannou_draw/src/draw/primitive/polygon.rs
+++ b/nannou_draw/src/draw/primitive/polygon.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use lyon::path::PathEvent;
 use lyon::tessellation::StrokeOptions;
 
-use crate::draw::drawing::DrawingContext;
+use crate::draw::drawing::{self, DrawingContext};
 use crate::draw::primitive::Primitive;
 use crate::draw::primitive::path::{self, PathEventSource};
 use crate::draw::properties::spatial::{orientation, position};
@@ -418,12 +418,12 @@ impl draw::render::RenderPrimitive for Polygon {
 
 impl<'a, T> Drawing<'a, T>
 where
-    T: SetPolygon + Into<Primitive> + Clone,
-    Primitive: Into<Option<T>>,
+    T: SetPolygon,
 {
     /// Specify no fill color and in turn no fill tessellation for the polygon.
     pub fn no_fill(self) -> Self {
-        self.map_ty(|ty| ty.no_fill())
+        set_polygon(&self.draw, self.index, Update::NoFill);
+        self
     }
 
     /// Specify a color to use for stroke tessellation.
@@ -434,12 +434,14 @@ where
     where
         C: Into<Color>,
     {
-        self.map_ty(|ty| ty.stroke_color(color))
+        set_polygon(&self.draw, self.index, Update::StrokeColor(color.into()));
+        self
     }
 
     /// Specify the whole set of polygon options.
     pub fn polygon_options(self, opts: PolygonOptions) -> Self {
-        self.map_ty(|ty| ty.polygon_options(opts))
+        set_polygon(&self.draw, self.index, Update::Opts(opts));
+        self
     }
 }
 
@@ -449,7 +451,7 @@ impl<'a> DrawingPolygonInit<'a> {
     where
         C: Into<Color>,
     {
-        self.map_ty(|ty| ty.stroke(color))
+        self.stroke_color(color)
     }
 
     /// Describe the polygon with a sequence of path events.
@@ -457,7 +459,9 @@ impl<'a> DrawingPolygonInit<'a> {
     where
         I: IntoIterator<Item = PathEvent>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.events(ctxt, events))
+        let mut events = events.into_iter();
+        polygon_events(&self.draw, self.index, &mut events);
+        self.transition()
     }
 
     /// Describe the polygon with a sequence of points.
@@ -466,7 +470,9 @@ impl<'a> DrawingPolygonInit<'a> {
         I: IntoIterator,
         I::Item: Into<Vec2>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.points(ctxt, points))
+        let mut points = points.into_iter().map(Into::into);
+        polygon_points(&self.draw, self.index, &mut points);
+        self.transition()
     }
 
     pub fn points_colored<I, P, C>(self, points: I) -> DrawingPolygon<'a>
@@ -475,9 +481,11 @@ impl<'a> DrawingPolygonInit<'a> {
         P: Into<Vec2>,
         C: Into<Color>,
     {
-        self.map_ty_with_context(|ty, ctxt| {
-            ty.points_vertex(ctxt, points.into_iter().map(|(p, c)| (p, c, Vec2::ZERO)))
-        })
+        let mut points = points
+            .into_iter()
+            .map(|(p, c)| (p.into(), c.into(), Vec2::ZERO));
+        polygon_points_vertex(&self.draw, self.index, &mut points);
+        self.transition()
     }
 
     /// Consumes an iterator of points and converts them to an iterator yielding path events.
@@ -488,7 +496,11 @@ impl<'a> DrawingPolygonInit<'a> {
         C: Into<Color>,
         U: Into<Vec2>,
     {
-        self.map_ty_with_context(|ty, ctxt| ty.points_vertex(ctxt, points))
+        let mut points = points
+            .into_iter()
+            .map(|(p, c, u)| (p.into(), c.into(), u.into()));
+        polygon_points_vertex(&self.draw, self.index, &mut points);
+        self.transition()
     }
 }
 
@@ -558,20 +570,59 @@ impl From<Polygon> for Primitive {
     }
 }
 
-impl Into<Option<PolygonInit>> for Primitive {
-    fn into(self) -> Option<PolygonInit> {
-        match self {
-            Primitive::PolygonInit(prim) => Some(prim),
-            _ => None,
-        }
-    }
+// An update to a primitive's polygon options.
+pub(crate) enum Update {
+    NoFill,
+    StrokeColor(Color),
+    Opts(PolygonOptions),
 }
 
-impl Into<Option<Polygon>> for Primitive {
-    fn into(self) -> Option<Polygon> {
-        match self {
-            Primitive::Polygon(prim) => Some(prim),
-            _ => None,
+// Update the polygon options of the primitive being drawn at `index`.
+pub(crate) fn set_polygon(draw: &draw::Draw, index: usize, update: Update) {
+    drawing::with_primitive(draw, index, |prim| match prim.polygon_options_mut() {
+        Some(opts) => match update {
+            Update::NoFill => opts.no_fill = true,
+            Update::StrokeColor(color) => opts.stroke_color = Some(color),
+            Update::Opts(new) => *opts = new,
+        },
+        None => bevy::log::warn_once!("drawing primitive does not support `polygon` options"),
+    })
+}
+
+// Submit the polygon's path events, transitioning the primitive from `PolygonInit` to `Polygon`.
+fn polygon_events(draw: &draw::Draw, index: usize, events: &mut dyn Iterator<Item = PathEvent>) {
+    drawing::with_primitive_ctxt(draw, index, |prim, ctxt| match prim {
+        Primitive::PolygonInit(p) => Primitive::Polygon(p.events(ctxt, events)),
+        other => {
+            bevy::log::warn_once!("expected a `PolygonInit` primitive");
+            other
         }
-    }
+    })
+}
+
+// Submit the polygon's points, transitioning the primitive from `PolygonInit` to `Polygon`.
+fn polygon_points(draw: &draw::Draw, index: usize, points: &mut dyn Iterator<Item = Vec2>) {
+    drawing::with_primitive_ctxt(draw, index, |prim, ctxt| match prim {
+        Primitive::PolygonInit(p) => Primitive::Polygon(p.points(ctxt, points)),
+        other => {
+            bevy::log::warn_once!("expected a `PolygonInit` primitive");
+            other
+        }
+    })
+}
+
+// Submit the polygon's vertex points, transitioning the primitive from `PolygonInit` to
+// `Polygon`.
+fn polygon_points_vertex(
+    draw: &draw::Draw,
+    index: usize,
+    points: &mut dyn Iterator<Item = (Vec2, Color, Vec2)>,
+) {
+    drawing::with_primitive_ctxt(draw, index, |prim, ctxt| match prim {
+        Primitive::PolygonInit(p) => Primitive::Polygon(p.points_vertex(ctxt, points)),
+        other => {
+            bevy::log::warn_once!("expected a `PolygonInit` primitive");
+            other
+        }
+    })
 }

--- a/nannou_draw/src/draw/primitive/quad.rs
+++ b/nannou_draw/src/draw/primitive/quad.rs
@@ -172,16 +172,21 @@ impl<'a> DrawingQuad<'a> {
     where
         P: Into<Vec2>,
     {
-        let quad = geom::Quad([a.into(), b.into(), c.into(), d.into()]);
-        update_quad(&self.draw, self.index, |q| q.quad = quad);
+        set_points(
+            &self.draw,
+            self.index,
+            geom::Quad([a.into(), b.into(), c.into(), d.into()]),
+        );
         self
     }
 }
 
-// Update the inner `Quad` of the primitive being drawn at `index`.
-fn update_quad(draw: &crate::draw::Draw, index: usize, f: impl FnOnce(&mut Quad)) {
+// Set the corner points of the `Quad` primitive being drawn at `index`.
+//
+// Non-generic so that the body compiles here rather than in the caller's crate.
+fn set_points(draw: &crate::draw::Draw, index: usize, points: geom::Quad<Vec2>) {
     crate::draw::drawing::with_primitive(draw, index, |prim| match prim {
-        Primitive::Quad(quad) => f(quad),
+        Primitive::Quad(quad) => quad.quad = points,
         _ => bevy::log::warn_once!("expected a `Quad` primitive"),
     })
 }

--- a/nannou_draw/src/draw/primitive/quad.rs
+++ b/nannou_draw/src/draw/primitive/quad.rs
@@ -164,15 +164,6 @@ impl From<Quad> for Primitive {
     }
 }
 
-impl Into<Option<Quad>> for Primitive {
-    fn into(self) -> Option<Quad> {
-        match self {
-            Primitive::Quad(prim) => Some(prim),
-            _ => None,
-        }
-    }
-}
-
 // Drawing methods.
 
 impl<'a> DrawingQuad<'a> {
@@ -181,6 +172,16 @@ impl<'a> DrawingQuad<'a> {
     where
         P: Into<Vec2>,
     {
-        self.map_ty(|ty| ty.points(a, b, c, d))
+        let quad = geom::Quad([a.into(), b.into(), c.into(), d.into()]);
+        update_quad(&self.draw, self.index, |q| q.quad = quad);
+        self
     }
+}
+
+// Update the inner `Quad` of the primitive being drawn at `index`.
+fn update_quad(draw: &crate::draw::Draw, index: usize, f: impl FnOnce(&mut Quad)) {
+    crate::draw::drawing::with_primitive(draw, index, |prim| match prim {
+        Primitive::Quad(quad) => f(quad),
+        _ => bevy::log::warn_once!("expected a `Quad` primitive"),
+    })
 }

--- a/nannou_draw/src/draw/primitive/quad.rs
+++ b/nannou_draw/src/draw/primitive/quad.rs
@@ -10,7 +10,6 @@ use crate::draw::properties::{
     SetColor, SetDimensions, SetOrientation, SetPosition, SetStroke, spatial,
 };
 use crate::draw::{self, Drawing};
-use crate::render::ShaderModel;
 
 /// Properties related to drawing a **Quad**.
 #[derive(Clone, Debug)]
@@ -21,7 +20,7 @@ pub struct Quad {
 }
 
 /// The drawing context for a `Quad`.
-pub type DrawingQuad<'a, SM> = Drawing<'a, Quad, SM>;
+pub type DrawingQuad<'a> = Drawing<'a, Quad>;
 
 // Quad-specific methods.
 
@@ -176,10 +175,7 @@ impl Into<Option<Quad>> for Primitive {
 
 // Drawing methods.
 
-impl<'a, SM> DrawingQuad<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingQuad<'a> {
     /// Use the given points as the vertices (corners) of the quad.
     pub fn points<P>(self, a: P, b: P, c: P, d: P) -> Self
     where

--- a/nannou_draw/src/draw/primitive/rect.rs
+++ b/nannou_draw/src/draw/primitive/rect.rs
@@ -6,7 +6,7 @@ use nannou_core::geom;
 use crate::draw::primitive::Primitive;
 use crate::draw::primitive::polygon::{self, PolygonInit, PolygonOptions, SetPolygon};
 use crate::draw::properties::spatial::{dimension, orientation, position};
-use crate::draw::properties::tex_coords::SetTexCoords;
+use crate::draw::properties::tex_coords::{self, SetTexCoords};
 use crate::draw::properties::{SetColor, SetDimensions, SetOrientation, SetPosition, SetStroke};
 use crate::draw::{self, Drawing};
 
@@ -39,11 +39,12 @@ impl<'a> DrawingRect<'a> {
     where
         C: Into<Color>,
     {
-        self.map_ty(|ty| ty.stroke(color))
+        self.stroke_color(color)
     }
 
     pub fn area(self, area: geom::Rect) -> Self {
-        self.map_ty(|ty| ty.area(area))
+        tex_coords::set_tex_coords_area(&self.draw, self.index, area);
+        self
     }
 }
 
@@ -164,14 +165,5 @@ impl SetTexCoords for Rect {
 impl From<Rect> for Primitive {
     fn from(prim: Rect) -> Self {
         Primitive::Rect(prim)
-    }
-}
-
-impl Into<Option<Rect>> for Primitive {
-    fn into(self) -> Option<Rect> {
-        match self {
-            Primitive::Rect(prim) => Some(prim),
-            _ => None,
-        }
     }
 }

--- a/nannou_draw/src/draw/primitive/rect.rs
+++ b/nannou_draw/src/draw/primitive/rect.rs
@@ -9,7 +9,6 @@ use crate::draw::properties::spatial::{dimension, orientation, position};
 use crate::draw::properties::tex_coords::SetTexCoords;
 use crate::draw::properties::{SetColor, SetDimensions, SetOrientation, SetPosition, SetStroke};
 use crate::draw::{self, Drawing};
-use crate::render::ShaderModel;
 
 /// Properties related to drawing a **Rect**.
 #[derive(Clone, Debug)]
@@ -20,7 +19,7 @@ pub struct Rect {
 }
 
 /// The drawing context for a Rect.
-pub type DrawingRect<'a, SM> = Drawing<'a, Rect, SM>;
+pub type DrawingRect<'a> = Drawing<'a, Rect>;
 
 // Trait implementations.
 
@@ -34,10 +33,7 @@ impl Rect {
     }
 }
 
-impl<'a, SM> DrawingRect<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingRect<'a> {
     /// Stroke the outline with the given color.
     pub fn stroke<C>(self, color: C) -> Self
     where

--- a/nannou_draw/src/draw/primitive/text.rs
+++ b/nannou_draw/src/draw/primitive/text.rs
@@ -6,7 +6,6 @@ use crate::draw::primitive::Primitive;
 use crate::draw::properties::spatial::{self, dimension, orientation, position};
 use crate::draw::properties::{SetColor, SetDimensions, SetOrientation, SetPosition};
 use crate::draw::{self, Drawing};
-use crate::render::ShaderModel;
 use crate::text::{self, Align, FontSize, Justify, Layout, Scalar, Wrap};
 use bevy::platform::hash::FixedHasher;
 use bevy::prelude::*;
@@ -34,7 +33,7 @@ pub struct Style {
 }
 
 /// The drawing context for the **Text** primitive.
-pub type DrawingText<'a, SM> = Drawing<'a, Text, SM>;
+pub type DrawingText<'a> = Drawing<'a, Text>;
 
 impl Text {
     /// Begin drawing some text.
@@ -154,10 +153,7 @@ impl Text {
     }
 }
 
-impl<'a, SM> DrawingText<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingText<'a> {
     /// The font size to use for the text.
     pub fn font_size(self, size: text::FontSize) -> Self {
         self.map_ty(|ty| ty.font_size(size))

--- a/nannou_draw/src/draw/primitive/text.rs
+++ b/nannou_draw/src/draw/primitive/text.rs
@@ -156,82 +156,99 @@ impl Text {
 impl<'a> DrawingText<'a> {
     /// The font size to use for the text.
     pub fn font_size(self, size: text::FontSize) -> Self {
-        self.map_ty(|ty| ty.font_size(size))
+        update_text_layout(&self.draw, self.index, |l| l.font_size(size));
+        self
     }
 
     /// Specify that the **Text** should not wrap lines around the width.
     pub fn no_line_wrap(self) -> Self {
-        self.map_ty(|ty| ty.no_line_wrap())
+        update_text_layout(&self.draw, self.index, |l| l.no_line_wrap());
+        self
     }
 
     /// Line wrap the **Text** at the beginning of the first word that exceeds the width.
     pub fn wrap_by_word(self) -> Self {
-        self.map_ty(|ty| ty.wrap_by_word())
+        update_text_layout(&self.draw, self.index, |l| l.wrap_by_word());
+        self
     }
 
     /// Line wrap the **Text** at the beginning of the first character that exceeds the width.
     pub fn wrap_by_character(self) -> Self {
-        self.map_ty(|ty| ty.wrap_by_character())
+        update_text_layout(&self.draw, self.index, |l| l.wrap_by_character());
+        self
     }
 
     /// A method for specifying the font family used for displaying the `Text`.
     pub fn font(self, family: impl Into<String>) -> Self {
-        self.map_ty(|ty| ty.font(family))
+        let family = family.into();
+        update_text_layout(&self.draw, self.index, |l| l.font_family(family));
+        self
     }
 
     /// Build the **Text** with the given **Style**.
     pub fn with_style(self, style: Style) -> Self {
-        self.map_ty(|ty| ty.with_style(style))
+        update_text(&self.draw, self.index, |text| text.style = style);
+        self
     }
 
     /// Describe the end along the *x* axis to which the text should be aligned.
     pub fn justify(self, justify: text::Justify) -> Self {
-        self.map_ty(|ty| ty.justify(justify))
+        update_text_layout(&self.draw, self.index, |l| l.justify(justify));
+        self
     }
 
     /// Align the text to the left of its bounding **Rect**'s *x* axis range.
     pub fn left_justify(self) -> Self {
-        self.map_ty(|ty| ty.left_justify())
+        update_text_layout(&self.draw, self.index, |l| l.left_justify());
+        self
     }
 
     /// Align the text to the middle of its bounding **Rect**'s *x* axis range.
     pub fn center_justify(self) -> Self {
-        self.map_ty(|ty| ty.center_justify())
+        update_text_layout(&self.draw, self.index, |l| l.center_justify());
+        self
     }
 
     /// Align the text to the right of its bounding **Rect**'s *x* axis range.
     pub fn right_justify(self) -> Self {
-        self.map_ty(|ty| ty.right_justify())
+        update_text_layout(&self.draw, self.index, |l| l.right_justify());
+        self
     }
 
     /// Specify how much vertical space should separate each line of text.
     pub fn line_spacing(self, spacing: text::Scalar) -> Self {
-        self.map_ty(|ty| ty.line_spacing(spacing))
+        update_text_layout(&self.draw, self.index, |l| l.line_spacing(spacing));
+        self
     }
 
     /// Specify how the whole text should be aligned along the y axis of its bounding rectangle
     pub fn y_align_text(self, align: Align) -> Self {
-        self.map_ty(|ty| ty.y_align(align))
+        update_text_layout(&self.draw, self.index, |l| l.y_align(align));
+        self
     }
 
     /// Align the top edge of the text with the top edge of its bounding rectangle.
     pub fn align_text_top(self) -> Self {
-        self.map_ty(|ty| ty.align_top())
+        update_text_layout(&self.draw, self.index, |l| l.align_top());
+        self
     }
 
     /// Align the middle of the text with the middle of the bounding rect along the y axis.
     pub fn align_text_middle_y(self) -> Self {
-        self.map_ty(|ty| ty.align_middle_y())
+        update_text_layout(&self.draw, self.index, |l| l.align_middle_y());
+        self
     }
 
     /// Align the bottom edge of the text with the bottom edge of its bounding rectangle.
     pub fn align_text_bottom(self) -> Self {
-        self.map_ty(|ty| ty.align_bottom())
+        update_text_layout(&self.draw, self.index, |l| l.align_bottom());
+        self
     }
 
     /// Set all the parameters via an existing `Layout`
     pub fn layout(self, layout: &Layout) -> Self {
-        self.map_ty(|ty| ty.layout(layout))
+        update_text_layout(&self.draw, self.index, |l| l.layout(layout));
+        self
     }
 
     /// Set a color for each glyph.
@@ -240,9 +257,32 @@ impl<'a> DrawingText<'a> {
         I: IntoIterator<Item = C>,
         C: Into<Color>,
     {
-        let glyph_colors = glyph_colors.into_iter().map(|c| c.into()).collect();
-        self.map_ty(|ty| ty.glyph_colors(glyph_colors))
+        let glyph_colors: Vec<Color> = glyph_colors.into_iter().map(|c| c.into()).collect();
+        update_text(&self.draw, self.index, |text| {
+            text.style.glyph_colors = glyph_colors
+        });
+        self
     }
+}
+
+// Update the inner `Text` of the primitive being drawn at `index`.
+fn update_text(draw: &crate::draw::Draw, index: usize, f: impl FnOnce(&mut Text)) {
+    crate::draw::drawing::with_primitive(draw, index, |prim| match prim {
+        Primitive::Text(text) => f(text),
+        _ => bevy::log::warn_once!("expected a `Text` primitive"),
+    })
+}
+
+// Update the layout builder of the `Text` primitive being drawn at `index`.
+fn update_text_layout(
+    draw: &crate::draw::Draw,
+    index: usize,
+    f: impl FnOnce(text::layout::Builder) -> text::layout::Builder,
+) {
+    update_text(draw, index, |text| {
+        let layout = std::mem::take(&mut text.style.layout);
+        text.style.layout = f(layout);
+    })
 }
 
 /// A run of glyph quads sampling a single font atlas texture.
@@ -481,14 +521,5 @@ impl SetColor for Text {
 impl From<Text> for Primitive {
     fn from(prim: Text) -> Self {
         Primitive::Text(prim)
-    }
-}
-
-impl Into<Option<Text>> for Primitive {
-    fn into(self) -> Option<Text> {
-        match self {
-            Primitive::Text(prim) => Some(prim),
-            _ => None,
-        }
     }
 }

--- a/nannou_draw/src/draw/primitive/text.rs
+++ b/nannou_draw/src/draw/primitive/text.rs
@@ -180,8 +180,7 @@ impl<'a> DrawingText<'a> {
 
     /// A method for specifying the font family used for displaying the `Text`.
     pub fn font(self, family: impl Into<String>) -> Self {
-        let family = family.into();
-        update_text_layout(&self.draw, self.index, |l| l.font_family(family));
+        set_font(&self.draw, self.index, family.into());
         self
     }
 
@@ -258,9 +257,7 @@ impl<'a> DrawingText<'a> {
         C: Into<Color>,
     {
         let glyph_colors: Vec<Color> = glyph_colors.into_iter().map(|c| c.into()).collect();
-        update_text(&self.draw, self.index, |text| {
-            text.style.glyph_colors = glyph_colors
-        });
+        set_glyph_colors(&self.draw, self.index, glyph_colors);
         self
     }
 }
@@ -283,6 +280,20 @@ fn update_text_layout(
         let layout = std::mem::take(&mut text.style.layout);
         text.style.layout = f(layout);
     })
+}
+
+// Set the font family of the `Text` primitive being drawn at `index`.
+//
+// Non-generic so that the body compiles here rather than in the caller's crate.
+fn set_font(draw: &crate::draw::Draw, index: usize, family: String) {
+    update_text_layout(draw, index, |l| l.font_family(family))
+}
+
+// Set the per-glyph colors of the `Text` primitive being drawn at `index`.
+//
+// Non-generic so that the body compiles here rather than in the caller's crate.
+fn set_glyph_colors(draw: &crate::draw::Draw, index: usize, colors: Vec<Color>) {
+    update_text(draw, index, |text| text.style.glyph_colors = colors)
 }
 
 /// A run of glyph quads sampling a single font atlas texture.

--- a/nannou_draw/src/draw/primitive/tri.rs
+++ b/nannou_draw/src/draw/primitive/tri.rs
@@ -8,7 +8,6 @@ use crate::draw::primitive::polygon::{self, PolygonInit, PolygonOptions, SetPoly
 use crate::draw::properties::spatial::{dimension, orientation, position};
 use crate::draw::properties::{SetColor, SetDimensions, SetOrientation, SetPosition, SetStroke};
 use crate::draw::{self, Drawing};
-use crate::render::ShaderModel;
 
 /// Properties related to drawing a **Tri**.
 #[derive(Clone, Debug)]
@@ -19,7 +18,7 @@ pub struct Tri {
 }
 
 /// The drawing context for a `Tri`.
-pub type DrawingTri<'a, SM> = Drawing<'a, Tri, SM>;
+pub type DrawingTri<'a> = Drawing<'a, Tri>;
 
 // Tri-specific methods.
 
@@ -47,10 +46,7 @@ impl Tri {
 
 // Drawing methods.
 
-impl<'a, SM> DrawingTri<'a, SM>
-where
-    SM: ShaderModel + Default,
-{
+impl<'a> DrawingTri<'a> {
     /// Stroke the outline with the given color.
     pub fn stroke<C>(self, color: C) -> Self
     where

--- a/nannou_draw/src/draw/primitive/tri.rs
+++ b/nannou_draw/src/draw/primitive/tri.rs
@@ -52,7 +52,7 @@ impl<'a> DrawingTri<'a> {
     where
         C: Into<Color>,
     {
-        self.map_ty(|ty| ty.stroke(color))
+        self.stroke_color(color)
     }
 
     /// Use the given points as the vertices (corners) of the triangle.
@@ -60,8 +60,18 @@ impl<'a> DrawingTri<'a> {
     where
         P: Into<Vec2>,
     {
-        self.map_ty(|ty| ty.points(a, b, c))
+        let tri = geom::Tri([a.into(), b.into(), c.into()]);
+        update_tri(&self.draw, self.index, |t| t.tri = tri);
+        self
     }
+}
+
+// Update the inner `Tri` of the primitive being drawn at `index`.
+fn update_tri(draw: &crate::draw::Draw, index: usize, f: impl FnOnce(&mut Tri)) {
+    crate::draw::drawing::with_primitive(draw, index, |prim| match prim {
+        Primitive::Tri(tri) => f(tri),
+        _ => bevy::log::warn_once!("expected a `Tri` primitive"),
+    })
 }
 
 // Trait implementations.
@@ -173,14 +183,5 @@ impl SetPolygon for Tri {
 impl From<Tri> for Primitive {
     fn from(prim: Tri) -> Self {
         Primitive::Tri(prim)
-    }
-}
-
-impl Into<Option<Tri>> for Primitive {
-    fn into(self) -> Option<Tri> {
-        match self {
-            Primitive::Tri(prim) => Some(prim),
-            _ => None,
-        }
     }
 }

--- a/nannou_draw/src/draw/primitive/tri.rs
+++ b/nannou_draw/src/draw/primitive/tri.rs
@@ -60,16 +60,21 @@ impl<'a> DrawingTri<'a> {
     where
         P: Into<Vec2>,
     {
-        let tri = geom::Tri([a.into(), b.into(), c.into()]);
-        update_tri(&self.draw, self.index, |t| t.tri = tri);
+        set_points(
+            &self.draw,
+            self.index,
+            geom::Tri([a.into(), b.into(), c.into()]),
+        );
         self
     }
 }
 
-// Update the inner `Tri` of the primitive being drawn at `index`.
-fn update_tri(draw: &crate::draw::Draw, index: usize, f: impl FnOnce(&mut Tri)) {
+// Set the corner points of the `Tri` primitive being drawn at `index`.
+//
+// Non-generic so that the body compiles here rather than in the caller's crate.
+fn set_points(draw: &crate::draw::Draw, index: usize, points: geom::Tri<Vec2>) {
     crate::draw::drawing::with_primitive(draw, index, |prim| match prim {
-        Primitive::Tri(tri) => f(tri),
+        Primitive::Tri(tri) => tri.tri = points,
         _ => bevy::log::warn_once!("expected a `Tri` primitive"),
     })
 }

--- a/nannou_draw/src/draw/properties/color.rs
+++ b/nannou_draw/src/draw/properties/color.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::Color;
 
+use crate::draw::{Draw, drawing};
+
 /// Nodes that support setting colors.
 pub trait SetColor: Sized {
     /// Provide a mutable reference to the RGBA field which can be used for setting colors.
@@ -164,4 +166,12 @@ impl SetColor for Option<Color> {
     fn color_mut(&mut self) -> &mut Option<Color> {
         self
     }
+}
+
+// Set the color of the primitive being drawn at `index`.
+pub(crate) fn set_color(draw: &Draw, index: usize, color: Color) {
+    drawing::with_primitive(draw, index, |prim| match prim.color_mut() {
+        Some(c) => *c = Some(color),
+        None => bevy::log::warn_once!("drawing primitive does not support `color`"),
+    })
 }

--- a/nannou_draw/src/draw/properties/fill.rs
+++ b/nannou_draw/src/draw/properties/fill.rs
@@ -1,5 +1,7 @@
 use lyon::tessellation::FillOptions;
 
+use crate::draw::{Draw, drawing};
+
 /// Nodes that support fill tessellation.
 ///
 /// This trait allows the `Drawing` context to automatically provide an implementation of the
@@ -52,5 +54,32 @@ pub trait SetFill: Sized {
 impl SetFill for Option<FillOptions> {
     fn fill_options_mut(&mut self) -> &mut FillOptions {
         self.get_or_insert_with(Default::default)
+    }
+}
+
+// An update to a primitive's fill tessellation options.
+pub(crate) enum Update {
+    Opts(FillOptions),
+    Tolerance(f32),
+    Rule(lyon::tessellation::FillRule),
+    SweepOrientation(lyon::tessellation::Orientation),
+    HandleIntersections(bool),
+}
+
+// Update the fill options of the primitive being drawn at `index`.
+pub(crate) fn set_fill(draw: &Draw, index: usize, update: Update) {
+    drawing::with_primitive(draw, index, |prim| match prim.fill_options_mut() {
+        Some(opts) => apply_update(opts, update),
+        None => bevy::log::warn_once!("drawing primitive does not support `fill` options"),
+    })
+}
+
+fn apply_update(opts: &mut FillOptions, update: Update) {
+    match update {
+        Update::Opts(new) => *opts = new,
+        Update::Tolerance(tolerance) => opts.tolerance = tolerance,
+        Update::Rule(rule) => opts.fill_rule = rule,
+        Update::SweepOrientation(orientation) => opts.sweep_orientation = orientation,
+        Update::HandleIntersections(handle) => opts.handle_intersections = handle,
     }
 }

--- a/nannou_draw/src/draw/properties/spatial/dimension.rs
+++ b/nannou_draw/src/draw/properties/spatial/dimension.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
 
+use crate::draw::{Draw, drawing};
+
 /// Dimension properties for **Drawing** a **Primitive**.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct Properties {
@@ -71,4 +73,30 @@ impl SetDimensions for Properties {
     fn properties(&mut self) -> &mut Properties {
         self
     }
+}
+
+// Set the dimensions of the primitive being drawn at `index`.
+//
+// `None` leaves the corresponding dimension unchanged.
+pub(crate) fn set_dimensions(
+    draw: &Draw,
+    index: usize,
+    x: Option<f32>,
+    y: Option<f32>,
+    z: Option<f32>,
+) {
+    drawing::with_primitive(draw, index, |prim| match prim.dimensions_mut() {
+        Some(props) => {
+            if x.is_some() {
+                props.x = x;
+            }
+            if y.is_some() {
+                props.y = y;
+            }
+            if z.is_some() {
+                props.z = z;
+            }
+        }
+        None => bevy::log::warn_once!("drawing primitive does not support `dimensions`"),
+    })
 }

--- a/nannou_draw/src/draw/properties/spatial/orientation.rs
+++ b/nannou_draw/src/draw/properties/spatial/orientation.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
 
+use crate::draw::{Draw, drawing};
+
 /// Orientation properties for **Drawing** a **Primitive**.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Properties {
@@ -183,5 +185,34 @@ fn expect_axes(p: &mut Properties) -> &mut Vec3 {
         Properties::Axes(ref mut axes) => axes,
         Properties::LookAt(_) => panic!("expected `Axes`, found `LookAt`"),
         Properties::Quat(_) => panic!("expected `Axes`, found `Quat`"),
+    }
+}
+
+// An update to a primitive's orientation properties.
+pub(crate) enum Update {
+    LookAt(Vec3),
+    XRadians(f32),
+    YRadians(f32),
+    ZRadians(f32),
+    Radians(Vec3),
+    Quat(Quat),
+}
+
+// Update the orientation of the primitive being drawn at `index`.
+pub(crate) fn set_orientation(draw: &Draw, index: usize, update: Update) {
+    drawing::with_primitive(draw, index, |prim| match prim.orientation_mut() {
+        Some(props) => apply_update(props, update),
+        None => bevy::log::warn_once!("drawing primitive does not support `orientation`"),
+    })
+}
+
+fn apply_update(props: &mut Properties, update: Update) {
+    match update {
+        Update::LookAt(target) => *props = Properties::LookAt(target),
+        Update::XRadians(x) => *props = SetOrientation::x_radians(*props, x),
+        Update::YRadians(y) => *props = SetOrientation::y_radians(*props, y),
+        Update::ZRadians(z) => *props = SetOrientation::z_radians(*props, z),
+        Update::Radians(v) => *props = SetOrientation::radians(*props, v),
+        Update::Quat(q) => *props = Properties::Quat(q),
     }
 }

--- a/nannou_draw/src/draw/properties/spatial/position.rs
+++ b/nannou_draw/src/draw/properties/spatial/position.rs
@@ -1,6 +1,8 @@
 //! Items related to describing positioning along each axis as
 use bevy::prelude::*;
 
+use crate::draw::{Draw, drawing};
+
 /// Position properties for **Drawing** a **Primitive**.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Properties {
@@ -68,4 +70,30 @@ impl Default for Properties {
         let point = Vec3::ZERO;
         Self { point }
     }
+}
+
+// Set the position of the primitive being drawn at `index`.
+//
+// `None` leaves the corresponding axis unchanged.
+pub(crate) fn set_position(
+    draw: &Draw,
+    index: usize,
+    x: Option<f32>,
+    y: Option<f32>,
+    z: Option<f32>,
+) {
+    drawing::with_primitive(draw, index, |prim| match prim.position_mut() {
+        Some(props) => {
+            if let Some(x) = x {
+                props.point.x = x;
+            }
+            if let Some(y) = y {
+                props.point.y = y;
+            }
+            if let Some(z) = z {
+                props.point.z = z;
+            }
+        }
+        None => bevy::log::warn_once!("drawing primitive does not support `position`"),
+    })
 }

--- a/nannou_draw/src/draw/properties/stroke.rs
+++ b/nannou_draw/src/draw/properties/stroke.rs
@@ -1,5 +1,7 @@
 use lyon::tessellation::{LineCap, LineJoin, StrokeOptions};
 
+use crate::draw::{Draw, drawing};
+
 /// Nodes that support stroke tessellation.
 ///
 /// This trait allows the `Drawing` context to automatically provide an implementation of the
@@ -154,5 +156,41 @@ pub trait SetStroke: Sized {
 impl SetStroke for Option<StrokeOptions> {
     fn stroke_options_mut(&mut self) -> &mut StrokeOptions {
         self.get_or_insert_with(Default::default)
+    }
+}
+
+// An update to a primitive's stroke tessellation options.
+pub(crate) enum Update {
+    Opts(StrokeOptions),
+    StartCap(LineCap),
+    EndCap(LineCap),
+    Caps(LineCap),
+    Join(LineJoin),
+    Weight(f32),
+    MiterLimit(f32),
+    Tolerance(f32),
+}
+
+// Update the stroke options of the primitive being drawn at `index`.
+pub(crate) fn set_stroke(draw: &Draw, index: usize, update: Update) {
+    drawing::with_primitive(draw, index, |prim| match prim.stroke_options_mut() {
+        Some(opts) => apply_update(opts, update),
+        None => bevy::log::warn_once!("drawing primitive does not support `stroke` options"),
+    })
+}
+
+fn apply_update(opts: &mut StrokeOptions, update: Update) {
+    match update {
+        Update::Opts(new) => *opts = new,
+        Update::StartCap(cap) => opts.start_cap = cap,
+        Update::EndCap(cap) => opts.end_cap = cap,
+        Update::Caps(cap) => {
+            opts.start_cap = cap;
+            opts.end_cap = cap;
+        }
+        Update::Join(join) => opts.line_join = join,
+        Update::Weight(weight) => opts.line_width = weight,
+        Update::MiterLimit(limit) => opts.miter_limit = limit,
+        Update::Tolerance(tolerance) => opts.tolerance = tolerance,
     }
 }

--- a/nannou_draw/src/draw/properties/tex_coords.rs
+++ b/nannou_draw/src/draw/properties/tex_coords.rs
@@ -1,5 +1,7 @@
 use nannou_core::geom;
 
+use crate::draw::{Draw, drawing};
+
 pub trait SetTexCoords: Sized {
     fn tex_coords_mut(&mut self) -> &mut Option<geom::Rect>;
 
@@ -13,4 +15,12 @@ impl SetTexCoords for Option<geom::Rect> {
     fn tex_coords_mut(&mut self) -> &mut Option<geom::Rect> {
         self
     }
+}
+
+// Set the texture coordinate area of the primitive being drawn at `index`.
+pub(crate) fn set_tex_coords_area(draw: &Draw, index: usize, area: geom::Rect) {
+    drawing::with_primitive(draw, index, |prim| match prim.tex_coords_mut() {
+        Some(tex_coords) => *tex_coords = Some(area),
+        None => bevy::log::warn_once!("drawing primitive does not support `tex_coords`"),
+    })
 }

--- a/nannou_draw/src/lib.rs
+++ b/nannou_draw/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! [Bevy]: https://bevyengine.org
 
-use crate::render::{NannouRenderPlugin, NannouShaderModel};
+use crate::render::NannouRenderPlugin;
 use bevy::prelude::*;
 use draw::Draw;
 use text::font::SharedTextCx;
@@ -50,6 +50,6 @@ fn spawn_draw(
     for entity in query.iter() {
         commands
             .entity(entity)
-            .insert(Draw::<NannouShaderModel>::new(entity, text_cx.clone()));
+            .insert(Draw::new(entity, text_cx.clone()));
     }
 }

--- a/nannou_draw/src/render.rs
+++ b/nannou_draw/src/render.rs
@@ -61,6 +61,28 @@ use std::{any::TypeId, hash::Hash, marker::PhantomData};
 pub const DEFAULT_NANNOU_SHADER_HANDLE: Handle<Shader> =
     uuid_handle!("f2dbf06f-38d5-47f1-8ad4-3f188d888dd0");
 
+/// A dyn-safe view of a [`ShaderModel`] instance, allowing the draw state to store and
+/// manipulate models of any type without knowing the concrete type.
+pub(crate) trait ErasedShaderModel: Send + Sync + 'static {
+    fn as_any(&self) -> &dyn std::any::Any;
+    fn clone_erased(&self) -> Box<dyn ErasedShaderModel>;
+    fn set_texture_erased(&mut self, texture: Handle<Image>);
+}
+
+impl<SM: ShaderModel> ErasedShaderModel for SM {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn clone_erased(&self) -> Box<dyn ErasedShaderModel> {
+        Box::new(self.clone())
+    }
+
+    fn set_texture_erased(&mut self, texture: Handle<Image>) {
+        self.set_texture(texture);
+    }
+}
+
 pub trait ShaderModel:
     Asset + AsBindGroup + Clone + Default + Sized + Send + Sync + 'static
 {
@@ -622,7 +644,7 @@ fn update_shader_model<SM>(
         let state = draw.state.write().unwrap();
         state.shader_models.iter().for_each(|(id, model)| {
             if id.type_id() == TypeId::of::<SM>() {
-                let model = model.downcast_ref::<SM>().unwrap();
+                let model = model.as_any().downcast_ref::<SM>().unwrap();
                 models.insert(id.typed(), model.clone()).unwrap();
             }
         });
@@ -720,7 +742,7 @@ fn update_draw_mesh(
                     let base = last_shader_model
                         .as_ref()
                         .and_then(|id| draw_state.shader_models.get(id))
-                        .and_then(|model| model.downcast_ref::<DefaultNannouShaderModel>())
+                        .and_then(|model| model.as_any().downcast_ref::<DefaultNannouShaderModel>())
                         .cloned()
                         .unwrap_or_default();
 


### PR DESCRIPTION
Closes #1054.

## Summary

`Draw<SM>` and `Drawing<'a, T, SM>` are now `Draw` and `Drawing<'a, T>`, where
`T` is a zero-cost marker.

The main cost of excessive generics is monomorphisation in downstream sketch crates: every builder call round-tripped the stored primitive through `map_ty` (`HashMap` remove + `Primitive -> Option<T> -> map -> Primitive` + insert), duplicated per `(T, SM)` pair. `map_primitive` alone was ~24% of the LLVM lines a simple sketch generated.

Builder methods are now thin shims over non-generic functions (compiled once in `nannou_draw`) that mutate the stored primitive in place.

## Results

| Metric | master | this PR |
|---|---|---|
| `draw` example LLVM lines (user crate) | 9412 lines / 311 copies | **1044 / 36 (-89%)** |
| Frame-build runtime (bench below) | 5.73 ms | **2.55 ms (2.2x)** |
| Touch-rebuild of the examples crate | 20.6-21.9 s | 20.3-21.5 s (~1%, noise) |
| Release binary (stripped) | ~73-78 MB | unchanged |

- The largest remaining item in a sketch's codegen is now the sketch's own `view` fn; what's left of the draw API is irreducible `Into` conversions of user argument types.
- The runtime win comes from in-place `get_mut` mutation replacing the per-call `HashMap` remove/insert and full `Primitive` enum moves.
- Wall-clock compile time barely moves for small sketches - rustc front-end and linking still dominate, but larger draw-heavy projects shed ~3.5k LLVM lines per binary.
- Bench: `cargo bench -p nannou_draw` (added in this PR, no new deps) - one frame of 10k ellipses with 6 chained properties each plus 1k 100-point polylines, median of 20 iterations.

## Design

The builder API is now a thin generic facade over a non-generic core. The existing primitive data types double as the `Drawing<'a, T>` markers, so all type aliases, method resolution (e.g. the `path().stroke()` type-state vs `ellipse().stroke(color)` name reuse) and type-state transitions are unchanged - the markers only gate which methods are available, via the same `Set*` traits that total `Option`-returning accessors on `Primitive` are built from, keeping the two in sync by construction. Shims convert their generic arguments first (iterators are passed as `&mut dyn Iterator`) and then call non-generic functions that mutate the stored primitive in place, so everything heavier than an `Into` call compiles once in `nannou_draw`.

Shader models follow the same recipe: stored as `Box<dyn ErasedShaderModel>`, with generics surviving only at method level where a concrete model is supplied (`shader_model(model)`, `map_shader_model::<SM>(..)`). The render-world plumbing (per-model plugins, pipelines, render commands) is untouched - bevy's `AsBindGroup` requires static types there, and that cost is per registered model type rather than per call site.

Operations that cannot be statically checked any more (a mismatched `map_shader_model`, default-model-only methods under a custom model) warn once and no-op rather than panic, mirroring the existing text-rendering fallback.

## Breaking changes

- `Draw<SM>` -> `Draw`; `Drawing<'a, T, SM>` -> `Drawing<'a, T>`; likewise `Background`, `Instanced`, `Indirect` and the `Drawing*` aliases. Typical sketch code is unaffected; type ascriptions like `fn f(draw: &Draw<SM>)` drop the param.
- `Drawing::map_shader_model::<SM>` is checked at runtime: closures need a typed param (`|mut mat: MyModel|`), and if the active model is not an `SM` a warning is emitted once and the mapping is skipped.
- `Draw::{alpha_blend,color_blend,blend,polygon_mode}` and `Drawing::base_color` only apply to the default nannou model; with a custom model active they warn once and no-op (mirrors the existing text-rendering fallback).
- `Drawing::texture(..)` now works with *any* shader model via `ShaderModel::set_texture` (previously restricted to the default model, and silently required by the mesh `*_textured` methods).
- `Drawing::map_ty` and the `Into<Option<T>> for Primitive` conversions are removed; builder methods mutate the stored primitive in place.