### PR TITLE
fix: use trunc() instead of floor() in fmod to match C behavior

### DIFF
--- a/nannou_core/src/math.rs
+++ b/nannou_core/src/math.rs
@@ -192,13 +192,31 @@ where
     S::one() + S::one()
 }
 
-/// Models the C++ fmod function.
+/// Models the C/C++ fmod function.
+///
+/// Computes the floating-point remainder of dividing `numer` by `denom`.
+/// The result has the same sign as `numer` and its magnitude is less than
+/// the magnitude of `denom`.
+///
+/// This matches the behavior of C's `fmod()` which uses truncation toward zero
+/// (not floor) for the quotient calculation.
+///
+/// # Examples
+///
+/// ```
+/// use nannou_core::math::fmod;
+///
+/// assert_eq!(fmod(5.1, 3.0), 5.1 % 3.0);
+/// assert_eq!(fmod(-5.1, 3.0), -5.1 % 3.0);
+/// assert_eq!(fmod(5.1, -3.0), 5.1 % -3.0);
+/// assert_eq!(fmod(-5.1, -3.0), -5.1 % -3.0);
+/// ```
 #[inline]
 pub fn fmod<F>(numer: F, denom: F) -> F
 where
     F: Float,
 {
-    let rquot: F = (numer / denom).floor();
+    let rquot: F = (numer / denom).trunc();
     numer - rquot * denom
 }
 


### PR DESCRIPTION
## Description

The C/C++ `fmod()` function uses truncation toward zero for the quotient, not floor. This caused incorrect results when mixing positive and negative values.

Fixes #983

### Before
```rust
fmod(-5.1, 3.0)  //  0.9000000000000004 ❌
fmod(5.1, -3.0)  // -0.9000000000000004 ❌
```

### After
```rust
fmod(-5.1, 3.0)  // -2.1 ✅
fmod(5.1, -3.0)  //  2.1 ✅
```

### Changes
- Changed `floor()` to `trunc()` in `nannou_core/src/math.rs`
- Added doc examples matching C behavior

### References
- [cppreference: fmod](https://en.cppreference.com/w/c/numeric/math/fmod)
- [Rust Playground verification](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=78143ac20af1ad75731c5cc3735fad91)
