### PR TITLE
ci(release-plz): provide the git-forge token via `GIT_TOKEN`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,10 @@ jobs:
     - name: Run release-plz
       run: nix develop --command release-plz release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # release-plz reads the git-forge token from GIT_TOKEN; it uses this to
+        # create the `v{version}` tag and GitHub Release. This is distinct from
+        # GITHUB_TOKEN, which the `release` subcommand does not consume.
+        GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Short-lived crates.io token minted via Trusted Publishing (OIDC);
         # release-plz passes it through to `cargo publish`. No crates.io secret
         # is stored. Requires each crate to have a trusted publisher configured


### PR DESCRIPTION
release-plz reads the forge token used to create the tag and GitHub Release from the `GIT_TOKEN` env var, not `GITHUB_TOKEN`. The release job exposed the secret as `GITHUB_TOKEN`, so `release-plz` saw no token and failed up front with 'git release not configured. Did you specify git-token and forge?' before publishing anything.

Rename the env var to `GIT_TOKEN`, matching the working gantz workflow.