### PR TITLE
Ensure nannou and plugin feature options reflect `bevy` features where relevant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ saved_timeline_data.json
 simple_capture/
 draw_capture/
 draw_capture_hi_res/
-target/
+target
 **/*.rs.bk
 .DS_Store
 .idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,12 +495,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "basis-universal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555fb05709f4e12fa2f6b93a480facf167eb0ecb2558ba41f610f588e77cbd14"
+dependencies = [
+ "basis-universal-sys",
+ "bitflags 1.3.2",
+ "lazy_static",
+]
+
+[[package]]
+name = "basis-universal-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd9bde5e9547958fb0e77d79fc7879edcf91d5e0c8e372ef8959916cf35e8506"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "bevy"
 version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66de79f9778e3458ca92a5a855b9e11cc4ec1b15a6c4330d8244a08d22539d9"
 dependencies = [
  "bevy_internal",
+ "tracing",
 ]
 
 [[package]]
@@ -564,6 +585,7 @@ dependencies = [
  "downcast-rs 2.0.2",
  "log",
  "thiserror 2.0.17",
+ "tracing",
  "variadics_please",
  "wasm-bindgen",
  "web-sys",
@@ -812,6 +834,7 @@ dependencies = [
  "slotmap",
  "smallvec 1.15.1",
  "thiserror 2.0.17",
+ "tracing",
  "variadics_please",
 ]
 
@@ -998,6 +1021,7 @@ version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa87f3aeb7bef218a51d97309c596f280b9c74b247ceefb4ebc10047accd0df"
 dependencies = [
+ "basis-universal",
  "bevy_app",
  "bevy_asset",
  "bevy_color",
@@ -1008,6 +1032,7 @@ dependencies = [
  "bevy_utils",
  "bitflags 2.11.1",
  "bytemuck",
+ "ddsfile",
  "futures-lite",
  "guillotiere",
  "half",
@@ -1097,7 +1122,6 @@ dependencies = [
  "bevy_text",
  "bevy_time",
  "bevy_transform",
- "bevy_ui",
  "bevy_utils",
  "bevy_window",
  "bevy_winit",
@@ -1140,9 +1164,12 @@ dependencies = [
  "bevy_platform",
  "bevy_utils",
  "tracing",
+ "tracing-chrome",
+ "tracing-error",
  "tracing-log",
  "tracing-oslog",
  "tracing-subscriber",
+ "tracing-tracy",
  "tracing-wasm",
 ]
 
@@ -1450,9 +1477,11 @@ dependencies = [
  "naga",
  "nonmax",
  "offset-allocator",
+ "profiling",
  "send_wrapper",
  "smallvec 1.15.1",
  "thiserror 2.0.17",
+ "tracy-client",
  "variadics_please",
  "wasm-bindgen",
  "weak-table",
@@ -2707,6 +2736,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "ddsfile"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479dfe1e6737aa9e96c6ac7b69689dc4c32da8383f2c12744739d76afa8b66c4"
+dependencies = [
+ "bitflags 2.11.1",
+ "byteorder",
+ "enum-primitive-derive",
+ "num-traits",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,6 +2935,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "enum-primitive-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
+dependencies = [
+ "num-traits",
+ "quote 1.0.42",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3453,6 +3505,21 @@ dependencies = [
  "nannou",
  "usvg",
  "wikipedia",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.4",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4543,6 +4610,19 @@ name = "log"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if 1.0.4",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "loop9"
@@ -6283,6 +6363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 dependencies = [
  "profiling-procmacros",
+ "tracing",
 ]
 
 [[package]]
@@ -8005,6 +8086,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8012,6 +8104,16 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -8056,6 +8158,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-tracy"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracy-client",
+]
+
+[[package]]
 name = "tracing-wasm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8064,6 +8177,27 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f6fc3baeac5d86ab90c772e9e30620fc653bf1864295029921a15ef478e6a5"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
+dependencies = [
+ "cc",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -95,6 +95,24 @@ ECS, renderer, asset system and plugins) is now available to nannou apps.
   `wgpu` `29`.
 - Crates now use the Rust 2024 edition and require a recent stable toolchain.
 
+### Cargo features
+
+Each nannou crate now enables only the bevy features it needs, and `nannou`
+re-exposes the commonly useful ones so they can be controlled from a `nannou`
+dependency alone ([#997](https://github.com/nannou-org/nannou/issues/997)):
+
+- Image formats for asset loading are now cargo features (`png`, `jpeg`, `hdr`,
+  `exr`, `gif`, `webp`, `tiff` and friends), with `png` and `jpeg` enabled by
+  default. Previously only JPEG textures could be loaded.
+- `multi_threaded` (enabled by default) runs bevy's task pools across multiple
+  threads; previously nannou apps ran single-threaded unless `hot_reload` was
+  enabled. Disable default features to opt out.
+- Both Linux window backends (`x11` and `wayland`) are now enabled by default,
+  matching bevy - the appropriate one is selected at runtime.
+- `trace`, `trace_chrome` and `trace_tracy` are re-exposed for profiling.
+- Any other bevy feature can still be enabled by adding a direct `bevy`
+  dependency, as cargo features are additive across the dependency graph.
+
 ### Migration notes
 
 For existing nannou `0.19` projects, the most common changes are:

--- a/guide/src/tutorials/draw/drawing-images.md
+++ b/guide/src/tutorials/draw/drawing-images.md
@@ -83,6 +83,10 @@ struct Model {
 
 Next, we'll need to load an image to initialize the struct with. We can accomplish this by asking Bevy's asset server to load an image file after we create the window in our `model` function, via the app's [`asset_server()`](https://docs.rs/nannou/latest/nannou/app/struct.App.html#method.asset_server) method. The asset server looks for files within the project's `assets` directory, so we only need to spell out the image path from the root of that directory. Loading happens in the background, and the returned `Handle` can be drawn as soon as the asset is ready.
 
+PNG and JPEG images are supported by default; further formats (e.g. `hdr`,
+`exr`, `gif`, `webp`, `tiff`) can be enabled via the cargo feature of the same
+name on the `nannou` crate.
+
 ```rust,no_run
 # #![allow(unreachable_code, unused_variables, dead_code)]
 # use nannou::prelude::*;

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -12,11 +12,10 @@ edition.workspace = true
 
 [dependencies]
 bevy = { workspace = true, default-features = false, features = [
+    "bevy_log",
     "bevy_post_process",
     "bevy_window",
     "bevy_winit",
-    "jpeg",
-    "zstd_rust",
 ]}
 # `bevy-inspector-egui` has no Bevy 0.19 release yet - kept disabled (see the
 # `inspector` feature below and the RC -> stable tracking issue).
@@ -49,12 +48,16 @@ image = { workspace = true, features = [] }
 
 [features]
 default = [
-    # FIXME: bevy defaults to x11 so we do.. but that seems oldschool?
-    # We should use wayland instead no?
+    "jpeg",
+    "multi_threaded",
+    "notosans",
+    "png",
+    "system_font_discovery",
+    # Both Linux window backends, matching bevy's defaults - the appropriate
+    # one is selected at runtime.
+    "wayland",
     "x11",
     "webgl2",
-    "notosans",
-    "system_font_discovery",
 ]
 config_json = ["bevy_common_assets/json"]
 config_toml = ["bevy_common_assets/toml"]
@@ -74,6 +77,42 @@ notosans = ["nannou_draw/notosans"]
 system_font_discovery = ["nannou_draw/system_font_discovery"]
 serde = ["dep:serde", "toml", "serde_json", "nannou_core/serde"]
 video = ["nannou_video"]
+
+# The features below re-expose bevy features so that they can be controlled
+# from a `nannou` dependency alone. Any other bevy feature can be enabled by
+# depending on `bevy` directly - cargo features are additive across the graph.
+
+# Run bevy's task pools across multiple threads. Native only - wasm builds
+# are always single-threaded.
+multi_threaded = ["bevy/multi_threaded"]
+
+# Tracing spans for profiling, e.g. `trace_tracy` for the Tracy profiler.
+trace = ["bevy/trace"]
+trace_chrome = ["bevy/trace_chrome"]
+trace_tracy = ["bevy/trace_tracy"]
+
+# Linux window backends.
 wayland = ["bevy/wayland"]
-webgl2 = ["bevy/webgl2"]
 x11 = ["bevy/x11"]
+
+# Fall back to WebGL2 on wasm when WebGPU is unavailable.
+webgl2 = ["bevy/webgl2"]
+
+# Image formats supported when loading textures via the asset server,
+# e.g. `app.asset_server().load("texture.png")`.
+basis-universal = ["bevy/basis-universal"]
+bmp = ["bevy/bmp"]
+dds = ["bevy/dds"]
+exr = ["bevy/exr"]
+ff = ["bevy/ff"]
+gif = ["bevy/gif"]
+hdr = ["bevy/hdr"]
+ico = ["bevy/ico"]
+jpeg = ["bevy/jpeg"]
+ktx2 = ["bevy/ktx2"]
+png = ["bevy/png"]
+pnm = ["bevy/pnm"]
+qoi = ["bevy/qoi"]
+tga = ["bevy/tga"]
+tiff = ["bevy/tiff"]
+webp = ["bevy/webp"]

--- a/nannou_draw/Cargo.toml
+++ b/nannou_draw/Cargo.toml
@@ -11,11 +11,12 @@ bevy = { workspace = true, default-features = false, features = [
     "bevy_asset",
     "bevy_color",
     "bevy_core_pipeline",
+    "bevy_log",
     "bevy_pbr",
     "bevy_render",
     "bevy_text",
-    "bevy_ui", # needed for `BackgroundColor`
-    "bevy_log",
+    # The default `Tonemapping` (TonyMcMapface) samples a LUT; the LUTs are
+    # zstd-compressed ktx2, hence `zstd_rust` (`tonemapping_luts` implies `ktx2`).
     "tonemapping_luts",
     "zstd_rust",
 ]}

--- a/nannou_draw/src/render.rs
+++ b/nannou_draw/src/render.rs
@@ -918,15 +918,11 @@ pub struct TextModelKeepalive(Vec<Handle<DefaultNannouShaderModel>>);
 
 fn clear_previous_frame(
     mut commands: Commands,
-    bg_color_q: Query<Entity, With<BackgroundColor>>,
     meshes_q: Query<Entity, With<NannouTransient>>,
     mut text_model_keepalive: ResMut<TextModelKeepalive>,
 ) {
     text_model_keepalive.0.clear();
     for entity in meshes_q.iter() {
-        commands.entity(entity).despawn();
-    }
-    for entity in bg_color_q.iter() {
         commands.entity(entity).despawn();
     }
 }

--- a/nannou_isf/Cargo.toml
+++ b/nannou_isf/Cargo.toml
@@ -7,7 +7,14 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-bevy = { workspace = true, features = ["shader_format_glsl"] }
+bevy = { workspace = true, features = [
+    "bevy_asset",
+    "bevy_core_pipeline",
+    "bevy_log",
+    "bevy_render",
+    "bevy_window",
+    "shader_format_glsl",
+] }
 # TODO: waiting on bevy 0.19 support
 #bevy-inspector-egui = { workspace = true }
 isf.workspace = true

--- a/nannou_video/Cargo.toml
+++ b/nannou_video/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 [dependencies]
 bevy = { workspace = true, default-features = false, features = [
     "bevy_asset",
-    "bevy_log",
     "bevy_render",
 ]}
 thiserror.workspace = true

--- a/nannou_webcam/Cargo.toml
+++ b/nannou_webcam/Cargo.toml
@@ -13,8 +13,6 @@ default = []
 flume = { workspace = true }
 bevy = { workspace = true, features = [
   "bevy_asset",
-  "bevy_camera",
-  "bevy_core_pipeline",
   "bevy_image",
   "bevy_log",
   "bevy_render",


### PR DESCRIPTION
Checks every crate's bevy features so that nothing unnecessary is forced, and re-exposes the commonly useful bevy features through `nannou`. Closes

#997.

## Fixes

- `nannou_isf` failed to build standalone - it only compiled thanks to workspace feature unification. It now declares the bevy features it uses. (Verified all five bevy-dependent crates with `cargo check -p <crate>`.)
- PNG asset loading failed at runtime: `jpeg` was force-enabled (a leftover from the original import) but nothing enabled `png`, while the examples ship 38 PNGs. `png` and `jpeg` are now nannou features, both default.
- Apps ran bevy single-threaded unless `hot_reload` was enabled. `multi_threaded` is now a default feature (no-op on wasm).

## Trimmed

- `nannou_draw`: drops `bevy_ui` along with the dead `BackgroundColor` despawn query that was its only use.
- `nannou_webcam`: drops unused `bevy_camera` and `bevy_core_pipeline`.
- `nannou_video`: `bevy_log` only for wasm builds, where it is used.
- `nannou`: drops `jpeg`/`zstd_rust` (zstd is owned by `nannou_draw`'s tonemapping LUTs), declares `bevy_log` explicitly.

## Exposed

`nannou` now re-exposes bevy's image format features (`png`, `jpeg`, `hdr`, `exr`, `gif`, `webp`, ...), `multi_threaded` and `trace`/`trace_chrome`/`trace_tracy`. Both Linux window backends (`x11`, `wayland`) are now default, matching bevy and resolving the old x11-vs-wayland FIXME - winit picks at runtime.

Smoke-tested by running a PNG-loading example (`p_4_3_1_02`) under Wayland; changelog and the drawing-images tutorial updated. Also fixes `.gitignore` so worktree `target` symlinks are ignored.