### PR TITLE
Make sure windows stay on top.

### DIFF
--- a/nannou/src/lib.rs
+++ b/nannou/src/lib.rs
@@ -23,7 +23,7 @@
 //! with no `unsafe` and no builder machinery. See the [`context`] module and the `system_param`
 //! example for details.
 use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
-use bevy::prelude::{App as BevyApp, IntoScheduleConfigs, Plugin, PostUpdate};
+use bevy::prelude::{App as BevyApp, IntoScheduleConfigs, Last, Plugin, PostUpdate};
 use bevy::winit::WinitSettings;
 
 pub use find_folder;
@@ -61,6 +61,7 @@ impl Plugin for NannouPlugin {
             PostUpdate,
             window::update_default_camera_z_range.before(bevy::camera::CameraUpdateSystems),
         );
+        app.add_systems(Last, window::reapply_initial_window_level);
         // `FramePlugin` extracts per-window scale factors so a `Frame` can be constructed from a
         // (custom or classic) render-world system.
         app.add_plugins(crate::frame::FramePlugin);

--- a/nannou/src/window.rs
+++ b/nannou/src/window.rs
@@ -12,10 +12,12 @@ use bevy::{
     camera::Hdr,
     camera::RenderTarget,
     camera::visibility::RenderLayers,
+    ecs::system::NonSendMarker,
     input::mouse::MouseWheel,
     prelude::*,
     render::extract_component::ExtractComponent,
     window::{PrimaryWindow, WindowLevel, WindowRef},
+    winit::{WINIT_WINDOWS, converters::convert_window_level},
 };
 
 /// A context for building a window.
@@ -662,4 +664,27 @@ pub(crate) fn update_default_camera_z_range(
             }
         }
     }
+}
+
+/// Marks a window whose initial [`WindowLevel`] nannou has already re-applied to the underlying
+/// winit window.
+#[derive(Component)]
+pub(crate) struct WindowLevelApplied;
+
+/// Re-apply each window's [`WindowLevel`] once, as soon as its winit window exists.
+pub(crate) fn reapply_initial_window_level(
+    mut commands: Commands,
+    windows: Query<(Entity, &bevy::window::Window), Without<WindowLevelApplied>>,
+    _non_send_marker: NonSendMarker,
+) {
+    WINIT_WINDOWS.with_borrow(|winit_windows| {
+        for (entity, window) in windows.iter() {
+            // The winit window may not have been created yet, retry on a later frame.
+            let Some(winit_window) = winit_windows.get_window(entity) else {
+                continue;
+            };
+            winit_window.set_window_level(convert_window_level(window.window_level));
+            commands.entity(entity).insert(WindowLevelApplied);
+        }
+    });
 }


### PR DESCRIPTION
We need to re-apply the setting after the window actually exists, which takes a few frames on some platforms.

Closes #1089