### PR TITLE
refactor(nannou): drop the unused `bevy_common_assets` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,22 +701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_common_assets"
-version = "0.17.0-rc1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddba736ddcd2d2f90f5be98b5f7c7a5acc072e90035d0b53b59a113585e32ff"
-dependencies = [
- "anyhow",
- "bevy_app",
- "bevy_asset",
- "bevy_reflect",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
- "toml 0.9.12+spec-1.1.0",
-]
-
-[[package]]
 name = "bevy_core_pipeline"
 version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4878,7 +4862,6 @@ name = "nannou"
 version = "0.19.0"
 dependencies = [
  "bevy",
- "bevy_common_assets",
  "bevy_egui",
  "find_folder",
  "image",
@@ -4893,7 +4876,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "walkdir",
  "wgpu",
 ]
@@ -6715,7 +6698,7 @@ dependencies = [
 name = "run_all_examples"
 version = "0.1.0"
 dependencies = [
- "toml 0.8.23",
+ "toml",
 ]
 
 [[package]]
@@ -6977,15 +6960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -7442,7 +7416,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml 0.8.23",
+ "toml",
  "version-compare",
 ]
 
@@ -7705,24 +7679,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned 0.6.9",
+ "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap 2.12.0",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.13",
 ]
 
 [[package]]
@@ -7760,7 +7719,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.12.0",
  "serde",
- "serde_spanned 0.6.9",
+ "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.13",
@@ -7804,12 +7763,6 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ audrey = "0.3"
 bevy = { version = "0.19.0-rc.2", default-features = false }
 # Pinned to the Bevy 0.19 release candidates while we wait for the stable
 # release. Tracked for a switch back to stable in #TODO (RC -> stable).
-bevy_common_assets = "0.17.0-rc1"
 bevy_egui = "0.40.0-rc.1"
 # `bevy-inspector-egui` has no Bevy 0.19 release yet. Re-enable it (and the
 # `inspector` feature + `inspector_ui` example) once one lands - see the

--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -21,7 +21,6 @@ bevy = { workspace = true, default-features = false, features = [
 # `inspector` feature below and the RC -> stable tracking issue).
 #bevy-inspector-egui = { workspace = true, optional = true }
 bevy_egui = { workspace = true, optional = true }
-bevy_common_assets = { workspace = true, optional = true }
 nannou_derive = { workspace = true }
 nannou_draw = { workspace = true }
 nannou_video = { workspace = true, optional = true }
@@ -58,8 +57,6 @@ default = [
     "x11",
     "webgl2",
 ]
-config_json = ["bevy_common_assets/json"]
-config_toml = ["bevy_common_assets/toml"]
 # `immutable_ctx` lets nannou read the egui context through `&self` (the classic `app.egui()`
 # returns a cheap `egui::Context` handle), matching nannou's imperative single-pass UI usage.
 egui = ["dep:bevy_egui", "bevy_egui/immutable_ctx"]

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -370,20 +370,6 @@ where
         self
     }
 
-    #[cfg(any(feature = "config_json", feature = "config_toml"))]
-    pub fn init_config<T>(mut self) -> Self
-    where
-        for<'de> T: serde::Deserialize<'de> + Asset,
-    {
-        self.app.add_plugins((
-            #[cfg(feature = "config_json")]
-            bevy_common_assets::json::JsonAssetPlugin::<T>::new(&[".json"]),
-            #[cfg(feature = "config_toml")]
-            bevy_common_assets::toml::TomlAssetPlugin::<T>::new(&[".toml"]),
-        ));
-        self
-    }
-
     pub fn add_plugin<P>(mut self, plugin: P) -> Self
     where
         P: Plugin,


### PR DESCRIPTION
The `App::init_config` method registered JSON/TOML asset loaders behind the off-by-default `config_json`/`config_toml` features, but had no consumers (no example, guide, test, or history), was undocumented, and was never part of a published release - it was added after 0.19.0 as part of the unreleased Bevy refactor.

For now, remove it along with the `bevy_common_assets` dependency, which was the last crate still pinned to a Bevy 0.19 release candidate with no stable upstream release. Perhaps we can consider re-introducing if once `bevy_common_assets` is published? In the meantime, users can use the `bevy_common_assets` directly.