### PR TITLE
fix(bevy): deliver `mouse_moved`/`touch` events in nannou coordinates

### DIFF
--- a/examples/audio/hrtf-noise.rs
+++ b/examples/audio/hrtf-noise.rs
@@ -1,8 +1,9 @@
 //! A minimal example to demonstrate the effect of HRTF (head-related transfer function) on a
 //! real-time stream of audio. HRTF is a popular approach to achieving binaural audio.
 //!
-//! The example uses generated white noise as the sound source. The source position can be rotated
-//! around the user by moving the mouse along the *x* axis.
+//! The example uses generated white noise as the sound source. The source position is controlled by
+//! moving the mouse: the *x* axis maps to left/right and the *y* axis maps to front/back, with the
+//! listener's head fixed at the centre of the window.
 //!
 //! The example will fail if the default cpal output device under the default host offers less than
 //! two channels.
@@ -241,10 +242,13 @@ fn view(app: &App, model: &Model) {
         .points(pt2(0.0, -30.0), pt2(0.0, 30.0));
     draw.text("HEAD").color(WHITE);
 
-    // Draw the source.
+    // Draw the source. Project the audio-space position back onto the screen to confirm the
+    // round-trip: the marker should sit directly under the cursor.
     let (x, y, z) = model.source_position.into();
+    let source_screen = pt2(x, z) * LISTENING_RADIUS;
+    draw.ellipse().radius(8.0).xy(source_screen).color(RED);
     let text = format!("Noise Source:\n[{:.2}, {:.2}, {:.2}]", x, y, z);
-    draw.text(&text).xy(app.mouse() + vec2(0.0, 20.0));
+    draw.text(&text).xy(source_screen + vec2(0.0, 20.0));
 }
 
 // Simple function for determining a gain based on the distance from the listener.

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -823,9 +823,11 @@ fn events<M, E>(
 
 // Each single-callback window-input driver has the same shape: for every message, look up the
 // target window's user functions, mark it the current view, and call the relevant callback
-// (optionally with a value derived from the event). Generate them from this macro.
+// (optionally with a value derived from the event, which may itself reference `app` - e.g. to
+// convert event coordinates into nannou's coordinate system). Generate them from this macro.
 macro_rules! window_event_driver {
-    ($name:ident, $msg:ty, $field:ident $(, |$evt:ident| $arg:expr)?) => {
+    // No derived value: the callback takes only `&App` and `&mut Model`.
+    ($name:ident, $msg:ty, $field:ident) => {
         fn $name<M>(
             app: App,
             mut events: MessageReader<$msg>,
@@ -838,11 +840,39 @@ macro_rules! window_event_driver {
                 if let Ok(user_fns) = user_fns.get(evt.window) {
                     if let Some(f) = user_fns.$field {
                         app.set_current_view(Some(evt.window));
-                        f(&app, &mut model $(, { let $evt = evt; $arg })?);
+                        f(&app, &mut model);
                     }
                 }
             }
         }
+    };
+    // Derived value with access to both `app` and the event.
+    ($name:ident, $msg:ty, $field:ident, |$app:ident, $evt:ident| $arg:expr) => {
+        fn $name<M>(
+            app: App,
+            mut events: MessageReader<$msg>,
+            user_fns: Query<&WindowUserFunctions<M>>,
+            mut model: ResMut<ModelHolder<M>>,
+        ) where
+            M: 'static + Send + Sync,
+        {
+            for evt in events.read() {
+                if let Ok(user_fns) = user_fns.get(evt.window) {
+                    if let Some(f) = user_fns.$field {
+                        app.set_current_view(Some(evt.window));
+                        f(&app, &mut model, {
+                            let $app = &app;
+                            let $evt = evt;
+                            $arg
+                        });
+                    }
+                }
+            }
+        }
+    };
+    // Derived value from the event alone.
+    ($name:ident, $msg:ty, $field:ident, |$evt:ident| $arg:expr) => {
+        window_event_driver!($name, $msg, $field, |_app, $evt| $arg);
     };
 }
 
@@ -908,8 +938,9 @@ fn received_char_events<M>(
     }
 }
 
-window_event_driver!(cursor_moved_events, CursorMoved, mouse_moved, |evt| evt
-    .position);
+window_event_driver!(cursor_moved_events, CursorMoved, mouse_moved, |app, evt| {
+    app.screen_to_points(evt.window, evt.position)
+});
 
 button_event_driver!(
     mouse_button_events,
@@ -926,7 +957,11 @@ window_event_driver!(window_moved_events, WindowMoved, moved, |evt| evt.position
 window_event_driver!(window_resized_events, WindowResized, resized, |evt| {
     Vec2::new(evt.width, evt.height)
 });
-window_event_driver!(touch_events, TouchInput, touch, |evt| *evt);
+window_event_driver!(touch_events, TouchInput, touch, |app, evt| {
+    let mut evt = *evt;
+    evt.position = app.screen_to_points(evt.window, evt.position);
+    evt
+});
 
 #[allow(clippy::type_complexity)]
 fn file_drop_events<M>(

--- a/nannou/src/context.rs
+++ b/nannou/src/context.rs
@@ -184,12 +184,20 @@ impl<'w, 's> App<'w, 's> {
     pub fn mouse(&self) -> Vec2 {
         self.with_window(self.window_id(), |window| {
             let screen_position = window.cursor_position().unwrap_or(Vec2::ZERO);
-            Vec2::new(
-                screen_position.x - window.width() / 2.0,
-                -(screen_position.y - window.height() / 2.0),
-            )
+            screen_to_points(screen_position, window.width(), window.height())
         })
         .expect("focused window entity is not a window")
+    }
+
+    /// Convert a raw screen position (top-left origin, y-down) within the given window into
+    /// nannou's coordinate system (centre origin, y-up), in points.
+    ///
+    /// Returns `Vec2::ZERO` if the window is no longer available.
+    pub(crate) fn screen_to_points(&self, window: Entity, screen_position: Vec2) -> Vec2 {
+        self.with_window(window, |window| {
+            screen_to_points(screen_position, window.width(), window.height())
+        })
+        .unwrap_or(Vec2::ZERO)
     }
 
     /// The [`Entity`] of the "current" window: the focused window, else the primary window, else a
@@ -728,4 +736,13 @@ impl LightBuilder<'_, '_, '_> {
                 .id()
         })
     }
+}
+
+/// Convert a raw screen position (top-left origin, y-down) within a window of the given dimensions
+/// into nannou's coordinate system (centre origin, y-up), in points.
+fn screen_to_points(screen_position: Vec2, width: f32, height: f32) -> Vec2 {
+    Vec2::new(
+        screen_position.x - width / 2.0,
+        -(screen_position.y - height / 2.0),
+    )
 }


### PR DESCRIPTION
The `cursor_moved_events` and `touch_events` window drivers forwarded bevy's raw event position (top-left origin, y-down) straight to the `mouse_moved`/`touch` callbacks, but nannou's convention - and what `App::mouse()` returns - is centre-origin, y-up. So mouse/touch positions were offset by half the window and vertically flipped, e.g. in the hrtf-noise example the noise source read [1, 0, 1] (silent) over the centred HEAD instead of [0, 0, 0] (loudest).

Factor the screen->points transform out of `App::mouse()` into a pure `screen_to_points(pos, w, h)` plus a `pub(crate)` `App::screen_to_points` keyed by window entity, then convert in both drivers. Add an `|app, evt|` arm to `window_event_driver!` (the macro body's `app` is unreachable from the caller-supplied arg expression due to hygiene); the existing `|evt|` form delegates to it. This also fixes laser_raw_stream and osc_sender, which were hit by the same regression.

Also polish the hrtf-noise example: draw a source marker projected from the audio-space position and correct the stale doc comment.