### PR TITLE
fix(draw): Scope draw meshes to their window's camera

### DIFF
--- a/nannou_draw/src/render.rs
+++ b/nannou_draw/src/render.rs
@@ -147,6 +147,7 @@ impl Plugin for NannouRenderPlugin {
 
         app.add_plugins((
             ExtractComponentPlugin::<NannouTransient>::default(),
+            ExtractComponentPlugin::<NannouMeshCamera>::default(),
             ExtractComponentPlugin::<ShaderModelMesh>::default(),
             ExtractComponentPlugin::<IndirectMesh>::default(),
             ExtractComponentPlugin::<InstancedMesh>::default(),
@@ -400,7 +401,7 @@ pub(crate) fn queue_shader_model<SM, QF, RC>(
         extracted_instances,
     ): (
         Res<RenderMeshInstances>,
-        Query<(Entity, &MainEntity, &DrawIndex), QF>,
+        Query<(Entity, &MainEntity, &DrawIndex, &NannouMeshCamera), QF>,
         ResMut<ViewSortedRenderPhases<Transparent3d>>,
         Query<(
             &ExtractedView,
@@ -441,7 +442,11 @@ pub(crate) fn queue_shader_model<SM, QF, RC>(
                 view_key |= MeshPipelineKey::DEBAND_DITHER;
             }
         }
-        for (entity, main_entity, draw_idx) in &nannou_meshes {
+        for (entity, main_entity, draw_idx, mesh_camera) in &nannou_meshes {
+            // Only queue a mesh into the view of the window it was drawn to.
+            if mesh_camera.0 != view.retained_view_entity.main_entity.id() {
+                continue;
+            }
             let Some(model_asset) = extracted_instances.get(main_entity) else {
                 continue;
             };
@@ -666,7 +671,7 @@ fn update_shader_model<SM>(
 fn update_draw_mesh(
     mut commands: Commands,
     draw_q: Query<&Draw>,
-    mut cameras_q: Query<(&mut Camera, &RenderTarget, &RenderLayers), With<NannouCamera>>,
+    mut cameras_q: Query<(Entity, &mut Camera, &RenderTarget, &RenderLayers), With<NannouCamera>>,
     windows: Query<(&Window, Has<PrimaryWindow>)>,
     mut meshes: ResMut<Assets<Mesh>>,
     text_cx: Res<crate::text::font::SharedTextCx>,
@@ -677,8 +682,8 @@ fn update_draw_mesh(
     mut text_model_keepalive: ResMut<TextModelKeepalive>,
 ) {
     for draw in draw_q.iter() {
-        let Some((mut window_camera, _, window_layers)) =
-            cameras_q.iter_mut().find(|(_, render_target, _)| {
+        let Some((camera_entity, mut window_camera, _, window_layers)) =
+            cameras_q.iter_mut().find(|(_, _, render_target, _)| {
                 if let RenderTarget::Window(WindowRef::Primary) = render_target {
                     let Ok((_, is_primary)) = windows.get(draw.window) else {
                         return false;
@@ -770,6 +775,7 @@ fn update_draw_mesh(
                             NoAutomaticBatching,
                             DrawIndex(idx),
                             window_layers.clone(),
+                            NannouMeshCamera(camera_entity),
                         ));
                         text_model_keepalive.0.push(handle);
                     }
@@ -808,6 +814,7 @@ fn update_draw_mesh(
                             NoAutomaticBatching,
                             DrawIndex(idx),
                             window_layers.clone(),
+                            NannouMeshCamera(camera_entity),
                         ));
                         mesh
                     });
@@ -851,6 +858,7 @@ fn update_draw_mesh(
                         NoAutomaticBatching,
                         DrawIndex(idx),
                         window_layers.clone(),
+                        NannouMeshCamera(camera_entity),
                     ));
                 }
                 DrawCommand::Indirect(prim, indirect_buffer) => {
@@ -889,6 +897,7 @@ fn update_draw_mesh(
                         NoAutomaticBatching,
                         DrawIndex(idx),
                         window_layers.clone(),
+                        NannouMeshCamera(camera_entity),
                     ));
                 }
                 DrawCommand::Context(ctx) => {
@@ -910,6 +919,13 @@ fn update_draw_mesh(
 
 #[derive(Component, ExtractComponent, Clone)]
 pub struct DrawIndex(pub usize);
+
+/// The main-world entity of the [`NannouCamera`] a draw mesh was generated for.
+///
+/// [`queue_shader_model`] uses this to scope each mesh to its window's view,
+/// rather than queuing every mesh into every camera's phase.
+#[derive(Component, ExtractComponent, Clone, Copy)]
+pub struct NannouMeshCamera(pub Entity);
 
 #[derive(Component, ExtractComponent, Clone)]
 pub struct NannouTransient;


### PR DESCRIPTION
## Problem

The render-world queue `queue_shader_model` iterated a global mesh query and added every draw mesh to every camera's `Transparent3d` phase. In multi-window apps this rendered each window's shapes on all windows. The `multi_window_draw` example showed all three windows' shapes on every window, with the last-drawn shape on top.

## Solution

Tag each generated mesh with the main-world entity of the `NannouCamera` it was drawn for, extract it to the render world, and skip meshes in the queue whose camera does not match the view being queued. This scopes each mesh to its window's view across the regular, instanced and indirect draw paths (all three share `queue_shader_model`).