### PR TITLE
Check all guide links in CI

### DIFF
--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -30,6 +30,10 @@ jobs:
             command: cargo test --locked -p nannou_core --no-default-features --features "libm serde"
           - name: test-book
             command: cargo test --locked -p book_tests
+          - name: check-links
+            command: mdbook-linkcheck2 -s guide/
+            # Remove once there are no link errors to enforce correct links.
+            continue-on-error: true
           - name: book
             command: mdbook build guide/
     steps:
@@ -59,9 +63,13 @@ jobs:
         pkg-config
     - name: Install mdbook
       if: matrix.name == 'book'
-      run: cargo install mdbook mdbook-linkcheck2 --locked
+      run: cargo install mdbook --locked
+    - name: Install mdbook-linkcheck2
+      if: matrix.name == 'check-links'
+      run: cargo install mdbook-linkcheck2 --locked
     - name: ${{ matrix.name }}
       run: ${{ matrix.command }}
+      continue-on-error: ${{ matrix.continue-on-error || false }}
 
   verifications:
     needs: [cargo]

--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -59,7 +59,7 @@ jobs:
         pkg-config
     - name: Install mdbook
       if: matrix.name == 'book'
-      run: cargo install mdbook --locked
+      run: cargo install mdbook mdbook-linkcheck2 --locked
     - name: ${{ matrix.name }}
       run: ${{ matrix.command }}
 

--- a/guide/book.toml
+++ b/guide/book.toml
@@ -4,5 +4,3 @@ authors = ["mitchmindtree", "JoshuaBatty", "freesig", "jozanza"]
 src = "src"
 description = "A one-stop shop for Nannou Knowledge!"
 
-[output.linkcheck2]
-follow-web-links = true

--- a/guide/book.toml
+++ b/guide/book.toml
@@ -4,3 +4,5 @@ authors = ["mitchmindtree", "JoshuaBatty", "freesig", "jozanza"]
 src = "src"
 description = "A one-stop shop for Nannou Knowledge!"
 
+[output.linkcheck2]
+follow-web-links = true


### PR DESCRIPTION
Closes #547 

Checks all links in the guide and emits errors if a link isn't working using the community maintained crate [mdbook-linkcheck2](https://crates.io/crates/mdbook-linkcheck2). This is a new pipeline job in the cargo matrix that purposefully does not block pipelines on errors. A future PR should handle that once all link errors are fixed.
