### PR TITLE
Default windows to `Mailbox` present mode, `UpdateMode` fixes + example fixes

### DIFF
--- a/examples/audio/record_wav.rs
+++ b/examples/audio/record_wav.rs
@@ -116,7 +116,7 @@ fn view(app: &App, model: &Model) {
     let draw = app.draw();
     draw.background().color(DIM_GRAY);
 
-    if !model.is_paused && app.elapsed_frames() % 30 < 20 {
+    if !model.is_paused {
         let draw = app.draw();
         draw.ellipse().w_h(100.0, 100.0).color(RED);
     }

--- a/examples/audio/record_wav.rs
+++ b/examples/audio/record_wav.rs
@@ -41,8 +41,26 @@ fn model(app: &App) -> Model {
     // Initialise the audio host so we can spawn an audio stream.
     let audio_host = audio::Host::new();
 
-    // Create a writer
-    let spec = get_spec(&audio_host);
+    // Record using the default input device's default config. We pin the stream to this device
+    // and config so the captured data matches the WAV header exactly (nannou would otherwise
+    // negotiate its own default sample rate and channel count).
+    let device = audio_host
+        .default_input_device()
+        .expect("no default input device available");
+    let config = device
+        .default_input_config()
+        .expect("failed to read the default input config");
+    let channels = config.channels();
+    let sample_rate = config.sample_rate();
+
+    // The stream captures samples as `f32` regardless of the device's native format, so the WAV
+    // is always written as 32-bit float.
+    let spec = hound::WavSpec {
+        channels,
+        sample_rate,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
     let writer = hound::WavWriter::create("recorded.wav", spec).unwrap();
     let capture_model = CaptureModel { writer };
 
@@ -52,6 +70,9 @@ fn model(app: &App) -> Model {
         let stream = audio_host
             .new_input_stream(capture_model)
             .capture(capture_fn)
+            .device(device)
+            .channels(channels as usize)
+            .sample_rate(sample_rate)
             .build()
             .unwrap();
 
@@ -119,23 +140,5 @@ fn view(app: &App, model: &Model) {
     if !model.is_paused {
         let draw = app.draw();
         draw.ellipse().w_h(100.0, 100.0).color(RED);
-    }
-}
-
-// Get specification from default device format.
-fn get_spec(audio_host: &nannou_audio::Host) -> hound::WavSpec {
-    let default_input_config = audio_host
-        .default_input_device()
-        .unwrap()
-        .default_input_config()
-        .unwrap();
-
-    // The stream captures samples as `f32` (the default sample type) regardless of the
-    // device's native format, so the WAV is always written as 32-bit float.
-    hound::WavSpec {
-        channels: default_input_config.channels(),
-        sample_rate: default_input_config.sample_rate(),
-        bits_per_sample: 32,
-        sample_format: hound::SampleFormat::Float,
     }
 }

--- a/generative_design/image/p_4_0_01.rs
+++ b/generative_design/image/p_4_0_01.rs
@@ -61,9 +61,11 @@ fn view(app: &App, model: &Model) {
     draw.background().color(BLACK);
     let win = app.window_rect();
     let tile_count_x = map_range(app.mouse().x, win.left(), win.right(), 1.0, win.w() / 3.0);
-    let tile_count_y = map_range(app.mouse().x, win.top(), win.bottom(), 1.0, win.h() / 3.0);
-    let step_x = win.w() / tile_count_x;
-    let step_y = win.h() / tile_count_y;
+    let tile_count_y = map_range(app.mouse().y, win.top(), win.bottom(), 1.0, win.h() / 3.0);
+    // Floor the steps so an off-window mouse can't drive them to zero (or negative),
+    // which would panic `step_by`.
+    let step_x = (win.w() / tile_count_x).max(1.0);
+    let step_y = (win.h() / tile_count_y).max(1.0);
 
     for grid_y in (0..win.h() as usize).step_by(step_y as usize) {
         for grid_x in (0..win.w() as usize).step_by(step_x as usize) {

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -1041,6 +1041,19 @@ pub trait UpdateModeExt {
     /// Stop driving updates from the frame loop, while still reacting to window events so
     /// the window can be closed, resized and redrawn.
     fn freeze() -> UpdateMode;
+    /// Drive updates at a fixed rate of `hz` ticks per second, like Processing's
+    /// `frameRate`.
+    ///
+    /// Device, user and window events are still received, but are buffered until the
+    /// next tick rather than waking the loop early, so the rate stays steady regardless
+    /// of input activity (input latency is at most one tick). The window remains
+    /// closable, resizable and redrawable because each tick runs the frame loop, and
+    /// thus bevy's `Last`-schedule window systems.
+    ///
+    /// A non-positive `hz` has no sensible tick interval and falls back to [`freeze`].
+    ///
+    /// [`freeze`]: UpdateModeExt::freeze
+    fn rate(hz: f64) -> UpdateMode;
 }
 
 impl UpdateModeExt for UpdateMode {
@@ -1062,6 +1075,20 @@ impl UpdateModeExt for UpdateMode {
             // `Last` schedule, which only runs when an update is triggered. Ignoring
             // window events here would leave a frozen window unable to close or redraw.
             react_to_window_events: true,
+        }
+    }
+
+    fn rate(hz: f64) -> UpdateMode {
+        if hz <= 0.0 {
+            return UpdateMode::freeze();
+        }
+        UpdateMode::Reactive {
+            wait: Duration::from_secs_f64(1.0 / hz),
+            // Buffer all events until the next tick so the rate stays steady; the finite
+            // wait keeps the frame loop (and window systems) running every tick.
+            react_to_device_events: false,
+            react_to_user_events: false,
+            react_to_window_events: false,
         }
     }
 }

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -1022,17 +1022,30 @@ where
     }
 }
 
+/// A practically-indefinite reactive wait used by [`UpdateModeExt::wait`] and
+/// [`UpdateModeExt::freeze`].
+///
+/// There is no `Instant::MAX` to wait until, and `Duration::MAX` can't be used here:
+/// `bevy_winit`'s reactive handler schedules the next wake-up as `Instant::now() + wait`
+/// via `Instant::checked_add`, which overflows (returns `None`) for `Duration::MAX`. When
+/// that happens `bevy_winit` silently skips setting the control flow and the app inherits
+/// whatever flow it was already in - benign when that is `Wait`, but a busy-loop if it had
+/// been polling. `u32::MAX` seconds (~136 years) is indistinguishable from "forever" for an
+/// interactive frame loop while staying well clear of overflow.
+const WAIT_INDEFINITELY: Duration = Duration::from_secs(u32::MAX as u64);
+
 pub trait UpdateModeExt {
-    /// Wait indefinitely for the next update.
+    /// Wait indefinitely for the next update, reacting to device, user and window events.
     fn wait() -> UpdateMode;
-    /// Freeze the application, sending no further updates.
+    /// Stop driving updates from the frame loop, while still reacting to window events so
+    /// the window can be closed, resized and redrawn.
     fn freeze() -> UpdateMode;
 }
 
 impl UpdateModeExt for UpdateMode {
     fn wait() -> UpdateMode {
         UpdateMode::Reactive {
-            wait: Duration::MAX,
+            wait: WAIT_INDEFINITELY,
             react_to_device_events: true,
             react_to_user_events: true,
             react_to_window_events: true,
@@ -1041,10 +1054,13 @@ impl UpdateModeExt for UpdateMode {
 
     fn freeze() -> UpdateMode {
         UpdateMode::Reactive {
-            wait: Duration::MAX,
+            wait: WAIT_INDEFINITELY,
             react_to_device_events: false,
             react_to_user_events: false,
-            react_to_window_events: false,
+            // Keep reacting to window events: bevy's window-close systems run in the
+            // `Last` schedule, which only runs when an update is triggered. Ignoring
+            // window events here would leave a frozen window unable to close or redraw.
+            react_to_window_events: true,
         }
     }
 }

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -270,6 +270,7 @@ where
                         primary_window: Some(Window {
                             title: "Nannou".to_string(),
                             resolution: (1024.0, 768.0).into(),
+                            present_mode: crate::window::DEFAULT_PRESENT_MODE,
                             ..default()
                         }),
                         exit_condition: ExitCondition::OnAllClosed,

--- a/nannou/src/context.rs
+++ b/nannou/src/context.rs
@@ -57,7 +57,7 @@ use std::cell::{Cell, RefCell};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use crate::app::find_project_path;
+use crate::app::{find_project_path, UpdateModeExt};
 use crate::camera::{CameraComponents, SetCamera};
 use crate::light::{LightComponents, SetLight};
 use crate::prelude::render::NannouCamera;
@@ -408,6 +408,15 @@ impl<'w, 's> App<'w, 's> {
     /// Set the update mode used while the window is focused.
     pub fn set_focused_update_mode(&self, mode: UpdateMode) {
         self.set_winit_settings(move |settings| settings.focused_mode = mode);
+    }
+
+    /// Drive updates at a fixed rate of `hz` ticks per second, while both focused and
+    /// unfocused. Analogous to Processing's `frameRate(fps)`.
+    ///
+    /// Convenience for `set_update_mode(UpdateMode::rate(hz))`. See
+    /// [`UpdateModeExt::rate`](crate::app::UpdateModeExt::rate) for the exact semantics.
+    pub fn set_update_rate(&self, hz: f64) {
+        self.set_update_mode(UpdateMode::rate(hz));
     }
 
     /// Queue a mutation of the [`WinitSettings`] resource.

--- a/nannou/src/context.rs
+++ b/nannou/src/context.rs
@@ -57,7 +57,7 @@ use std::cell::{Cell, RefCell};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use crate::app::{find_project_path, UpdateModeExt};
+use crate::app::{UpdateModeExt, find_project_path};
 use crate::camera::{CameraComponents, SetCamera};
 use crate::light::{LightComponents, SetLight};
 use crate::prelude::render::NannouCamera;

--- a/nannou/src/context.rs
+++ b/nannou/src/context.rs
@@ -496,10 +496,15 @@ impl<'w, 's> App<'w, 's> {
         Window { app: self, entity }
     }
 
-    /// A handle for reading and updating the primary window, falling back to a primary window
-    /// created this call (but not yet spawned).
+    /// A handle for reading and updating the app's main window.
     ///
-    /// **Panics** if there is no primary window.
+    /// This is the window explicitly marked primary (see
+    /// [`Builder::primary`](crate::window::Builder::primary)) if there is one, including a
+    /// primary window created this call but not yet spawned. Otherwise it falls back to the
+    /// current window (see [`window_id`](Self::window_id)), so a single window is treated as
+    /// the main window without needing to be marked primary.
+    ///
+    /// **Panics** if there are no windows open.
     pub fn main_window(&self) -> Window<'_, 'w, 's> {
         let entity = self
             .primary_window
@@ -514,7 +519,8 @@ impl<'w, 's> App<'w, 's> {
                     .find(|(_, primary, _)| *primary)
                     .map(|(e, _, _)| *e)
             })
-            .expect("no primary window is open in the App");
+            // No window is explicitly primary: fall back to the current window.
+            .unwrap_or_else(|| self.window_id());
         Window { app: self, entity }
     }
 }

--- a/nannou/src/prelude.rs
+++ b/nannou/src/prelude.rs
@@ -21,7 +21,7 @@ pub use bevy::render::render_resource::*;
 pub use bevy::shader::*;
 pub use bevy::tasks::prelude::{AsyncComputeTaskPool, IoTaskPool, block_on};
 pub use bevy::tasks::{Task, futures_lite::future};
-pub use bevy::window::CursorOptions;
+pub use bevy::window::{CursorOptions, PresentMode};
 pub use bevy::winit::UpdateMode;
 
 #[cfg(feature = "egui")]

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -15,7 +15,7 @@ use bevy::{
     input::mouse::MouseWheel,
     prelude::*,
     render::extract_component::ExtractComponent,
-    window::{PrimaryWindow, WindowLevel, WindowRef},
+    window::{PresentMode, PrimaryWindow, WindowLevel, WindowRef},
 };
 
 /// A context for building a window.
@@ -194,6 +194,13 @@ pub type UnfocusedFn<Model> = fn(&App<'_, '_>, &mut Model);
 /// A function for processing window closed events.
 pub type ClosedFn<Model> = fn(&App<'_, '_>, &mut Model);
 
+/// The default [`PresentMode`] used for nannou windows.
+///
+/// [`Mailbox`](PresentMode::Mailbox) ("fast vsync") gives low latency without
+/// tearing. Bevy falls back gracefully (`Mailbox` -> `Immediate` -> `Fifo`) on
+/// surfaces that don't support it, so it is safe everywhere.
+pub const DEFAULT_PRESENT_MODE: PresentMode = PresentMode::Mailbox;
+
 impl<'a, 'w, 's, M> Builder<'a, 'w, 's, M>
 where
     M: 'static,
@@ -202,7 +209,10 @@ where
     pub fn new(app: &'a App<'w, 's>) -> Self {
         Builder {
             app,
-            window: bevy::window::Window::default(),
+            window: bevy::window::Window {
+                present_mode: DEFAULT_PRESENT_MODE,
+                ..bevy::window::Window::default()
+            },
             camera: None,
             light: None,
             primary: false,
@@ -518,6 +528,24 @@ where
     pub fn size_pixels(self, width: u32, height: u32) -> Self {
         self.map_window(|mut w| {
             w.resolution.set_physical_resolution(width, height);
+            w
+        })
+    }
+
+    /// The [`PresentMode`] (a.k.a. swapchain / vsync mode) to use for this window.
+    ///
+    /// Defaults to [`DEFAULT_PRESENT_MODE`]. Bevy falls back gracefully on
+    /// surfaces that don't support the requested mode, so any variant is safe
+    /// to request.
+    ///
+    /// Note that non-blocking modes such as [`PresentMode::Mailbox`] and
+    /// [`PresentMode::Immediate`] remove the vblank backpressure that throttles
+    /// the update/draw loop, so they may increase CPU/GPU usage unless the frame
+    /// rate is otherwise limited. Use [`PresentMode::Fifo`] for traditional
+    /// "vsync on" behaviour.
+    pub fn present_mode(self, present_mode: PresentMode) -> Self {
+        self.map_window(|mut w| {
+            w.present_mode = present_mode;
             w
         })
     }

--- a/nature_of_code/chp_01_vectors/1_10_motion101_acceleration.rs
+++ b/nature_of_code/chp_01_vectors/1_10_motion101_acceleration.rs
@@ -59,6 +59,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let _window = app.new_window().size(640, 360).view(view).build();
     let mover = Mover::new(app.window_rect());
     Model { mover }

--- a/nature_of_code/chp_01_vectors/1_11_motion101_acceleration_array.rs
+++ b/nature_of_code/chp_01_vectors/1_11_motion101_acceleration_array.rs
@@ -66,6 +66,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_01_vectors/1_1_bouncingball_novectors.rs
+++ b/nature_of_code/chp_01_vectors/1_1_bouncingball_novectors.rs
@@ -17,6 +17,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let x = 100.0;
     let y = 100.0;
     let x_speed = 2.5;

--- a/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors.rs
+++ b/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors.rs
@@ -15,6 +15,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let position = pt2(100.0, 100.0);
     let velocity = vec2(2.5, 5.0);
 

--- a/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors_object.rs
+++ b/nature_of_code/chp_01_vectors/1_2_bouncingball_vectors_object.rs
@@ -51,7 +51,8 @@ impl Ball {
     }
 }
 
-fn model(_app: &App) -> Model {
+fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let ball = Ball::new();
     Model { ball }
 }

--- a/nature_of_code/chp_01_vectors/1_7_motion101.rs
+++ b/nature_of_code/chp_01_vectors/1_7_motion101.rs
@@ -57,6 +57,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let mover = Mover::new(app.window_rect());
     Model { mover }

--- a/nature_of_code/chp_01_vectors/1_8_motion101_acceleration.rs
+++ b/nature_of_code/chp_01_vectors/1_8_motion101_acceleration.rs
@@ -68,6 +68,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let mover = Mover::new(app.window_rect());
     Model { mover }

--- a/nature_of_code/chp_01_vectors/1_9_motion101_acceleration.rs
+++ b/nature_of_code/chp_01_vectors/1_9_motion101_acceleration.rs
@@ -70,6 +70,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let mover = Mover::new(app.window_rect());
     Model { mover }

--- a/nature_of_code/chp_02_forces/2_10_exercise_attract_repel.rs
+++ b/nature_of_code/chp_02_forces/2_10_exercise_attract_repel.rs
@@ -162,6 +162,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_02_forces/2_1_forces.rs
+++ b/nature_of_code/chp_02_forces/2_1_forces.rs
@@ -71,6 +71,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_02_forces/2_2_forces_many.rs
+++ b/nature_of_code/chp_02_forces/2_2_forces_many.rs
@@ -71,6 +71,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_02_forces/2_3_forces_many_real_gravity.rs
+++ b/nature_of_code/chp_02_forces/2_3_forces_many_real_gravity.rs
@@ -71,6 +71,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_02_forces/2_4_forces_friction.rs
+++ b/nature_of_code/chp_02_forces/2_4_forces_friction.rs
@@ -71,6 +71,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(383.0, 200.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_02_forces/2_4_forces_no_friction.rs
+++ b/nature_of_code/chp_02_forces/2_4_forces_no_friction.rs
@@ -71,6 +71,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(383.0, 200.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_02_forces/2_5_fluid_resistance.rs
+++ b/nature_of_code/chp_02_forces/2_5_fluid_resistance.rs
@@ -127,6 +127,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_02_forces/2_6_attraction.rs
+++ b/nature_of_code/chp_02_forces/2_6_attraction.rs
@@ -148,6 +148,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_02_forces/2_7_attraction_many.rs
+++ b/nature_of_code/chp_02_forces/2_7_attraction_many.rs
@@ -136,6 +136,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     let _window = app
         .new_window()

--- a/nature_of_code/chp_02_forces/2_8_mutual_attraction.rs
+++ b/nature_of_code/chp_02_forces/2_8_mutual_attraction.rs
@@ -66,6 +66,7 @@ impl Mover {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_02_forces/2_forces_many_mutual_boundaries.rs
+++ b/nature_of_code/chp_02_forces/2_forces_many_mutual_boundaries.rs
@@ -85,6 +85,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_03_oscillation/3_01_angular_motion.rs
+++ b/nature_of_code/chp_03_oscillation/3_01_angular_motion.rs
@@ -17,6 +17,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let angle = 0.0;
     let angle_velocity = 0.0;
     let angle_acceleration = -0.0001;

--- a/nature_of_code/chp_03_oscillation/3_02_forces_angular_motion.rs
+++ b/nature_of_code/chp_03_oscillation/3_02_forces_angular_motion.rs
@@ -107,6 +107,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(800.0, 200.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_03_oscillation/3_04_exercise_spiral.rs
+++ b/nature_of_code/chp_03_oscillation/3_04_exercise_spiral.rs
@@ -15,6 +15,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let r = 0.0;
     let theta = 0.0;
 

--- a/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian.rs
+++ b/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian.rs
@@ -15,6 +15,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian_trail.rs
+++ b/nature_of_code/chp_03_oscillation/3_04_polar_to_cartesian_trail.rs
@@ -15,6 +15,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(800.0, 200.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_03_oscillation/3_06_simple_harmonic_motion.rs
+++ b/nature_of_code/chp_03_oscillation/3_06_simple_harmonic_motion.rs
@@ -15,6 +15,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let angle = 0.0;
     let a_velocity = 0.03;
 

--- a/nature_of_code/chp_03_oscillation/3_07_oscillating_objects.rs
+++ b/nature_of_code/chp_03_oscillation/3_07_oscillating_objects.rs
@@ -59,6 +59,7 @@ impl Oscillator {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_03_oscillation/3_09_exercise_additive_wave.rs
+++ b/nature_of_code/chp_03_oscillation/3_09_exercise_additive_wave.rs
@@ -23,6 +23,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
 
     let x_spacing = 8.0;

--- a/nature_of_code/chp_03_oscillation/3_09_wave.rs
+++ b/nature_of_code/chp_03_oscillation/3_09_wave.rs
@@ -15,6 +15,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let start_angle = 0.0;
     let angle_vel = 0.23;

--- a/nature_of_code/chp_03_oscillation/3_09_wave_a.rs
+++ b/nature_of_code/chp_03_oscillation/3_09_wave_a.rs
@@ -15,6 +15,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(250, 200).view(view).build();
     let start_angle = 0.0;
     let angle_vel = 0.05;

--- a/nature_of_code/chp_03_oscillation/3_09_wave_b.rs
+++ b/nature_of_code/chp_03_oscillation/3_09_wave_b.rs
@@ -15,6 +15,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(250, 200).view(view).build();
     let start_angle = 0.0;
     let angle_vel = 0.2;

--- a/nature_of_code/chp_03_oscillation/3_09_wave_c.rs
+++ b/nature_of_code/chp_03_oscillation/3_09_wave_c.rs
@@ -15,6 +15,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(200, 200).view(view).build();
     let start_angle = 0.0;
     let angle_vel = 0.4;

--- a/nature_of_code/chp_03_oscillation/3_10_exercise_oop_wave.rs
+++ b/nature_of_code/chp_03_oscillation/3_10_exercise_oop_wave.rs
@@ -75,6 +75,7 @@ impl Wave {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(750, 200).view(view).build();
     let wave0 = Wave::new(pt2(-325.0, 25.0), 100.0, 20.0, 500.0);
     let wave1 = Wave::new(pt2(-75.0, 0.0), 300.0, 40.0, 220.0);

--- a/nature_of_code/chp_03_oscillation/3_10_pendulum_example.rs
+++ b/nature_of_code/chp_03_oscillation/3_10_pendulum_example.rs
@@ -126,6 +126,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(640, 360)
         .view(view)

--- a/nature_of_code/chp_03_oscillation/3_10_pendulum_example_simplified.rs
+++ b/nature_of_code/chp_03_oscillation/3_10_pendulum_example_simplified.rs
@@ -89,6 +89,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let pendulum = Pendulum::new(pt2(0.0, app.window_rect().top()), 175.0);
 

--- a/nature_of_code/chp_03_oscillation/3_11_exercise_additive_wave.rs
+++ b/nature_of_code/chp_03_oscillation/3_11_exercise_additive_wave.rs
@@ -21,6 +21,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(750, 200).view(view).build();
 
     let x_spacing = 8.0;

--- a/nature_of_code/chp_03_oscillation/3_11_spring.rs
+++ b/nature_of_code/chp_03_oscillation/3_11_spring.rs
@@ -161,6 +161,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(640, 360)
         .view(view)

--- a/nature_of_code/chp_03_oscillation/3_16_exercise_springs.rs
+++ b/nature_of_code/chp_03_oscillation/3_16_exercise_springs.rs
@@ -130,6 +130,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(640, 360)
         .view(view)

--- a/nature_of_code/chp_03_oscillation/3_16_exercise_springs_array.rs
+++ b/nature_of_code/chp_03_oscillation/3_16_exercise_springs_array.rs
@@ -126,6 +126,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(640, 360)
         .view(view)

--- a/nature_of_code/chp_03_oscillation/3_exercise_spring_sine.rs
+++ b/nature_of_code/chp_03_oscillation/3_exercise_spring_sine.rs
@@ -14,6 +14,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     Model {
         angle: 0.0,

--- a/nature_of_code/chp_03_oscillation/3_extra_oscillating_body.rs
+++ b/nature_of_code/chp_03_oscillation/3_extra_oscillating_body.rs
@@ -135,6 +135,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(640, 360)
         .view(view)

--- a/nature_of_code/chp_03_oscillation/3_extra_oscillating_body.rs
+++ b/nature_of_code/chp_03_oscillation/3_extra_oscillating_body.rs
@@ -110,22 +110,23 @@ impl Mover {
     }
 
     fn display(&self, draw: &Draw) {
-        let heading = (self.velocity.angle() + PI / 2.0) * -1.0;
+        // The body is a circle, so it needs no rotation.
         draw.ellipse()
             .xy(self.position)
             .w_h(16.0, 16.0)
             .color(GREY)
             .stroke(BLACK)
-            .stroke_weight(2.0)
-            .rotate(heading);
+            .stroke_weight(2.0);
 
+        // A small square "nose" offset in the direction of travel.
+        let nose = self.position + self.velocity.normalize_or_zero() * 20.0;
         draw.rect()
-            .x_y(self.position.x + 20.0, self.position.y)
+            .xy(nose)
             .w_h(10.0, 10.0)
             .color(GREY)
             .stroke(BLACK)
             .stroke_weight(2.0)
-            .rotate(heading);
+            .rotate(self.velocity.angle());
     }
 }
 

--- a/nature_of_code/chp_03_oscillation/3_extra_oscillating_up_and_down.rs
+++ b/nature_of_code/chp_03_oscillation/3_extra_oscillating_up_and_down.rs
@@ -14,6 +14,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(400, 400).view(view).build();
     let angle = 0.0;
     Model { angle }

--- a/nature_of_code/chp_03_oscillation/3_multiple_oscillations.rs
+++ b/nature_of_code/chp_03_oscillation/3_multiple_oscillations.rs
@@ -19,6 +19,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let angle1 = 0.0;
     let a_velocity1 = 0.01;
     let amplitude1 = 300.0;

--- a/nature_of_code/chp_03_oscillation/3_oop_wave_particles.rs
+++ b/nature_of_code/chp_03_oscillation/3_oop_wave_particles.rs
@@ -95,6 +95,7 @@ impl Wave {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(750, 200).view(view).build();
     let wave0 = Wave::new(pt2(-325.0, 25.0), 100.0, 20.0, 500.0);
     let wave1 = Wave::new(pt2(-75.0, 0.0), 300.0, 40.0, 220.0);

--- a/nature_of_code/chp_04_systems/4_01_single_particle.rs
+++ b/nature_of_code/chp_04_systems/4_01_single_particle.rs
@@ -59,6 +59,7 @@ impl Particle {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let p = Particle::new(pt2(0.0, app.window_rect().top() - 20.0));
     Model { p }

--- a/nature_of_code/chp_04_systems/4_01_single_particle_trail.rs
+++ b/nature_of_code/chp_04_systems/4_01_single_particle_trail.rs
@@ -60,6 +60,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(800, 200)
         .view(view)

--- a/nature_of_code/chp_04_systems/4_02_vector_particle.rs
+++ b/nature_of_code/chp_04_systems/4_02_vector_particle.rs
@@ -59,6 +59,7 @@ impl Particle {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let particles = Vec::new();
     Model { particles }

--- a/nature_of_code/chp_04_systems/4_03_exercise_moving_particle_system.rs
+++ b/nature_of_code/chp_04_systems/4_03_exercise_moving_particle_system.rs
@@ -91,6 +91,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let (_w, h) = app.window_rect().w_h();
     let ps = ParticleSystem::new(pt2(0.0, (h / 2.0) - 50.0));

--- a/nature_of_code/chp_04_systems/4_03_particle_system_type.rs
+++ b/nature_of_code/chp_04_systems/4_03_particle_system_type.rs
@@ -92,6 +92,7 @@ impl ParticleSystem {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let (_w, h) = app.window_rect().w_h();
     let ps = ParticleSystem::new(pt2(0.0, (h / 2.0) - 50.0));

--- a/nature_of_code/chp_04_systems/4_04_system_of_systems.rs
+++ b/nature_of_code/chp_04_systems/4_04_system_of_systems.rs
@@ -100,6 +100,7 @@ impl ParticleSystem {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(640, 360)
         .mouse_pressed(mouse_pressed)

--- a/nature_of_code/chp_04_systems/4_05_particle_system_inheritance_polymorphism.rs
+++ b/nature_of_code/chp_04_systems/4_05_particle_system_inheritance_polymorphism.rs
@@ -118,6 +118,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let (_w, h) = app.window_rect().w_h();
     let ps = ParticleSystem::new(pt2(0.0, (h / 2.0) - 50.0));

--- a/nature_of_code/chp_04_systems/4_06_exercise_shatter.rs
+++ b/nature_of_code/chp_04_systems/4_06_exercise_shatter.rs
@@ -107,6 +107,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(640, 360)
         .view(view)

--- a/nature_of_code/chp_04_systems/4_06_particle_system_forces.rs
+++ b/nature_of_code/chp_04_systems/4_06_particle_system_forces.rs
@@ -107,6 +107,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let ps = ParticleSystem::new(pt2(0.0, app.window_rect().top() - 50.0));
     Model { ps }

--- a/nature_of_code/chp_04_systems/4_07_particle_system_forces_repeller.rs
+++ b/nature_of_code/chp_04_systems/4_07_particle_system_forces_repeller.rs
@@ -152,6 +152,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let ps = ParticleSystem::new(pt2(0.0, app.window_rect().top() - 50.0));
     let repeller = Repeller::new(-20.0, 0.0);

--- a/nature_of_code/chp_04_systems/4_10_exercise_particle_intersection.rs
+++ b/nature_of_code/chp_04_systems/4_10_exercise_particle_intersection.rs
@@ -128,6 +128,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let ps = ParticleSystem::new(pt2(0.0, 0.0));
     Model { ps }

--- a/nature_of_code/chp_04_systems/4_10_exercise_particle_repel.rs
+++ b/nature_of_code/chp_04_systems/4_10_exercise_particle_repel.rs
@@ -126,6 +126,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let ps = ParticleSystem::new(pt2(0.0, 0.0));
     Model { ps }

--- a/nature_of_code/chp_06_agents/6_01_seek.rs
+++ b/nature_of_code/chp_06_agents/6_01_seek.rs
@@ -65,6 +65,7 @@ impl Vehicle {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let middle = app.window_rect().xy();
     let vehicle = Vehicle::new(middle.x, middle.y);

--- a/nature_of_code/chp_06_agents/6_01_seek_trail.rs
+++ b/nature_of_code/chp_06_agents/6_01_seek_trail.rs
@@ -71,6 +71,7 @@ impl Vehicle {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let middle = app.window_rect().xy();
     let vehicle = Vehicle::new(middle.x, middle.y);

--- a/nature_of_code/chp_06_agents/6_02_arrive.rs
+++ b/nature_of_code/chp_06_agents/6_02_arrive.rs
@@ -62,6 +62,7 @@ impl Vehicle {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let middle = app.window_rect().xy();
     let vehicle = Vehicle::new(middle.x, middle.y);

--- a/nature_of_code/chp_06_agents/6_03_stay_within_walls.rs
+++ b/nature_of_code/chp_06_agents/6_03_stay_within_walls.rs
@@ -89,6 +89,7 @@ impl Vehicle {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(640, 360)
         .view(view)

--- a/nature_of_code/chp_06_agents/6_03_stay_within_walls_trail.rs
+++ b/nature_of_code/chp_06_agents/6_03_stay_within_walls_trail.rs
@@ -97,6 +97,7 @@ impl Vehicle {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(640, 360)
         .view(view)

--- a/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_figures.rs
+++ b/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_figures.rs
@@ -141,6 +141,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(1800.0, 600.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_simple.rs
+++ b/nature_of_code/chp_07_cellular_automata/7_01_wolfram_ca_simple.rs
@@ -112,6 +112,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(800.0, 400.0);
     let _window = app
         .new_window()

--- a/nature_of_code/chp_07_cellular_automata/7_02_game_of_life_simple.rs
+++ b/nature_of_code/chp_07_cellular_automata/7_02_game_of_life_simple.rs
@@ -131,6 +131,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_07_cellular_automata/7_03_game_of_life_oop.rs
+++ b/nature_of_code/chp_07_cellular_automata/7_03_game_of_life_oop.rs
@@ -153,6 +153,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 360.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_07_cellular_automata/7_04_exercise_wolfram_ca_scrolling.rs
+++ b/nature_of_code/chp_07_cellular_automata/7_04_exercise_wolfram_ca_scrolling.rs
@@ -147,6 +147,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(640.0, 800.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_07_cellular_automata/7_game_of_life_wrap_around.rs
+++ b/nature_of_code/chp_07_cellular_automata/7_game_of_life_wrap_around.rs
@@ -117,6 +117,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(400.0, 400.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_07_cellular_automata/7_hexagon_cells.rs
+++ b/nature_of_code/chp_07_cellular_automata/7_hexagon_cells.rs
@@ -113,6 +113,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let rect = geom::Rect::from_w_h(600.0, 600.0);
     app.new_window()
         .size(rect.w() as u32, rect.h() as u32)

--- a/nature_of_code/chp_08_fractals/8_4_tree.rs
+++ b/nature_of_code/chp_08_fractals/8_4_tree.rs
@@ -18,6 +18,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     let _window = app.new_window().size(300, 200).view(view).build();
     Model { theta: 0.0 }
 }

--- a/nature_of_code/chp_09_genetic_algorithms/9_1_ga_shakespeare.rs
+++ b/nature_of_code/chp_09_genetic_algorithms/9_1_ga_shakespeare.rs
@@ -217,6 +217,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
     let target = "To be or not to be.".to_string();
     let pop_max = 150;

--- a/nature_of_code/chp_09_genetic_algorithms/9_1_ga_shakespeare.rs
+++ b/nature_of_code/chp_09_genetic_algorithms/9_1_ga_shakespeare.rs
@@ -151,7 +151,7 @@ impl Population {
         // a lower fitness = fewer entries to mating pool = less likely to be picked as a parent
         for i in 0..self.population.len() {
             let fitness = map_range(self.population[i].fitness, 0.0, max_fitness, 0.0, 1.0);
-            let n = fitness as usize * 100; // Arbitrary multiplier, we can also use monte carlo method
+            let n = (fitness * 100.0) as usize; // Arbitrary multiplier, we can also use monte carlo method
             for _ in 0..n {
                 self.mating_pool.push(self.population[i].clone());
             }
@@ -233,6 +233,11 @@ fn model(app: &App) -> Model {
 }
 
 fn update(_app: &App, model: &mut Model) {
+    // Once we've evolved the target phrase, stop evolving so we don't keep
+    // churning the (already solved) population on every reactive update.
+    if model.population.finished {
+        return;
+    }
     // Generate mating pool
     model.population.natural_selection();
     // Create next generation

--- a/nature_of_code/chp_10_neural_networks/10_01_simple_perceptron.rs
+++ b/nature_of_code/chp_10_neural_networks/10_01_simple_perceptron.rs
@@ -88,6 +88,7 @@ fn f(x: f32) -> f32 {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window().size(640, 360).view(view).build();
 
     let x_min = -400.0;

--- a/nature_of_code/chp_10_neural_networks/10_02_seeking_neural.rs
+++ b/nature_of_code/chp_10_neural_networks/10_02_seeking_neural.rs
@@ -148,6 +148,7 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    app.set_update_rate(60.0);
     app.new_window()
         .size(640, 360)
         .view(view)

--- a/nature_of_code/chp_10_neural_networks/10_02_seeking_neural.rs
+++ b/nature_of_code/chp_10_neural_networks/10_02_seeking_neural.rs
@@ -124,7 +124,6 @@ impl Vehicle {
 
     fn display(&self, draw: &Draw) {
         // Draw a triangle rotated in the direction of velocity
-        // This calculation is wrong
         let theta = (self.velocity.angle() + PI / 2.0) * -1.0;
         let points = vec![
             pt2(0.0, -self.r * 2.0),
@@ -136,7 +135,7 @@ impl Vehicle {
             .points(points)
             .xy(self.position)
             .srgb(0.5, 0.5, 0.5)
-            .rotate(theta);
+            .rotate(-theta);
     }
 }
 


### PR DESCRIPTION
## Summary

Defaults nannou windows to bevy's `Mailbox` present mode for lower latency and smoother interaction/resizing, adds a fixed update-rate API so animations stay stable when the loop is no longer vsync-bound, and fixes a batch of example bugs surfaced while walking through the examples for the 0.20 release.

## Present mode + update rate

- Default windows to `PresentMode::Mailbox` ("fast vsync": low latency, no tearing). Bevy falls back gracefully (Mailbox -> Immediate -> Fifo) on surfaces that don't support it. Adds a `window::Builder::present_mode()` method and re-exports `PresentMode` from the prelude, with a shared `DEFAULT_PRESENT_MODE` const.
- Add `UpdateMode::rate(hz)` and `App::set_update_rate(hz)` (like Processing's `frameRate`): a clean fixed tick that still receives input, buffered until the next tick. The global default stays free-running.
- Drive the 71 animating `nature_of_code` examples at a fixed 60hz so their per-frame increments animate at a stable speed regardless of display refresh (previously latent, exposed by the Mailbox default).
- Includes the `fix-freeze-update-mode` fix: keep frozen windows responsive in `UpdateMode::freeze` (and avoid a `Duration::MAX` overflow in bevy_winit's reactive handler).

## Example / framework fixes

- `App::main_window()` now falls back to the current window when no window is explicitly marked primary, so a single window is treated as the main window again (fixes `save_screenshot` panicking across ~68 examples).
- `10_02_seeking_neural`: agent triangle pointed backwards (rotation sign).
- `3_extra_oscillating_body`: nose now offsets along the heading instead of spinning in place.
- `p_4_0_01`: stop a `step_by(0)` panic (used `mouse().x` for the vertical tile count; floor the steps).
- `record_wav`: keep the recording indicator steady, and record using the default input device's config so the WAV header matches the captured data (was producing an over-long, scrambled file).