### PR TITLE
Improve guide lint: nix dev shell, dedicated CI job, fix warnings

### DIFF
--- a/.github/workflows/nannou.yml
+++ b/.github/workflows/nannou.yml
@@ -30,10 +30,6 @@ jobs:
             command: cargo test --locked -p nannou_core --no-default-features --features "libm serde"
           - name: test-book
             command: cargo test --locked -p book_tests
-          - name: check-links
-            command: mdbook-linkcheck2 -s guide/
-            # Remove once there are no link errors to enforce correct links.
-            continue-on-error: true
           - name: book
             command: mdbook build guide/
     steps:
@@ -64,15 +60,22 @@ jobs:
     - name: Install mdbook
       if: matrix.name == 'book'
       run: cargo install mdbook --locked
-    - name: Install mdbook-linkcheck2
-      if: matrix.name == 'check-links'
-      run: cargo install mdbook-linkcheck2 --locked
     - name: ${{ matrix.name }}
       run: ${{ matrix.command }}
-      continue-on-error: ${{ matrix.continue-on-error || false }}
+
+  # Check the guide for broken links, using the same `mdbook-linkcheck2` as the
+  # nix dev shell (pinned via `flake.lock`).
+  check-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31
+    - name: Check guide links
+      run: nix shell --inputs-from . 'nixpkgs#mdbook-linkcheck2' --command mdbook-linkcheck2 --standalone guide/
 
   verifications:
-    needs: [cargo]
+    needs: [cargo, check-links]
     runs-on: ubuntu-latest
     steps:
     - run: echo "Verifications complete"

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -27,6 +27,7 @@
     - [PR Checklist](./contributing/pr-checklist.md)
     - [PR Reviews](./contributing/pr-reviews.md)
     - [Publishing New Versions](./contributing/publishing-new-versions.md)
+    - [Nix Shell](./contributing/nix-shell.md)
 - [Developer Reference](./developer_reference.md)
 - [API Reference](./api_reference.md)
 - [Showcases](./showcases.md)

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -606,8 +606,8 @@ changelog entry
 - Update conrod dependencies to 0.68 for vulkano patch. New version includes
   copy/paste, double-click select and shift-click select support for the
   `TextEdit` widget.
-- [Breaking] Small change to Vulkan debug items.
-- [Breaking] New fields have been added to `DynamicState`.
+- \[Breaking\] Small change to Vulkan debug items.
+- \[Breaking\] New fields have been added to `DynamicState`.
 - Update shade_runner to 0.3 for vulkano patch.
 - Frame command buffer builder no longer provides access to unrelated
   `secondary` buffer methods.

--- a/guide/src/tutorials.md
+++ b/guide/src/tutorials.md
@@ -22,19 +22,19 @@ Tutorials for learning the basics of Rust with nannou.
 
 A suite of tutorials for getting familiar with the Nannou environment.
 
-- [Anatomy of a nannou app](/tutorials/basics/anatomy-of-a-nannou-app.md)
-- [Drawing a sketch](/tutorials/basics/draw-a-sketch.md)
-- [Sketch vs App](/tutorials/basics/sketch-vs-app.md)
-- [Window Coordinates](/tutorials/basics/window-coordinates.md)
+- [Anatomy of a nannou app](./tutorials/basics/anatomy-of-a-nannou-app.md)
+- [Drawing a sketch](./tutorials/basics/draw-a-sketch.md)
+- [Sketch vs App](./tutorials/basics/sketch-vs-app.md)
+- [Window Coordinates](./tutorials/basics/window-coordinates.md)
 - Nannou events
 
 ## Drawing
 
 Working with Nannou's `Draw` API - a simple approach of coding graphics.
 
-- [Drawing 2D shapes](/tutorials/draw/drawing-2d-shapes.md)
-- [Animating a circle](/tutorials/draw/animating-a-circle.md)
-- [Drawing images](/tutorials/draw/drawing-images.md)
+- [Drawing 2D shapes](./tutorials/draw/drawing-2d-shapes.md)
+- [Animating a circle](./tutorials/draw/animating-a-circle.md)
+- [Drawing images](./tutorials/draw/drawing-images.md)
 - Drawing 3D shapes
 - Drawing meshes
 
@@ -107,8 +107,8 @@ Detecting and outputting to LASER DACs on a network.
 
 ## OSC
 
-- [An intro to OSC](/tutorials/osc/osc-introduction.md).
-- [Sending OSC](/tutorials/osc/osc-sender.md).
+- [An intro to OSC](./tutorials/osc/osc-introduction.md).
+- [Sending OSC](./tutorials/osc/osc-sender.md).
 - Receiving OSC.
 
 ## DMX

--- a/guide/src/tutorials/basics/anatomy-of-a-nannou-app.md
+++ b/guide/src/tutorials/basics/anatomy-of-a-nannou-app.md
@@ -4,7 +4,7 @@
 
 - Author: tpltnt, mitchmindtree
 - Required Knowledge:
-    - [Getting Started](/getting_started.md)
+    - [Getting Started](../../getting_started.md)
 - Reading Time: 10 minutes
 
 ---

--- a/guide/src/tutorials/basics/draw-a-sketch.md
+++ b/guide/src/tutorials/basics/draw-a-sketch.md
@@ -4,7 +4,7 @@
 
 - Author: tpltnt
 - Required Knowledge:
-    - [Getting Started](/getting_started.md)
+    - [Getting Started](../../getting_started.md)
 - Reading Time: 5 minutes
 
 ---

--- a/guide/src/tutorials/basics/sketch-vs-app.md
+++ b/guide/src/tutorials/basics/sketch-vs-app.md
@@ -4,7 +4,7 @@
 
 - Author: mitchmindtree
 - Required Knowledge:
-    - [Getting Started](/getting_started.md)
+    - [Getting Started](../../getting_started.md)
 - Reading Time: 7 minutes
 
 ---
@@ -189,6 +189,6 @@ And that's it! You are now ready to take your sketch to the next level.
 | Templates | [template_sketch.rs](https://github.com/nannou-org/nannou/blob/master/examples/templates/template_sketch.rs) | [template_app.rs](https://github.com/nannou-org/nannou/blob/master/examples/templates/template_app.rs) |
 | Can make awesome stuff? | Yes | Yes |
 
-To learn more about nannou **sketches** visit the [Draw a sketch](/tutorials/basics/draw-a-sketch.md) tutorial.
+To learn more about nannou **sketches** visit the [Draw a sketch](./draw-a-sketch.md) tutorial.
 
-To learn more about nannou **apps** visit the [Anatomy of a nannou app](/tutorials/basics/anatomy-of-a-nannou-app.md) tutorial.
+To learn more about nannou **apps** visit the [Anatomy of a nannou app](./anatomy-of-a-nannou-app.md) tutorial.

--- a/guide/src/tutorials/basics/window-coordinates.md
+++ b/guide/src/tutorials/basics/window-coordinates.md
@@ -4,7 +4,7 @@
 
 - Author: mitchmindtree
 - Required Knowledge:
-    - [Getting Started](/getting_started.md)
+    - [Getting Started](../../getting_started.md)
 - Reading Time: 15 minutes
 
 ---
@@ -119,7 +119,7 @@ So satisfying!
 window?*
 
 One approach would be to calculate the position by hand. For example, we know
-the top-left corner is equal to [-300, 200]. From there, we need to move the
+the top-left corner is equal to \[-300, 200\]. From there, we need to move the
 square to the right by half the width and down by half the height:
 
 ```rust,no_run
@@ -181,7 +181,7 @@ let r = geom::Rect::from_w_h(100.0, 100.0);
 # }
 ```
 
-`r` now represents our square, positioned at [0.0, 0.0] with a width and height
+`r` now represents our square, positioned at \[0.0, 0.0\] with a width and height
 of 100.0. We can confirm this by changing our square drawing code to use `r`
 like so:
 

--- a/guide/src/tutorials/draw/animating-a-circle.md
+++ b/guide/src/tutorials/draw/animating-a-circle.md
@@ -4,20 +4,20 @@
 
 - Author: [madskjeldgaard](https://madskjeldgaard.dk)
 - Required Knowledge:
-    - [Getting Started](/getting_started.md)
-    - [Anatomy of a nannou app](/tutorials/basics/anatomy-of-a-nannou-app.md)
-    - [Drawing 2D Shapes](/tutorials/basics/drawing-2d-shapes.md)
+    - [Getting Started](../../getting_started.md)
+    - [Anatomy of a nannou app](../basics/anatomy-of-a-nannou-app.md)
+    - [Drawing 2D Shapes](./drawing-2d-shapes.md)
 - Reading Time: 10 minutes
 ---
 
-![osc-circle](/tutorials/basics/images/moving-circle.gif)
+![osc-circle](./images/moving-circle.gif)
 
 # Moving a circle about on the screen
 In this tutorial we will cover the basics of moving a shape around in the window of a nannou app.
 
 Let's start by making a simple program which draws a circle in the center of the screen.
 
-We will be using the barebones app from [Anatomy of a nannou app](/tutorials/basics/anatomy-of-a-nannou-app.md) as a starting point for this.
+We will be using the barebones app from [Anatomy of a nannou app](../basics/anatomy-of-a-nannou-app.md) as a starting point for this.
 
 Update the view function of your nannou-app to look like this:
 

--- a/guide/src/tutorials/draw/drawing-2d-shapes.md
+++ b/guide/src/tutorials/draw/drawing-2d-shapes.md
@@ -4,8 +4,8 @@
 
 - Author: Seth Boyles
 - Required Knowledge:
-    - [Getting Started](/getting_started.md)
-    - [Draw a Sketch](./draw-a-sketch.md)
+    - [Getting Started](../../getting_started.md)
+    - [Draw a Sketch](../basics/draw-a-sketch.md)
 - Reading Time: 20 minutes
 
 ---

--- a/guide/src/tutorials/draw/drawing-images.md
+++ b/guide/src/tutorials/draw/drawing-images.md
@@ -4,8 +4,8 @@
 
 - Author: Josiah Savary
 - Required Knowledge:
-    - [Getting Started](/getting_started.md)
-    - [Draw a Sketch](./draw-a-sketch.md)
+    - [Getting Started](../../getting_started.md)
+    - [Draw a Sketch](../basics/draw-a-sketch.md)
 - Reading Time: 20 minutes
 
 ---

--- a/guide/src/tutorials/osc/osc-introduction.md
+++ b/guide/src/tutorials/osc/osc-introduction.md
@@ -4,7 +4,7 @@
 
 - Author: [madskjeldgaard](https://madskjeldgaard.dk)
 - Required Knowledge:
-    - [Anatomy of a nannou App](/tutorials/basics/anatomy-of-a-nannou-app.md)
+    - [Anatomy of a nannou App](../basics/anatomy-of-a-nannou-app.md)
 - Reading Time: 5 minutes
 ---
 

--- a/guide/src/tutorials/osc/osc-receiver.md
+++ b/guide/src/tutorials/osc/osc-receiver.md
@@ -4,19 +4,19 @@
 
 - Author: mitchmindtree
 - Required Knowledge:
-    - [Anatomy of a nannou App](/tutorials/basics/anatomy-of-a-nannou-app.md)
-    - [OSC introduction](/tutorials/osc/osc-introduction.md)
-    - [Sending OSC](/tutorials/osc/osc-sender.md)
+    - [Anatomy of a nannou App](../basics/anatomy-of-a-nannou-app.md)
+    - [OSC introduction](./osc-introduction.md)
+    - [Sending OSC](./osc-sender.md)
 - Reading Time: 15 minutes
 
 ---
 
-In the [previous tutorial](/tutorials/osc/osc-sender.md) we sent the position of
+In the [previous tutorial](./osc-sender.md) we sent the position of
 a circle out over OSC. In this tutorial we will do the opposite: we will *receive*
 OSC packets from another application and display them in a window.
 
 We will again use the `nannou_osc` crate. If you have not already added it to your
-project, see the [OSC introduction](/tutorials/osc/osc-introduction.md).
+project, see the [OSC introduction](./osc-introduction.md).
 
 ```rust,no_run
 # #![allow(unused_imports)]
@@ -45,7 +45,7 @@ struct Model {
 Next, we set up our `Model` in the `model` function. An `osc::Receiver` is bound
 to a network *port* - the same port that the sending application is targeting.
 Make sure this matches the port used by your sender (in the
-[sending tutorial](/tutorials/osc/osc-sender.md) we used `1234`, here we use
+[sending tutorial](./osc-sender.md) we used `1234`, here we use
 `34254` to match nannou's `osc_sender.rs` example - pick whichever you like, as
 long as the sender and receiver agree).
 

--- a/guide/src/tutorials/osc/osc-sender.md
+++ b/guide/src/tutorials/osc/osc-sender.md
@@ -4,17 +4,17 @@
 
 - Author: [madskjeldgaard](https://madskjeldgaard.dk)
 - Required Knowledge:
-    - [Anatomy of a nannou App](/tutorials/basics/anatomy-of-a-nannou-app.md)
-    - [Drawing 2D Shapes](/tutorials/basics/drawing-2d-shapes.md)
-    - [Animating a Circle](/tutorials/draw/animating-a-circle.md)
-    - [OSC introduction](/tutorials/osc/osc-introduction.md)
+    - [Anatomy of a nannou App](../basics/anatomy-of-a-nannou-app.md)
+    - [Drawing 2D Shapes](../draw/drawing-2d-shapes.md)
+    - [Animating a Circle](../draw/animating-a-circle.md)
+    - [OSC introduction](./osc-introduction.md)
 - Reading Time: 20 minutes
 
 ---
 
 In this tutorial we will cover how to send OSC data from a nannou app to another application using the `nannou_osc` crate.
 
-We are going to write a simple program which has a circle moving about on the screen while the circle's position is sent via OSC to another application. We will continue working on the app from [Animating a Circle](/tutorials/draw/animating-a-circle.md).
+We are going to write a simple program which has a circle moving about on the screen while the circle's position is sent via OSC to another application. We will continue working on the app from [Animating a Circle](../draw/animating-a-circle.md).
 
 ## Setting up an OSC sender
 

--- a/guide/src/welcome.md
+++ b/guide/src/welcome.md
@@ -9,31 +9,31 @@ have something for you!
 
 As excited as we are about developing tools for creative coding, we are equally
 excited about fostering a warm, welcoming and inclusive community. Please make
-yourself familiar with our [Code of Conduct](/code_of_conduct.md) and feel free
+yourself familiar with our [Code of Conduct](./code_of_conduct.md) and feel free
 to join us on the Nannou
 [Slack](https://communityinviter.com/apps/nannou/nannou-slack) or
 [Matrix](https://matrix.to/#/+nannou:matrix.org) community.
 
-### [Why Nannou?](/why_nannou.md)
+### [Why Nannou?](./why_nannou.md)
 
 Here you can read about the motivations and philosophy behind Nannou. Why start
 Nannou? What drives forward progress?
 
-### [Getting Started](/getting_started.md)
+### [Getting Started](./getting_started.md)
 
 Is this your first time using Nannou or Rust? This is the chapter for you.
 This chapter covers everything from installing Rust right through to starting
 your own Nannou project.
 
-### [Tutorials](/tutorials.md)
+### [Tutorials](./tutorials.md)
 
 A suite of tutorials demonstrating how to do different things with Nannou. For
 example, "How do I output sounds?", "How do I draw shapes?", "How can I connect
 to my laser?"
 
-> You can find more tutorials by the community [here](/community_tutorials.md).
+> You can find more tutorials by the community [here](./community_tutorials.md).
 
-### [Developer Reference](/developer_reference.md)
+### [Developer Reference](./developer_reference.md)
 
 Learn more about the design philosophy behind Nannou, how the project is
 architected and how you can contribute.
@@ -44,6 +44,6 @@ If you are looking for the source code reference, check out
 [docs.rs/nannou](https://docs.rs/nannou). Here you can find documentation about
 the API generated from the code itself.
 
-### [Showcases](/showcases.md)
+### [Showcases](./showcases.md)
 
 See what's possible with Nannou! A collection of projects made with Nannou.

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,6 @@
 { lib
 , mdbook
+, mdbook-linkcheck2
 , nannou
 , mkShell
 , rust-analyzer
@@ -11,6 +12,7 @@ mkShell {
   inputsFrom = [ nannou ];
   buildInputs = [
     mdbook
+    mdbook-linkcheck2
     rust-analyzer
     rustfmt
   ];


### PR DESCRIPTION
Follow-up to #1067, which added the `mdbook-linkcheck2` check as a `continue-on-error` entry in the cargo CI matrix.

## Guide link fixes

`mdbook-linkcheck2 -s guide/` now passes with zero errors and zero warnings:

- Fixed links to `drawing-2d-shapes.md` and `moving-circle.gif` that pointed at `tutorials/basics/` when the files live under `tutorials/draw/` - these were genuine 404s on the published guide.
- Fixed `./draw-a-sketch.md` links in `tutorials/draw/` pages to point at `../basics/draw-a-sketch.md`.
- Added the existing `contributing/nix-shell.md` page to `SUMMARY.md` so the link from `contributing.md` resolves.
- Made all remaining absolute links (`/getting_started.md` etc.) relative, so they also work when browsing the book from the file system.
- Escaped literal square brackets that are not links (`\[Breaking\]` in the changelog, coordinate pairs in the window-coordinates tutorial).

## Nix dev shell

`mdbook-linkcheck2` is now provided by the dev shell (the locked nixpkgs already ships 0.12.0), so the CI check can be reproduced locally with `mdbook-linkcheck2 -s guide/`.

## CI

The link check moved out of the cargo matrix into a dedicated `check-links` job. It installs nix and runs the tool from the flake-locked nixpkgs via `nix shell --inputs-from .`, so CI uses exactly the same version as the dev shell and skips the rust toolchain, apt dependencies and cargo cache it doesn't need. With the guide now clean, `continue-on-error` is gone and `verifications` gates on the new job, so broken links fail the pipeline.

Note: `mdbook-linkcheck2` only exits non-zero on *errors* (broken links); warning-level regressions still pass. Enforcing warnings-as-errors requires configuring it as an mdbook output backend in `book.toml`, which changes the book output layout and would break the deploy job's copy step - left as a possible follow-up.