### PR TITLE
fix: Run mode behaviour (`loop_once` / `loop_ntimes`)

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -180,6 +180,9 @@ path = "nannou_basics/multi_window_draw.rs"
 [[example]]
 name = "simple_window"
 path = "nannou_basics/simple_window.rs"
+[[example]]
+name = "loop_once"
+path = "nannou_basics/loop_once.rs"
 
 # Offline
 [[example]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -183,6 +183,9 @@ path = "nannou_basics/simple_window.rs"
 [[example]]
 name = "loop_once"
 path = "nannou_basics/loop_once.rs"
+[[example]]
+name = "run_modes"
+path = "nannou_basics/run_modes.rs"
 
 # Offline
 [[example]]

--- a/examples/nannou_basics/loop_once.rs
+++ b/examples/nannou_basics/loop_once.rs
@@ -1,0 +1,35 @@
+//! `loop_once` - draw a single frame, then hold it on screen.
+//!
+//! `view` runs exactly once: the composition is drawn and then frozen. The window
+//! idles (no CPU) and stays closable and resizable, but nothing ever redraws -
+//! waiting or moving the mouse changes nothing. This is the modern equivalent of
+//! the old `LoopMode::loop_once()`, ideal for static, sketch-based art.
+//!
+//! Swap `loop_once()` for `loop_ntimes(n)` to advance `n` frames first, or drop it
+//! entirely to animate continuously.
+
+use nannou::prelude::*;
+
+fn main() {
+    nannou::sketch(view).size(600, 600).loop_once().run();
+}
+
+fn view(app: &App) {
+    let draw = app.draw();
+    draw.background().color(SNOW);
+
+    // A static spiral of circles, drawn once and then held on screen.
+    let win = app.window_rect();
+    let n = 240;
+    for i in 0..n {
+        let t = i as f32 / n as f32;
+        let angle = t * PI * 24.0;
+        let radius = t * win.w() * 0.45;
+        let x = angle.cos() * radius;
+        let y = angle.sin() * radius;
+        draw.ellipse()
+            .x_y(x, y)
+            .radius(6.0 * (1.0 - t) + 1.0)
+            .hsv(t, 0.7, 0.9);
+    }
+}

--- a/examples/nannou_basics/run_modes.rs
+++ b/examples/nannou_basics/run_modes.rs
@@ -1,0 +1,130 @@
+//! Switch run modes and update modes at runtime to feel how each behaves.
+//!
+//! Watch the orbiting dot and the `updates` counter - the dot's position follows the
+//! counter, so it freezes whenever `update` stops running:
+//!   - Continuous : counter climbs every frame; the dot orbits smoothly.
+//!   - Rate (10)  : counter climbs ~10x/sec.
+//!   - Wait       : counter climbs only when you give input (move the mouse / press keys).
+//!   - loop_once  : counter stops at 1; the frame is held (~0 CPU).
+//!   - loop_ntimes(60): counter stops at 60, then held.
+//!
+//! Keys:
+//!   Space          toggle Continuous <-> loop_once
+//!   1 Continuous   2 Rate(10)   3 Wait   4 loop_once   5 loop_ntimes(60)
+
+use nannou::prelude::*;
+
+fn main() {
+    nannou::app(model).update(update).run();
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Mode {
+    Continuous,
+    Rate,
+    Wait,
+    LoopOnce,
+    Loop60,
+}
+
+impl Mode {
+    fn label(self) -> &'static str {
+        match self {
+            Mode::Continuous => "Continuous",
+            Mode::Rate => "Reactive rate (10 fps)",
+            Mode::Wait => "Wait (redraw on input)",
+            Mode::LoopOnce => "loop_once (draw once, held)",
+            Mode::Loop60 => "loop_ntimes(60)",
+        }
+    }
+}
+
+struct Model {
+    mode: Mode,
+    count: u32,
+}
+
+fn model(app: &App) -> Model {
+    app.new_window()
+        .size(640, 640)
+        .view(view)
+        .key_pressed(key_pressed)
+        .build();
+    Model {
+        mode: Mode::Continuous,
+        count: 0,
+    }
+}
+
+fn update(_app: &App, model: &mut Model) {
+    model.count += 1;
+}
+
+fn key_pressed(app: &App, model: &mut Model, key: KeyCode) {
+    let mode = match key {
+        KeyCode::Space => {
+            if model.mode == Mode::LoopOnce {
+                Mode::Continuous
+            } else {
+                Mode::LoopOnce
+            }
+        }
+        KeyCode::Digit1 => Mode::Continuous,
+        KeyCode::Digit2 => Mode::Rate,
+        KeyCode::Digit3 => Mode::Wait,
+        KeyCode::Digit4 => Mode::LoopOnce,
+        KeyCode::Digit5 => Mode::Loop60,
+        _ => return,
+    };
+    set_mode(app, model, mode);
+}
+
+// Apply a mode as a (run mode, update mode) pair. Loop modes only set the run mode - the
+// framework drives them and then freezes; the others are `UntilExit` with an explicit
+// update mode.
+fn set_mode(app: &App, model: &mut Model, mode: Mode) {
+    model.mode = mode;
+    model.count = 0;
+    match mode {
+        Mode::Continuous => {
+            app.set_run_mode(RunMode::UntilExit);
+            app.set_update_mode(UpdateMode::Continuous);
+        }
+        Mode::Rate => {
+            app.set_run_mode(RunMode::UntilExit);
+            app.set_update_rate(10.0);
+        }
+        Mode::Wait => {
+            app.set_run_mode(RunMode::UntilExit);
+            app.set_update_mode(UpdateMode::wait());
+        }
+        Mode::LoopOnce => app.set_run_mode(RunMode::loop_once()),
+        Mode::Loop60 => app.set_run_mode(RunMode::loop_ntimes(60)),
+    }
+}
+
+fn view(app: &App, model: &Model) {
+    let draw = app.draw();
+    draw.background().srgb(0.09, 0.10, 0.13);
+    let win = app.window_rect();
+
+    // Orbiting dot - position advances with the update counter.
+    let a = model.count as f32 * 0.08;
+    let r = win.w().min(win.h()) * 0.3;
+    draw.ellipse()
+        .x_y(a.cos() * r, a.sin() * r)
+        .radius(24.0)
+        .color(TOMATO);
+
+    // HUD: current mode + update count, and the key hints.
+    draw.text(&format!("{}\nupdates: {}", model.mode.label(), model.count))
+        .x_y(0.0, win.h() * 0.5 - 44.0)
+        .wh(vec2(win.w() - 20.0, 80.0))
+        .font_size(22)
+        .color(WHITE);
+    draw.text("space: Continuous <-> loop_once     1 Continuous   2 Rate   3 Wait   4 loop_once   5 loop60")
+        .x_y(0.0, -win.h() * 0.5 + 24.0)
+        .wh(vec2(win.w() - 20.0, 30.0))
+        .font_size(13)
+        .color(GRAY);
+}

--- a/guide/src/changelog.md
+++ b/guide/src/changelog.md
@@ -5,6 +5,44 @@ back to the origins.
 
 ---
 
+# Unreleased
+
+- Added `RunMode::loop_once()` and `RunMode::loop_ntimes(n)`, with matching
+  `.loop_once()` / `.loop_ntimes(n)` shortcuts on both the app `Builder` and the
+  `SketchBuilder`. These run `update` and `view` a fixed number of times and then
+  hold the last frame on screen while the window idles (~0 CPU) and stays closable
+  and resizable - the modern equivalent of the old `LoopMode::loop_once()` /
+  `NTimes`, ideal for static `sketch`-based compositions. This fills a gap left by
+  the Bevy refactor: no single `UpdateMode` could both ignore mouse movement and
+  stay responsive, because `bevy_winit` cannot distinguish cursor movement from
+  window close/resize (both are "window events"). The static frame is held by
+  freezing the draw (the rendered meshes persist and keep being drawn) rather than
+  by re-running `view`, so `view` runs exactly `n` times even for a sketch that
+  reads live time or input.
+
+  Migrating from the pre-0.20 `LoopMode`:
+
+  - `LoopMode::loop_once()` -> `RunMode::loop_once()` (or `.loop_once()` on the app
+    or sketch builder).
+  - `LoopMode::loop_ntimes(n)` -> `RunMode::loop_ntimes(n)`.
+  - `LoopMode::Wait` -> `app.set_update_mode(UpdateMode::wait())`.
+  - `LoopMode::Rate` / `rate_fps(fps)` -> `app.set_update_rate(fps)` or
+    `UpdateMode::rate(hz)`.
+  - `LoopMode::RefreshSync` -> `UpdateMode::Continuous` (the default).
+
+- Added `App::set_run_mode(..)` to change the `RunMode` at runtime (e.g. to switch
+  into or out of a loop mode), mirroring `App::set_update_mode`. Entering a loop mode
+  resets its budget and drives the loop until it freezes, so loop modes can be entered
+  and re-entered live. See the new `run_modes` example for switching between
+  Continuous, reactive-rate, wait, and loop modes with the keyboard.
+
+- Removed `RunMode::Ticks(n)`, `RunMode::Duration(..)` and `RunMode::once()`. They
+  were unused, undocumented, and `once()` (quit after one frame) was easily confused
+  with `loop_once()` (hold after one frame). To run a fixed number of frames and then
+  quit, call `App::quit()` from your own `update` once a counter reaches the target.
+
+---
+
 # Version 0.20.0 (2026-06-20)
 
 ## The Bevy Refactor

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -6,7 +6,8 @@
 //! - [**App**](./struct.App.html) - provides a context and API for windowing, devices, etc.
 //! - [**Proxy**](./struct.Proxy.html) - a handle to an **App** that may be used from a non-main
 //!   thread.
-//! - [**LoopMode**](./enum.LoopMode.html) - describes the behaviour of the application event loop.
+//! - [`RunMode`] and [`UpdateModeExt`] - describe the behaviour of the application loop and how
+//!   often the `update`/`view` functions are called.
 use bevy::asset::UnapprovedPathMode;
 use bevy::{
     app::AppExit,
@@ -193,16 +194,37 @@ pub enum RunMode {
     /// Run until the user exits the application.
     #[default]
     UntilExit,
-    /// Run for a fixed number of frames.
-    Ticks(u64),
-    /// Run for a fixed duration (best effort).
-    Duration(Duration),
+    /// Run `update` and `view` a fixed number of times, then hold the last frame on
+    /// screen while the window idles.
+    ///
+    /// The modern equivalent of the old `LoopMode::loop_once()` / `NTimes`: `update`
+    /// and `view` each run exactly `n` times, then the draw is frozen (see
+    /// [`nannou_draw::DrawFrozen`]) so the last frame's rendered meshes keep being
+    /// drawn and the frame stays on screen. The window idles at ~0 CPU and remains
+    /// closable and resizable. Input and window callbacks keep firing; they just no
+    /// longer trigger `update`/`view`.
+    ///
+    /// Because `view` runs a fixed number of times rather than continuously, a
+    /// `sketch` whose `view` reads live `app.time()`/`app.mouse()` is genuinely
+    /// frozen - this is the intended mode for static, sketch-based compositions.
+    ///
+    /// To instead run a fixed number of frames and then *quit* the process (e.g. for
+    /// headless rendering), call [`App::quit`](crate::app::App::quit) from your own
+    /// `update` once a counter reaches the desired frame.
+    LoopNTimes(u64),
 }
 
 impl RunMode {
-    /// Run the main update loop once.
-    pub fn once() -> Self {
-        RunMode::Ticks(1)
+    /// Run `update` and `view` once, then hold that frame on screen while the window
+    /// idles - the modern equivalent of `LoopMode::loop_once()`.
+    pub fn loop_once() -> Self {
+        RunMode::LoopNTimes(1)
+    }
+
+    /// Run `update` and `view` `n` times, then hold the last frame on screen while
+    /// the window idles - the modern equivalent of `LoopMode::loop_ntimes(n)`.
+    pub fn loop_ntimes(n: u64) -> Self {
+        RunMode::LoopNTimes(n)
     }
 }
 
@@ -343,8 +365,8 @@ where
 
     /// A function for updating the model within the application loop.
     ///
-    /// See the `LoopMode` documentation for more information about the different kinds of
-    /// application loop modes available in nannou and how they behave.
+    /// See [`RunMode`] and [`set_update_mode`](App::set_update_mode) for more information about how
+    /// often the loop runs and how the `update`/`view` functions are scheduled.
     ///
     /// Update events are also emitted as a variant of the `event` function. Note that if you
     /// specify both an `event` function and an `update` function, the `event` function will always
@@ -398,6 +420,24 @@ where
         self.ensure_initialized();
         self.app.insert_resource(run_mode);
         self
+    }
+
+    /// Run `update` and `view` once, then hold that frame on screen while the window
+    /// idles - the modern equivalent of `LoopMode::loop_once()`.
+    ///
+    /// Shorthand for [`set_run_mode`](Self::set_run_mode) with
+    /// [`RunMode::loop_once`].
+    pub fn loop_once(self) -> Self {
+        self.set_run_mode(RunMode::loop_once())
+    }
+
+    /// Run `update` and `view` `n` times, then hold the last frame on screen while
+    /// the window idles - the modern equivalent of `LoopMode::loop_ntimes(n)`.
+    ///
+    /// Shorthand for [`set_run_mode`](Self::set_run_mode) with
+    /// [`RunMode::loop_ntimes`].
+    pub fn loop_ntimes(self, n: u64) -> Self {
+        self.set_run_mode(RunMode::loop_ntimes(n))
     }
 
     pub fn shader_model<SM>(mut self) -> Self
@@ -497,7 +537,7 @@ where
                     window_closed_events::<M>,
                 ),
             )
-            .add_systems(Last, last::<M>)
+            .add_systems(Last, (apply_loop_once, last::<M>))
             .run();
     }
 }
@@ -520,6 +560,24 @@ impl SketchBuilder {
     /// The size of the sketch window.
     pub fn size(mut self, width: u32, height: u32) -> Self {
         self.builder = self.builder.size(width, height);
+        self
+    }
+
+    /// Draw the sketch once, then hold that frame on screen while the window idles -
+    /// the modern equivalent of `LoopMode::loop_once()`.
+    ///
+    /// `view` runs exactly once, so the composition is frozen (even a sketch whose
+    /// `view` reads live `app.time()`/`app.mouse()`). The window idles at ~0 CPU and
+    /// stays closable and resizable.
+    pub fn loop_once(mut self) -> Self {
+        self.builder = self.builder.loop_once();
+        self
+    }
+
+    /// Draw the sketch `n` times, then hold the last frame on screen while the window
+    /// idles. See [`loop_once`](Self::loop_once).
+    pub fn loop_ntimes(mut self, n: u64) -> Self {
+        self.builder = self.builder.loop_ntimes(n);
         self
     }
 
@@ -721,29 +779,19 @@ fn update<M>(
     view_fn: Res<ViewFnRes<M>>,
     mut model: ResMut<ModelHolder<M>>,
     run_mode: Res<RunMode>,
-    time: Res<Time>,
-    mut ticks: Local<u64>,
+    draw_frozen: Res<nannou_draw::DrawFrozen>,
     windows: Query<(Entity, &WindowUserFunctions<M>)>,
 ) where
     M: 'static + Send + Sync,
 {
-    match *run_mode {
-        RunMode::UntilExit => {
-            // Do nothing, we'll quit when the user closes the window.
+    // Once a `LoopNTimes` draw has been frozen (see `apply_loop_once`), stop advancing
+    // the model and re-running `view`. The frozen draw meshes keep the last frame on
+    // screen, so `update` and `view` each run exactly `n` times in total.
+    if let RunMode::LoopNTimes(_) = *run_mode {
+        if draw_frozen.0 {
+            return;
         }
-        RunMode::Ticks(run_ticks) => {
-            if *ticks >= run_ticks {
-                app.quit();
-                return;
-            }
-        }
-        RunMode::Duration(duration) => {
-            if time.elapsed() >= duration {
-                app.quit();
-                return;
-            }
-        }
-    };
+    }
 
     // Run the model update function. Reset the current view first so `app.draw()` called from
     // `update` targets the focused window rather than the last window of the previous frame's
@@ -778,8 +826,45 @@ fn update<M>(
             }
         }
     }
+}
 
-    *ticks += 1;
+/// Freeze the draw once a [`RunMode::LoopNTimes`] budget has been rendered.
+///
+/// Runs in `Last`, after `update_draw_mesh` (`PostUpdate`) has spawned the frame's
+/// meshes and before the next frame's `clear_previous_frame` (`First`) would despawn
+/// them, so the last rendered frame's meshes are preserved. Setting [`nannou_draw::DrawFrozen`]
+/// then stops the draw systems and, via [`update`], the user's `update`/`view`; switching to
+/// [`UpdateMode::freeze`] idles the loop while keeping the window closable and resizable.
+fn apply_loop_once(
+    app: App,
+    run_mode: Res<RunMode>,
+    mut draw_frozen: ResMut<nannou_draw::DrawFrozen>,
+    mut rendered: Local<u64>,
+) {
+    // Reset the freeze state whenever the run mode changes, so a loop mode can be
+    // (re-)entered at runtime via `App::set_run_mode`. Harmless at build time (the
+    // resource reads as changed on the first frame, re-affirming the defaults).
+    if run_mode.is_changed() {
+        *rendered = 0;
+        draw_frozen.0 = false;
+        // Entering a loop mode needs a driving update mode so its frames render before
+        // it freezes below. Other modes leave the update mode to the caller.
+        if matches!(*run_mode, RunMode::LoopNTimes(_)) {
+            app.set_update_mode(UpdateMode::Continuous);
+        }
+    }
+
+    let RunMode::LoopNTimes(n) = *run_mode else {
+        return;
+    };
+    if draw_frozen.0 {
+        return;
+    }
+    *rendered += 1;
+    if *rendered >= n {
+        draw_frozen.0 = true;
+        app.set_update_mode(UpdateMode::freeze());
+    }
 }
 
 #[allow(clippy::type_complexity)]
@@ -1086,6 +1171,11 @@ pub trait UpdateModeExt {
     fn wait() -> UpdateMode;
     /// Stop driving updates from the frame loop, while still reacting to window events so
     /// the window can be closed, resized and redrawn.
+    ///
+    /// Note that `bevy_winit` treats cursor movement over a focused window as a window event,
+    /// so a bare `freeze` still re-runs `update`/`view` whenever the mouse moves. For a true
+    /// "draw once, then hold" loop use [`RunMode::loop_once`], which caps how many times
+    /// `update`/`view` run regardless of input and holds the last frame on screen.
     fn freeze() -> UpdateMode;
     /// Drive updates at a fixed rate of `hz` ticks per second, like Processing's
     /// `frameRate`.

--- a/nannou/src/context.rs
+++ b/nannou/src/context.rs
@@ -57,7 +57,7 @@ use std::cell::{Cell, RefCell};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use crate::app::{UpdateModeExt, find_project_path};
+use crate::app::{RunMode, UpdateModeExt, find_project_path};
 use crate::camera::{CameraComponents, SetCamera};
 use crate::light::{LightComponents, SetLight};
 use crate::prelude::render::NannouCamera;
@@ -394,6 +394,20 @@ impl<'w, 's> App<'w, 's> {
         self.par_commands.command_scope(|mut commands| {
             commands.queue(|world: &mut World| {
                 world.write_message(AppExit::Success);
+            });
+        });
+    }
+
+    /// Set the [`RunMode`] at runtime, e.g. to switch into or out of a loop mode.
+    ///
+    /// Entering a loop mode (`RunMode::loop_once`/`loop_ntimes`) resets its frame budget
+    /// and drives the loop until it freezes; switching to another mode leaves the update
+    /// mode to you (pair it with [`set_update_mode`](Self::set_update_mode) if you want to
+    /// resume continuous animation).
+    pub fn set_run_mode(&self, run_mode: RunMode) {
+        self.par_commands.command_scope(move |mut commands| {
+            commands.queue(move |world: &mut World| {
+                *world.resource_mut::<RunMode>() = run_mode;
             });
         });
     }

--- a/nannou_draw/src/lib.rs
+++ b/nannou_draw/src/lib.rs
@@ -31,9 +31,26 @@ impl Plugin for NannouDrawPlugin {
             app.add_plugins(bevy::text::TextPlugin);
         }
         text::font::init_shared_text_cx(app);
-        app.add_plugins(NannouRenderPlugin)
-            .add_systems(First, (spawn_draw, reset_draw).chain());
+        app.init_resource::<DrawFrozen>()
+            .add_plugins(NannouRenderPlugin)
+            // `spawn_draw` stays ungated so newly created windows always get a `Draw`;
+            // `reset_draw` is skipped while frozen so the recorded scene is retained.
+            .add_systems(First, (spawn_draw, reset_draw.run_if(draw_active)).chain());
     }
+}
+
+/// When set, the per-frame draw systems (`reset_draw`, `clear_previous_frame` and
+/// `update_draw_mesh`) are skipped so the last frame's rendered meshes and camera
+/// clear color persist and keep being drawn by the render graph.
+///
+/// nannou's single-view run mode (`RunMode::loop_once`) sets this once the frame has
+/// been drawn, holding a static frame on screen without re-running the user's `view`.
+#[derive(Resource, Default)]
+pub struct DrawFrozen(pub bool);
+
+/// Run condition gating the per-frame draw systems on [`DrawFrozen`].
+pub(crate) fn draw_active(frozen: Res<DrawFrozen>) -> bool {
+    !frozen.0
 }
 
 fn reset_draw(mut draw_q: Query<&mut Draw>) {

--- a/nannou_draw/src/render.rs
+++ b/nannou_draw/src/render.rs
@@ -157,7 +157,10 @@ impl Plugin for NannouRenderPlugin {
             NannouShaderModelPlugin::<DefaultNannouShaderModel>::default(),
         ))
         .init_resource::<TextModelKeepalive>()
-        .add_systems(First, clear_previous_frame)
+        // Both are skipped while `DrawFrozen` is set so the last frame's meshes are
+        // neither despawned (`clear_previous_frame`) nor rebuilt (`update_draw_mesh`),
+        // leaving them - and the camera clear color - in place for the render graph.
+        .add_systems(First, clear_previous_frame.run_if(crate::draw_active))
         // `update_draw_mesh` (re)spawns the draw meshes each frame, so it must run
         // before Bevy computes visibility - otherwise the freshly spawned meshes
         // have `ViewVisibility == false` when the render-world extraction runs and
@@ -166,6 +169,7 @@ impl Plugin for NannouRenderPlugin {
         .add_systems(
             PostUpdate,
             update_draw_mesh
+                .run_if(crate::draw_active)
                 .before(VisibilitySystems::VisibilityPropagate)
                 .after(bevy::text::load_font_assets_into_font_collection),
         );


### PR DESCRIPTION
## Summary

Reintroduces the pre-0.20 `LoopMode::loop_once()` behaviour that was lost in the Bevy port, and cleans up the surrounding `RunMode` API.

Previously, `set_update_mode(UpdateMode::reactive(..))` keeps re-running on mouse movement, and no single `UpdateMode` can both ignore input and stay responsive, because `bevy_winit` cannot distinguish cursor movement from window close/resize (both are "window events").

## What this adds

- `RunMode::loop_once()` and `RunMode::loop_ntimes(n)`, with matching `.loop_once()` / `.loop_ntimes(n)` shortcuts on both the app `Builder` and the `SketchBuilder`. `update` and `view` each run exactly `n` times (default 1), then the last frame is held on screen while the window idles and stays closable and resizable. This is the intended mode for static, sketch-based compositions.
- `App::set_run_mode(..)` to change the run mode at runtime, mirroring `App::set_update_mode`. Loop modes can be entered and re-entered live.
- Two examples under `examples/nannou_basics/`:
    - `loop_once` - draws a static spiral once and holds it, and
    - `run_modes` - switches between Continuous, reactive rate, wait, and the loop modes at runtime with the keyboard.

## How the frame is held

Simply capping `view` presents a black window. Under Bevy the drawn frame lives in the camera's persistent intermediate render texture, which is only kept populated **while the window keeps drawing.** Once drawing stops, empty passes plus MSAA-writeback ping-pong plus `TextureCache` eviction leave it black, so unfortunately our old approach of just re-using the texture is blocked at the moment.

Instead, in this workaround we freeze the `Draw` instance itself. A new `nannou_draw::DrawFrozen` resource gates the per-frame draw systems (`reset_draw`, `clear_previous_frame`, `update_draw_mesh`), so the last frame's rendered meshes and clear color persist and the render graph keeps drawing them. `update`/`view` are then skipped too, so they run exactly `n` times even for a sketch whose `view` reads live time or input. A `Last`-schedule system (`apply_loop_once`) counts rendered frames and, once the budget is spent, freezes the draw and switches to `freeze()` to idle. It runs in `Last` so the final frame's meshes, spawned in `PostUpdate`, survive into the next frame.

## Breaking change: `RunMode` trimmed

`RunMode` is reduced to `UntilExit` and `LoopNTimes`. The `Ticks`, `Duration` and `once()` variants (run N frames or a duration, then quit) are removed. They were unused and undocumented, and `once()` (quit after one frame) was easily confused with `loop_once()` (hold after one frame). To run a fixed number of frames and then quit, call `App::quit()` from your own `update` once a counter reaches the target.

## Migrating from the pre-0.20 `LoopMode`

- `LoopMode::loop_once()` -> `RunMode::loop_once()` (or `.loop_once()` on the app or sketch builder).
- `LoopMode::loop_ntimes(n)` -> `RunMode::loop_ntimes(n)`.
- `LoopMode::Wait` -> `app.set_update_mode(UpdateMode::wait())`.
- `LoopMode::Rate` / `rate_fps(fps)` -> `app.set_update_rate(fps)` or `UpdateMode::rate(hz)`.
- `LoopMode::RefreshSync` -> `UpdateMode::Continuous` (the default).