### PR TITLE
fix: clarify BufferInner ownership in laser FFI

### DIFF
--- a/nannou_laser/src/ffi.rs
+++ b/nannou_laser/src/ffi.rs
@@ -208,10 +208,11 @@ pub struct Buffer {
 
 struct FrameInner(*mut crate::stream::frame::Frame);
 
-struct BufferInner(
-    // FIXME: Currently unused - should we be freeing this?
-    #[allow(dead_code)] *mut crate::stream::raw::Buffer,
-);
+/// Wrapper for raw buffer pointer passed to callbacks.
+///
+/// This is intentionally a thin wrapper without a `Drop` implementation
+/// because the underlying buffer is owned by the stream, not by this FFI handle.
+struct BufferInner(*mut crate::stream::raw::Buffer);
 
 struct ApiInner {
     inner: crate::Api,


### PR DESCRIPTION
## Description

Clarifies the ownership model of `BufferInner` in the laser FFI module.

Fixes #1010

### Problem
The `BufferInner` struct contained a `*mut crate::stream::raw::Buffer` pointer with a `FIXME` comment asking whether it should be freed. This caused confusion about memory ownership.

### Solution
Added documentation explaining that `BufferInner` intentionally does **not** implement `Drop` because:
- The underlying buffer is owned by the stream, not by the FFI handle
- `BufferInner` is a thin wrapper used only to pass the buffer through callbacks
- The stream manages the buffer's lifecycle

### Changes
- Replaced `#[allow(dead_code)]` and FIXME comment with clear ownership documentation
- No functional changes - this is a documentation/clarification fix
